### PR TITLE
feat(server): add PG mock proxy at /api/web/2/staff/*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,7 @@ TW_SERVER_PORT=3000
 # TW_OTPAAS_NAMESPACE=
 # TW_OTPAAS_SECRET=
 # TW_OTPAAS_TIMEOUT=10s
+
+# PG (Parents Gateway) integration
+TW_PG_MOCK=true
+# TW_PG_BASE_URL=https://pg.moe.edu.sg

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ out
 # Ignore environment variables.
 *.env*
 !.env.example
+
+# Ignore worktrees.
+.worktrees

--- a/plans/2026-04-07-pg-mock-proxy.md
+++ b/plans/2026-04-07-pg-mock-proxy.md
@@ -1,0 +1,127 @@
+# PG Mock Proxy — Implementation Plan
+
+**Date:** 2026-04-07  
+**Branch:** feat/pg-mock-proxy  
+**Goal:** Add a mock proxy package (`server/internal/pg`) that serves fixture JSON at `/api/web/2/staff/*` routes, unblocking Reza's FE while the real pgw-web integration is negotiated with the PG team.
+
+**API path choice:** `/api/web/2/staff/*` mirrors the real PG API paths exactly, so when we flip from mock to real proxy, no FE URL changes are needed.
+
+---
+
+## Task 1: Add PGConfig to server config
+
+**Files:**
+- Modify: `server/internal/config/config.go`
+
+Add `PGConfig` struct and wire it into `Config`:
+
+```go
+type PGConfig struct {
+    Mock    bool   `dotenv:"TW_PG_MOCK"`
+    BaseURL string `dotenv:"TW_PG_BASE_URL"`
+}
+```
+
+Add `PG PGConfig \`dotenv:",squash"\`` field to `Config` struct.
+
+Add defaults in `Default()`:
+```go
+PG: PGConfig{
+    Mock:    true,
+    BaseURL: "https://pg.moe.edu.sg",
+},
+```
+
+No validation needed for Phase 1 (mock mode only).
+
+**Commit:** `feat(server): add PGConfig to server config`
+
+---
+
+## Task 2: Create server/internal/pg package
+
+**Files to create:**
+- `server/internal/pg/handler.go` — Handler struct, New(), Register()
+- `server/internal/pg/mock.go` — mock mode: serves fixture JSON from embedded FS
+- `server/internal/pg/fixtures/announcements.json` — announcements list fixture
+
+### handler.go
+
+```go
+package pg
+
+import (
+    "net/http"
+    "github.com/String-sg/teacher-workspace/server/internal/config"
+)
+
+// Handler handles all /api/web/2/staff/* routes.
+type Handler struct {
+    cfg *config.PGConfig
+}
+
+// New creates a new PG handler.
+func New(cfg *config.PGConfig) *Handler {
+    return &Handler{cfg: cfg}
+}
+
+// Register attaches PG routes to the provided ServeMux.
+func (h *Handler) Register(mux *http.ServeMux) {
+    if h.cfg.Mock {
+        h.registerMock(mux)
+        return
+    }
+    // Phase 2: real proxy routes go here
+}
+```
+
+### mock.go
+
+Use `embed` to bundle fixture files into the binary. Serve fixture JSON based on request path.
+
+Route map (path suffix → fixture file):
+- `GET /api/web/2/staff/announcements` → `fixtures/announcements.json`
+
+Return 404 for unknown routes.
+
+### fixtures/announcements.json
+
+JSON array matching Reza's `PGAnnouncement[]` type from `web/data/mock-pg-announcements.ts`. Wrap in `{ "items": [...] }` envelope — consistent with how list endpoints typically work.
+
+---
+
+## Task 3: Wire PG handler into main handler
+
+**Files:**
+- Modify: `server/internal/handler/handler.go`
+
+In `New()`, instantiate `pg.New(&cfg.PG)` and call `.Register(mux)` inside `Register()`.
+
+---
+
+## Task 4: Update .env.example
+
+Add PG vars to `.env.example`:
+```
+# PG (Parents Gateway) integration
+TW_PG_MOCK=true
+# TW_PG_BASE_URL=https://pg.moe.edu.sg
+```
+
+---
+
+## Task 5: Verify
+
+```bash
+go build ./...
+go test ./...
+```
+
+Then manually test:
+```bash
+curl http://localhost:3000/api/web/2/staff/announcements
+```
+
+Expected: JSON response with announcements array.
+
+**Commit:** `feat(server): add PG mock proxy serving fixture JSON`

--- a/plans/FE-API-WIRING.md
+++ b/plans/FE-API-WIRING.md
@@ -1,0 +1,125 @@
+# FE → API Wiring Instructions
+
+**For:** Reza's AI agent  
+**Branch:** feat/pg-mock-proxy (merge into feat/posts-list-page or rebase on top)  
+**Context:** The Go BFF now serves mock PG data at real API endpoints. The FE should fetch from these instead of importing hardcoded mock data files.
+
+---
+
+## What changed on the backend
+
+A new mock proxy is live at `/api/web/2/staff/*`. These routes mirror the real PG API paths exactly — when real pgw-web integration is wired up, the URLs will not change.
+
+Currently available:
+
+| Method | URL | Returns |
+|--------|-----|---------|
+| `GET` | `/api/web/2/staff/announcements` | `{ items: PGAnnouncement[] }` |
+
+---
+
+## What needs to change in the FE
+
+### 1. `web/containers/PostsView.tsx`
+
+**Remove** the mock data import:
+```ts
+import {
+  mockPGAnnouncements,
+  type PGAnnouncement,
+  type ResponseTypeWithResponse,
+  requiresResponse,
+} from '~/data/mock-pg-announcements';
+```
+
+**Replace** with a `fetch` call to the API:
+```ts
+const [announcements, setAnnouncements] = React.useState<PGAnnouncement[]>([]);
+
+React.useEffect(() => {
+  fetch('/api/web/2/staff/announcements')
+    .then((res) => res.json())
+    .then((data: { items: PGAnnouncement[] }) => setAnnouncements(data.items));
+}, []);
+```
+
+Then replace all references to `mockPGAnnouncements` with `announcements`.
+
+Keep the `PGAnnouncement` type and helper imports — move them from `~/data/mock-pg-announcements` into a standalone types file (e.g. `~/apps/pg/types/announcements.ts`) since the mock data file should eventually be deleted.
+
+### 2. `web/data/mock-pg-announcements.ts`
+
+The mock data array (`mockPGAnnouncements`) can be removed once PostsView is wired up. Keep the **types and helpers** — move them out first:
+
+- `PGAnnouncement`, `PGStatus`, `PGOwnership`, `PGRecipient`, `PGAnnouncementStats`, `ResponseType`, `ResponseTypeWithResponse` → move to `web/apps/pg/types/announcements.ts`
+- `requiresResponse()` helper → move with the types
+
+---
+
+## Response shape
+
+`GET /api/web/2/staff/announcements` returns:
+
+```json
+{
+  "items": [
+    {
+      "id": "string",
+      "title": "string",
+      "description": "string",
+      "status": "posted" | "scheduled" | "draft",
+      "responseType": "view-only" | "acknowledge" | "yes-no",
+      "ownership": "mine" | "shared",
+      "role": "owner" | "viewer",        // optional
+      "postedAt": "ISO8601",             // optional
+      "scheduledAt": "ISO8601",          // optional
+      "createdAt": "ISO8601",
+      "createdBy": "string",
+      "stats": {
+        "totalCount": number,
+        "readCount": number,
+        "responseCount": number,
+        "yesCount": number,
+        "noCount": number
+      },
+      "recipients": [
+        {
+          "studentId": "string",
+          "studentName": "string",
+          "classId": "string",
+          "parentName": "string",
+          "readStatus": "read" | "unread",
+          "respondedAt": "ISO8601",      // optional
+          "formResponse": "yes" | "no"  // optional
+        }
+      ]
+    }
+  ]
+}
+```
+
+This matches the existing `PGAnnouncement` TypeScript types in `web/data/mock-pg-announcements.ts` exactly — no type changes needed.
+
+---
+
+## Dev setup
+
+The Go server must be running alongside Vite for API calls to work locally:
+
+```bash
+# Terminal 1 — Go BFF
+go run ./server/cmd/tw
+
+# Terminal 2 — Vite dev server
+pnpm dev
+```
+
+Vite proxies `/api/*` calls to the Go server. If the proxy isn't configured yet, add this to `vite.config.ts`:
+
+```ts
+server: {
+  proxy: {
+    '/api': 'http://localhost:3000',
+  },
+},
+```

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 
 	Server ServerConfig `dotenv:",squash"`
 	OTPaaS OTPaaSConfig `dotenv:",squash"`
+	PG     PGConfig     `dotenv:",squash"`
 }
 
 // ServerConfig represents the configuration for the HTTP server.
@@ -36,6 +37,12 @@ type ServerConfig struct {
 	ReadHeaderTimeout time.Duration `dotenv:"TW_SERVER_READ_HEADER_TIMEOUT"`
 	WriteTimeout      time.Duration `dotenv:"TW_SERVER_WRITE_TIMEOUT"`
 	IdleTimeout       time.Duration `dotenv:"TW_SERVER_IDLE_TIMEOUT"`
+}
+
+// PGConfig holds configuration for the Parents Gateway integration.
+type PGConfig struct {
+	Mock    bool   `dotenv:"TW_PG_MOCK"`
+	BaseURL string `dotenv:"TW_PG_BASE_URL"`
 }
 
 type OTPaaSConfig struct {
@@ -71,6 +78,11 @@ func Default() *Config {
 			Namespace: "",
 			Secret:    "",
 			Timeout:   10 * time.Second,
+		},
+
+		PG: PGConfig{
+			Mock:    true,
+			BaseURL: "https://pg.moe.edu.sg",
 		},
 	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -9,6 +9,7 @@ import (
 	"github.com/String-sg/teacher-workspace/server/internal/config"
 	"github.com/String-sg/teacher-workspace/server/internal/htmlutil"
 	"github.com/String-sg/teacher-workspace/server/internal/middleware"
+	"github.com/String-sg/teacher-workspace/server/internal/pg"
 )
 
 const (
@@ -63,6 +64,8 @@ func New(cfg *config.Config) (*Handler, error) {
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("POST /otp/request", h.RequestOTP)
 	mux.HandleFunc("POST /otp/verify", h.VerifyOTP)
+
+	pg.New(&h.cfg.PG).Register(mux)
 
 	mux.HandleFunc("GET /", h.Index)
 }

--- a/server/internal/pg/fixtures/announcements.json
+++ b/server/internal/pg/fixtures/announcements.json
@@ -1,0 +1,75 @@
+{
+  "items": [
+    {
+      "id": "1",
+      "title": "Term 4 Letter to Parents",
+      "description": "Dear parents, please find attached the letter regarding Term 4 arrangements including exam schedules and upcoming school events.",
+      "status": "posted",
+      "responseType": "view-only",
+      "ownership": "mine",
+      "postedAt": "2026-03-10T09:00:00+08:00",
+      "createdAt": "2026-03-09T14:30:00+08:00",
+      "createdBy": "Ms Tan Wei Ling",
+      "stats": {
+        "totalCount": 4,
+        "readCount": 2,
+        "responseCount": 0,
+        "yesCount": 0,
+        "noCount": 0
+      },
+      "recipients": [
+        { "studentId": "S001", "studentName": "Alice Tan", "classId": "4A", "parentName": "Mr Tan Ah Kow", "readStatus": "read" },
+        { "studentId": "S002", "studentName": "Bob Lim", "classId": "4A", "parentName": "Mrs Lim Mei Hua", "readStatus": "read" },
+        { "studentId": "S003", "studentName": "Carol Chen", "classId": "4A", "parentName": "Mr Chen Wei", "readStatus": "unread" },
+        { "studentId": "S004", "studentName": "David Ng", "classId": "4A", "parentName": "Mrs Ng Li Fang", "readStatus": "unread" }
+      ]
+    },
+    {
+      "id": "2",
+      "title": "Class Chalet 2026 – RSVP",
+      "description": "We are organising a class chalet on 15-16 June 2026 at Costa Sands Resort. Please indicate if your child will be attending.",
+      "status": "posted",
+      "responseType": "yes-no",
+      "ownership": "shared",
+      "role": "owner",
+      "postedAt": "2026-03-12T10:00:00+08:00",
+      "createdAt": "2026-03-11T16:00:00+08:00",
+      "createdBy": "Mr Ahmad Bin Ibrahim",
+      "stats": {
+        "totalCount": 3,
+        "readCount": 2,
+        "responseCount": 2,
+        "yesCount": 1,
+        "noCount": 1
+      },
+      "recipients": [
+        { "studentId": "S001", "studentName": "Alice Tan", "classId": "4A", "parentName": "Mr Tan Ah Kow", "readStatus": "read", "respondedAt": "2026-03-12T12:30:00+08:00", "formResponse": "yes" },
+        { "studentId": "S002", "studentName": "Bob Lim", "classId": "4A", "parentName": "Mrs Lim Mei Hua", "readStatus": "read", "respondedAt": "2026-03-13T08:00:00+08:00", "formResponse": "no" },
+        { "studentId": "S005", "studentName": "Emily Wong", "classId": "4A", "parentName": "Mrs Wong Siew Lan", "readStatus": "unread" }
+      ]
+    },
+    {
+      "id": "3",
+      "title": "Science Centre Learning Journey",
+      "description": "Your child has been selected for the Science Centre Learning Journey on 20 April 2026. Please acknowledge receipt of this notification.",
+      "status": "scheduled",
+      "responseType": "acknowledge",
+      "ownership": "mine",
+      "scheduledAt": "2026-04-05T08:00:00+08:00",
+      "createdAt": "2026-03-20T11:00:00+08:00",
+      "createdBy": "Ms Tan Wei Ling",
+      "stats": {
+        "totalCount": 3,
+        "readCount": 0,
+        "responseCount": 0,
+        "yesCount": 0,
+        "noCount": 0
+      },
+      "recipients": [
+        { "studentId": "S001", "studentName": "Alice Tan", "classId": "4A", "parentName": "Mr Tan Ah Kow", "readStatus": "unread" },
+        { "studentId": "S003", "studentName": "Carol Chen", "classId": "4A", "parentName": "Mr Chen Wei", "readStatus": "unread" },
+        { "studentId": "S005", "studentName": "Emily Wong", "classId": "4A", "parentName": "Mrs Wong Siew Lan", "readStatus": "unread" }
+      ]
+    }
+  ]
+}

--- a/server/internal/pg/handler.go
+++ b/server/internal/pg/handler.go
@@ -1,0 +1,26 @@
+package pg
+
+import (
+	"net/http"
+
+	"github.com/String-sg/teacher-workspace/server/internal/config"
+)
+
+// Handler handles all /api/web/2/staff/* routes.
+type Handler struct {
+	cfg *config.PGConfig
+}
+
+// New creates a new PG handler.
+func New(cfg *config.PGConfig) *Handler {
+	return &Handler{cfg: cfg}
+}
+
+// Register attaches PG routes to the provided ServeMux.
+func (h *Handler) Register(mux *http.ServeMux) {
+	if h.cfg.Mock {
+		h.registerMock(mux)
+		return
+	}
+	// Phase 2: real proxy routes go here
+}

--- a/server/internal/pg/mock.go
+++ b/server/internal/pg/mock.go
@@ -1,0 +1,28 @@
+package pg
+
+import (
+	"embed"
+	"net/http"
+)
+
+//go:embed fixtures
+var fixtures embed.FS
+
+func (h *Handler) registerMock(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/web/2/staff/announcements", serveFixture("fixtures/announcements.json"))
+}
+
+func serveFixture(path string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := fixtures.ReadFile(path)
+		if err != nil {
+			http.Error(w, "fixture not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `server/internal/pg` package with mock mode (default `TW_PG_MOCK=true`)
- Serves fixture JSON at `GET /api/web/2/staff/announcements` matching existing FE types
- Wires PG handler into main handler — no other routes affected
- Adds `plans/FE-API-WIRING.md` with instructions for wiring up the FE

## Why mock first

Real proxy to pgw-web requires the PG team to whitelist TW's server IP and define a service-to-service auth contract. That's in flight. Mock mode unblocks FE development in the meantime — when real integration is ready, flip `TW_PG_MOCK=false` and add the proxy handler in Phase 2.

## For Reza

See `plans/FE-API-WIRING.md` — covers exactly what to change in `PostsView.tsx` and where to move types. Your AI can pick it up directly.

After merging this, rebase `feat/posts-list-page` on `main` and wire up the fetch call.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `curl http://localhost:3000/api/web/2/staff/announcements` returns fixture JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)