### PR TITLE
feat(server): add full PG fixture set in real API shapes

### DIFF
--- a/server/internal/pg/fixtures/announcement_detail.json
+++ b/server/internal/pg/fixtures/announcement_detail.json
@@ -1,0 +1,27 @@
+{
+  "announcementId": 1036,
+  "title": "Term 4 Letter to Parents",
+  "content": null,
+  "richTextContent": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"Dear Parents,\"}]},{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"Please find attached the letter regarding Term 4 arrangements including exam schedules and upcoming school events.\"}]},{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"Thank you.\"}]}]}",
+  "staffName": "MS TAN WEI LING",
+  "createdBy": 1013,
+  "createdAt": "2026-03-09T06:30:00.000Z",
+  "postedDate": "2026-03-10T01:00:00.000Z",
+  "enquiryEmailAddress": "greenridge_sec@moe.edu.sg",
+  "attachments": [],
+  "images": [],
+  "shortcutLink": [],
+  "websiteLinks": [],
+  "staffOwners": [
+    { "staffID": 1013, "staffName": "TAN GUANG SHIN" }
+  ],
+  "students": [
+    { "studentId": 1, "studentName": "TAN XIAO MING", "className": "4A", "isRead": true },
+    { "studentId": 2, "studentName": "LEE WEI LIANG", "className": "4A", "isRead": true },
+    { "studentId": 3, "studentName": "CAROL CHEN HUI", "className": "4A", "isRead": false },
+    { "studentId": 4, "studentName": "DAVID NG JUN WEI", "className": "4A", "isRead": false }
+  ],
+  "status": "POSTED",
+  "scheduledSendAt": null,
+  "scheduledSendFailureCode": null
+}

--- a/server/internal/pg/fixtures/announcements.json
+++ b/server/internal/pg/fixtures/announcements.json
@@ -1,75 +1,51 @@
 {
-  "items": [
+  "posts": [
     {
-      "id": "1",
+      "id": "ann_1036",
+      "postId": 1036,
       "title": "Term 4 Letter to Parents",
-      "description": "Dear parents, please find attached the letter regarding Term 4 arrangements including exam schedules and upcoming school events.",
-      "status": "posted",
-      "responseType": "view-only",
-      "ownership": "mine",
-      "postedAt": "2026-03-10T09:00:00+08:00",
-      "createdAt": "2026-03-09T14:30:00+08:00",
-      "createdBy": "Ms Tan Wei Ling",
-      "stats": {
-        "totalCount": 4,
-        "readCount": 2,
-        "responseCount": 0,
-        "yesCount": 0,
-        "noCount": 0
-      },
-      "recipients": [
-        { "studentId": "S001", "studentName": "Alice Tan", "classId": "4A", "parentName": "Mr Tan Ah Kow", "readStatus": "read" },
-        { "studentId": "S002", "studentName": "Bob Lim", "classId": "4A", "parentName": "Mrs Lim Mei Hua", "readStatus": "read" },
-        { "studentId": "S003", "studentName": "Carol Chen", "classId": "4A", "parentName": "Mr Chen Wei", "readStatus": "unread" },
-        { "studentId": "S004", "studentName": "David Ng", "classId": "4A", "parentName": "Mrs Ng Li Fang", "readStatus": "unread" }
-      ]
+      "date": "2026-03-10T01:00:00.000Z",
+      "status": "POSTED",
+      "toParentsOf": ["4A"],
+      "readMetrics": { "readPerStudent": 0.5, "totalStudents": 4 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "MS TAN WEI LING"
     },
     {
-      "id": "2",
+      "id": "ann_1037",
+      "postId": 1037,
       "title": "Class Chalet 2026 – RSVP",
-      "description": "We are organising a class chalet on 15-16 June 2026 at Costa Sands Resort. Please indicate if your child will be attending.",
-      "status": "posted",
-      "responseType": "yes-no",
-      "ownership": "shared",
-      "role": "owner",
-      "postedAt": "2026-03-12T10:00:00+08:00",
-      "createdAt": "2026-03-11T16:00:00+08:00",
-      "createdBy": "Mr Ahmad Bin Ibrahim",
-      "stats": {
-        "totalCount": 3,
-        "readCount": 2,
-        "responseCount": 2,
-        "yesCount": 1,
-        "noCount": 1
-      },
-      "recipients": [
-        { "studentId": "S001", "studentName": "Alice Tan", "classId": "4A", "parentName": "Mr Tan Ah Kow", "readStatus": "read", "respondedAt": "2026-03-12T12:30:00+08:00", "formResponse": "yes" },
-        { "studentId": "S002", "studentName": "Bob Lim", "classId": "4A", "parentName": "Mrs Lim Mei Hua", "readStatus": "read", "respondedAt": "2026-03-13T08:00:00+08:00", "formResponse": "no" },
-        { "studentId": "S005", "studentName": "Emily Wong", "classId": "4A", "parentName": "Mrs Wong Siew Lan", "readStatus": "unread" }
-      ]
+      "date": "2026-03-12T02:00:00.000Z",
+      "status": "POSTED",
+      "toParentsOf": ["4A"],
+      "readMetrics": { "readPerStudent": 0.67, "totalStudents": 3 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "MR AHMAD BIN IBRAHIM"
     },
     {
-      "id": "3",
+      "id": "ann_1038",
+      "postId": 1038,
       "title": "Science Centre Learning Journey",
-      "description": "Your child has been selected for the Science Centre Learning Journey on 20 April 2026. Please acknowledge receipt of this notification.",
-      "status": "scheduled",
-      "responseType": "acknowledge",
-      "ownership": "mine",
-      "scheduledAt": "2026-04-05T08:00:00+08:00",
-      "createdAt": "2026-03-20T11:00:00+08:00",
-      "createdBy": "Ms Tan Wei Ling",
-      "stats": {
-        "totalCount": 3,
-        "readCount": 0,
-        "responseCount": 0,
-        "yesCount": 0,
-        "noCount": 0
-      },
-      "recipients": [
-        { "studentId": "S001", "studentName": "Alice Tan", "classId": "4A", "parentName": "Mr Tan Ah Kow", "readStatus": "unread" },
-        { "studentId": "S003", "studentName": "Carol Chen", "classId": "4A", "parentName": "Mr Chen Wei", "readStatus": "unread" },
-        { "studentId": "S005", "studentName": "Emily Wong", "classId": "4A", "parentName": "Mrs Wong Siew Lan", "readStatus": "unread" }
-      ]
+      "date": "2026-04-05T00:00:00.000Z",
+      "status": "SCHEDULED",
+      "toParentsOf": ["4A"],
+      "readMetrics": { "readPerStudent": 0, "totalStudents": 3 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "MS TAN WEI LING"
+    },
+    {
+      "id": "ann_1039",
+      "postId": 1039,
+      "title": "End of Year Prize-Giving Ceremony",
+      "date": "2026-03-28T08:00:00.000Z",
+      "status": "DRAFT",
+      "toParentsOf": [],
+      "readMetrics": { "readPerStudent": 0, "totalStudents": 0 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "MS TAN WEI LING"
     }
-  ]
+  ],
+  "total": 4,
+  "page": 1,
+  "pageSize": 10
 }

--- a/server/internal/pg/fixtures/announcements_shared.json
+++ b/server/internal/pg/fixtures/announcements_shared.json
@@ -1,0 +1,18 @@
+{
+  "posts": [
+    {
+      "id": "ann_1040",
+      "postId": 1040,
+      "title": "Sports Day Arrangements",
+      "date": "2026-03-15T03:00:00.000Z",
+      "status": "POSTED",
+      "toParentsOf": ["4A", "4B"],
+      "readMetrics": { "readPerStudent": 0.8, "totalStudents": 60 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "MR LEE KAH SENG"
+    }
+  ],
+  "total": 1,
+  "page": 1,
+  "pageSize": 10
+}

--- a/server/internal/pg/fixtures/configs.json
+++ b/server/internal/pg/fixtures/configs.json
@@ -1,0 +1,21 @@
+{
+  "flags": {
+    "absence_submission": { "enabled": true },
+    "duplicate_announcement_form_post": { "enabled": true },
+    "heytalia_chat": { "enabled": true },
+    "schedule_announcement_form_post": { "enabled": true }
+  },
+  "configs": {
+    "absence_notification": { "blacklist": [] },
+    "two_way_comms": {
+      "isTwoWayCommsBetaEnabled": true,
+      "twoWayCommsBetaSchoolWhiteList": []
+    },
+    "web_notification": {
+      "enabled": false,
+      "endDateTime": "2026-04-01T00:00:00.000Z",
+      "message": "",
+      "startDateTime": "2026-03-01T00:00:00.000Z"
+    }
+  }
+}

--- a/server/internal/pg/fixtures/consent_form_detail.json
+++ b/server/internal/pg/fixtures/consent_form_detail.json
@@ -1,0 +1,27 @@
+{
+  "consentFormId": 1038,
+  "title": "Consent Form for Boxing Competition 1 April 2026",
+  "richTextContent": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"Dear Parents,\"}]},{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"Your child has been selected to represent the school in the National Boxing Competition on 1 April 2026. Please indicate your consent below.\"}]}]}",
+  "responseType": "YES_NO",
+  "eventStartDate": "2026-04-01T04:00:00.000Z",
+  "eventEndDate": "2026-04-01T09:00:00.000Z",
+  "consentByDate": "2026-03-30T15:59:59.000Z",
+  "addReminderType": "ONE_TIME",
+  "reminderDate": "2026-03-29T15:59:59.000Z",
+  "postedDate": "2026-03-24T03:08:05.000Z",
+  "enquiryEmailAddress": "greenridge_sec@moe.edu.sg",
+  "staffName": "TAN GUANG SHIN",
+  "createdBy": 1013,
+  "createdAt": "2026-03-24T03:08:05.000Z",
+  "attachments": [],
+  "images": [],
+  "websiteLinks": [],
+  "customQuestions": [],
+  "staffOwners": [{ "staffID": 1013, "staffName": "TAN GUANG SHIN" }],
+  "students": [
+    { "studentId": 1, "studentName": "TAN XIAO MING", "className": "Boxing", "response": "YES", "respondedAt": "2026-03-25T09:00:00.000Z" },
+    { "studentId": 5, "studentName": "EMILY WONG SHU HUI", "className": "Boxing", "response": null, "respondedAt": null }
+  ],
+  "status": "OPEN",
+  "consentFormHistory": []
+}

--- a/server/internal/pg/fixtures/consent_forms.json
+++ b/server/internal/pg/fixtures/consent_forms.json
@@ -1,0 +1,31 @@
+{
+  "posts": [
+    {
+      "id": "cf_1038",
+      "postId": 1038,
+      "title": "Consent Form for Boxing Competition 1 April 2026",
+      "date": "2026-03-24T03:08:05.000Z",
+      "status": "OPEN",
+      "toParentsOf": ["Boxing"],
+      "respondedMetrics": { "respondedPerStudent": 0.5, "totalStudents": 2 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "TAN GUANG SHIN",
+      "consentByDate": "2026-03-30T15:59:59.000Z"
+    },
+    {
+      "id": "cf_1039",
+      "postId": 1039,
+      "title": "International Olympiad Trip – Parent Consent",
+      "date": "2026-03-18T04:00:00.000Z",
+      "status": "CLOSED",
+      "toParentsOf": ["4A"],
+      "respondedMetrics": { "respondedPerStudent": 0.93, "totalStudents": 30 },
+      "scheduledSendFailureCode": null,
+      "createdByName": "TAN GUANG SHIN",
+      "consentByDate": "2026-03-25T15:59:59.000Z"
+    }
+  ],
+  "total": 2,
+  "page": 1,
+  "pageSize": 10
+}

--- a/server/internal/pg/fixtures/group_custom_detail.json
+++ b/server/internal/pg/fixtures/group_custom_detail.json
@@ -1,0 +1,14 @@
+{
+  "customGroupId": 5,
+  "name": "Olympiad Study Group",
+  "createdBy": 1013,
+  "createdByName": "TAN GUANG SHIN",
+  "isShared": false,
+  "sharedWith": [],
+  "students": [
+    { "studentId": 1, "studentName": "TAN XIAO MING", "className": "4A", "indexNumber": 15, "ccas": ["BOXING"] },
+    { "studentId": 2, "studentName": "LEE WEI LIANG", "className": "4A", "indexNumber": 8, "ccas": [] },
+    { "studentId": 3, "studentName": "CAROL CHEN HUI", "className": "4A", "indexNumber": 3, "ccas": ["CHOIR"] }
+  ],
+  "createdAt": "2026-03-01T08:00:00.000Z"
+}

--- a/server/internal/pg/fixtures/groups_assigned.json
+++ b/server/internal/pg/fixtures/groups_assigned.json
@@ -1,0 +1,32 @@
+{
+  "classes": [
+    {
+      "classId": 101,
+      "className": "4A",
+      "level": "SECONDARY 4",
+      "year": 2026,
+      "role": "FORM_TEACHER",
+      "studentCount": 30
+    }
+  ],
+  "ccas": [
+    {
+      "ccaId": 10,
+      "ccaName": "BOXING",
+      "studentCount": 15
+    }
+  ],
+  "levels": [
+    {
+      "levelId": 4,
+      "levelName": "SECONDARY 4",
+      "year": 2026,
+      "studentCount": 120
+    }
+  ],
+  "school": {
+    "schoolId": 1001,
+    "schoolName": "GREENRIDGE SECONDARY SCHOOL",
+    "studentCount": 600
+  }
+}

--- a/server/internal/pg/fixtures/groups_custom.json
+++ b/server/internal/pg/fixtures/groups_custom.json
@@ -1,0 +1,13 @@
+{
+  "customGroups": [
+    {
+      "customGroupId": 5,
+      "name": "Olympiad Study Group",
+      "studentCount": 8,
+      "createdBy": 1013,
+      "createdByName": "TAN GUANG SHIN",
+      "isShared": false,
+      "createdAt": "2026-03-01T08:00:00.000Z"
+    }
+  ]
+}

--- a/server/internal/pg/fixtures/meeting_detail.json
+++ b/server/internal/pg/fixtures/meeting_detail.json
@@ -1,0 +1,28 @@
+{
+  "eventId": 1001,
+  "title": "Parent-Teacher Meeting Term 2 2026",
+  "richTextContent": "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"Dear Parents, please book a slot to meet your child's form teacher.\"}]}]}",
+  "venue": "Classroom 4A",
+  "enquiryEmailAddress": "greenridge_sec@moe.edu.sg",
+  "eventDates": [
+    {
+      "startDateTime": "2026-04-10T01:00:00.000Z",
+      "endDateTime": "2026-04-10T05:00:00.000Z"
+    }
+  ],
+  "bookingWindows": [
+    {
+      "windowDate": {
+        "startDateTime": "2026-04-05T00:00:00.000Z",
+        "endDateTime": "2026-04-09T16:00:00.000Z"
+      }
+    }
+  ],
+  "slotDuration": 10,
+  "bookingsPerSlot": 1,
+  "staffOwners": [{ "staffID": 1013, "staffName": "TAN GUANG SHIN" }],
+  "attachments": [],
+  "websiteLinks": [],
+  "status": "BOOKING_OPEN",
+  "createdDate": "2026-03-20T08:00:00.000Z"
+}

--- a/server/internal/pg/fixtures/meeting_timeslots.json
+++ b/server/internal/pg/fixtures/meeting_timeslots.json
@@ -1,0 +1,40 @@
+{
+  "eventId": 1001,
+  "timeslots": [
+    {
+      "slotId": 1,
+      "startDateTime": "2026-04-10T01:00:00.000Z",
+      "endDateTime": "2026-04-10T01:10:00.000Z",
+      "capacity": 1,
+      "booked": 0,
+      "isBlocked": false,
+      "bookings": []
+    },
+    {
+      "slotId": 2,
+      "startDateTime": "2026-04-10T01:10:00.000Z",
+      "endDateTime": "2026-04-10T01:20:00.000Z",
+      "capacity": 1,
+      "booked": 1,
+      "isBlocked": false,
+      "bookings": [
+        {
+          "bookingId": 10,
+          "studentId": 1,
+          "studentName": "TAN XIAO MING",
+          "parentName": "TAN AH KOW",
+          "bookedAt": "2026-04-06T09:00:00.000Z"
+        }
+      ]
+    },
+    {
+      "slotId": 3,
+      "startDateTime": "2026-04-10T01:20:00.000Z",
+      "endDateTime": "2026-04-10T01:30:00.000Z",
+      "capacity": 1,
+      "booked": 0,
+      "isBlocked": true,
+      "bookings": []
+    }
+  ]
+}

--- a/server/internal/pg/fixtures/meetings.json
+++ b/server/internal/pg/fixtures/meetings.json
@@ -1,0 +1,54 @@
+{
+  "upcoming": [
+    {
+      "eventId": 1001,
+      "title": "Parent-Teacher Meeting Term 2 2026",
+      "eventDates": [
+        {
+          "startDateTime": "2026-04-10T01:00:00.000Z",
+          "endDateTime": "2026-04-10T05:00:00.000Z"
+        }
+      ],
+      "bookingWindows": [
+        {
+          "windowDate": {
+            "startDateTime": "2026-04-05T00:00:00.000Z",
+            "endDateTime": "2026-04-09T16:00:00.000Z"
+          }
+        }
+      ],
+      "bookingSummary": { "available": 4, "pending": 2, "booked": 2 },
+      "targetStudents": 30,
+      "createdDate": "2026-03-20T08:00:00.000Z",
+      "slotDuration": 10,
+      "bookingsPerSlot": 1,
+      "status": "BOOKING_OPEN"
+    }
+  ],
+  "past": [
+    {
+      "eventId": 1000,
+      "title": "Parent-Teacher Meeting Term 1 2026",
+      "eventDates": [
+        {
+          "startDateTime": "2026-01-15T01:00:00.000Z",
+          "endDateTime": "2026-01-15T05:00:00.000Z"
+        }
+      ],
+      "bookingWindows": [
+        {
+          "windowDate": {
+            "startDateTime": "2026-01-10T00:00:00.000Z",
+            "endDateTime": "2026-01-14T16:00:00.000Z"
+          }
+        }
+      ],
+      "bookingSummary": { "available": 0, "pending": 0, "booked": 28 },
+      "targetStudents": 30,
+      "createdDate": "2026-01-05T08:00:00.000Z",
+      "slotDuration": 10,
+      "bookingsPerSlot": 1,
+      "status": "PAST"
+    }
+  ]
+}

--- a/server/internal/pg/fixtures/notification_preferences.json
+++ b/server/internal/pg/fixtures/notification_preferences.json
@@ -1,0 +1,7 @@
+{
+  "preferences": [
+    { "eventType": "CONSENT_FORM_RESPONSE_YES", "label": "When a parent responds 'Yes'", "enabled": true },
+    { "eventType": "CONSENT_FORM_RESPONSE_NO", "label": "When a parent responds 'No'", "enabled": true },
+    { "eventType": "CONSENT_FORM_RESPONSE_CHANGED", "label": "When a parent changes their response", "enabled": false }
+  ]
+}

--- a/server/internal/pg/fixtures/school_groups.json
+++ b/server/internal/pg/fixtures/school_groups.json
@@ -1,0 +1,15 @@
+{
+  "classes": [
+    { "classId": 101, "className": "4A", "level": "SECONDARY 4", "year": 2026 },
+    { "classId": 102, "className": "4B", "level": "SECONDARY 4", "year": 2026 },
+    { "classId": 103, "className": "4C", "level": "SECONDARY 4", "year": 2026 }
+  ],
+  "levels": [
+    { "levelId": 4, "levelName": "SECONDARY 4", "year": 2026 }
+  ],
+  "ccas": [
+    { "ccaId": 10, "ccaName": "BOXING" },
+    { "ccaId": 11, "ccaName": "CHOIR" },
+    { "ccaId": 12, "ccaName": "BASKETBALL" }
+  ]
+}

--- a/server/internal/pg/fixtures/school_staff.json
+++ b/server/internal/pg/fixtures/school_staff.json
@@ -1,0 +1,7 @@
+{
+  "staff": [
+    { "staffId": 1013, "staffName": "TAN GUANG SHIN", "email": "tangs@schools.gov.sg", "schoolEmail": "greenridge_sec@moe.edu.sg", "assignedClass": "4A" },
+    { "staffId": 1014, "staffName": "LEE KAH SENG", "email": "leeks@schools.gov.sg", "schoolEmail": "greenridge_sec@moe.edu.sg", "assignedClass": "4B" },
+    { "staffId": 1015, "staffName": "AHMAD BIN IBRAHIM", "email": "ahmadi@schools.gov.sg", "schoolEmail": "greenridge_sec@moe.edu.sg", "assignedClass": "4C" }
+  ]
+}

--- a/server/internal/pg/fixtures/school_students.json
+++ b/server/internal/pg/fixtures/school_students.json
@@ -1,0 +1,10 @@
+{
+  "students": [
+    { "studentId": 1, "studentName": "TAN XIAO MING", "className": "4A", "level": "SECONDARY 4", "indexNumber": 15, "ccas": ["BOXING"] },
+    { "studentId": 2, "studentName": "LEE WEI LIANG", "className": "4A", "level": "SECONDARY 4", "indexNumber": 8, "ccas": [] },
+    { "studentId": 3, "studentName": "CAROL CHEN HUI", "className": "4A", "level": "SECONDARY 4", "indexNumber": 3, "ccas": ["CHOIR"] },
+    { "studentId": 4, "studentName": "DAVID NG JUN WEI", "className": "4A", "level": "SECONDARY 4", "indexNumber": 5, "ccas": ["BASKETBALL"] },
+    { "studentId": 5, "studentName": "EMILY WONG SHU HUI", "className": "4A", "level": "SECONDARY 4", "indexNumber": 7, "ccas": ["BOXING"] }
+  ],
+  "total": 5
+}

--- a/server/internal/pg/fixtures/session_current.json
+++ b/server/internal/pg/fixtures/session_current.json
@@ -1,0 +1,18 @@
+{
+  "staffId": 1013,
+  "staffName": "TAN GUANG SHIN",
+  "isA": false,
+  "staffSchoolId": 1001,
+  "staffEmailAdd": "tangs@schools.gov.sg",
+  "is2FAAuthorized": true,
+  "schoolEmailAddress": "greenridge_sec@moe.edu.sg",
+  "schoolName": "GREENRIDGE SECONDARY SCHOOL",
+  "sessionTimeLeft": 1799,
+  "displayName": "",
+  "displayEmail": "",
+  "displayUpdatedBy": "",
+  "displayUpdatedAt": "",
+  "isAdminUpdated": false,
+  "isIhl": false,
+  "heyTaliaAccess": true
+}

--- a/server/internal/pg/fixtures/users_me.json
+++ b/server/internal/pg/fixtures/users_me.json
@@ -1,0 +1,13 @@
+{
+  "staffId": 1013,
+  "staffName": "TAN GUANG SHIN",
+  "email": "tangs@schools.gov.sg",
+  "schoolEmail": "greenridge_sec@moe.edu.sg",
+  "schoolName": "GREENRIDGE SECONDARY SCHOOL",
+  "displayName": "",
+  "displayEmail": "",
+  "recentLogins": [
+    { "loginAt": "2026-04-07T08:00:00.000Z", "device": "MacBook Pro", "browser": "Chrome 124", "ipAddress": "128.106.1.1" },
+    { "loginAt": "2026-04-06T09:30:00.000Z", "device": "iPhone 15", "browser": "Mobile Safari", "ipAddress": "128.106.1.1" }
+  ]
+}

--- a/server/internal/pg/mock.go
+++ b/server/internal/pg/mock.go
@@ -9,7 +9,38 @@ import (
 var fixtures embed.FS
 
 func (h *Handler) registerMock(mux *http.ServeMux) {
+	// Session & config
+	mux.HandleFunc("GET /api/web/2/staff/session/current", serveFixture("fixtures/session_current.json"))
+	mux.HandleFunc("GET /api/configs", serveFixture("fixtures/configs.json"))
+
+	// Announcements
 	mux.HandleFunc("GET /api/web/2/staff/announcements", serveFixture("fixtures/announcements.json"))
+	mux.HandleFunc("GET /api/web/2/staff/announcements/shared", serveFixture("fixtures/announcements_shared.json"))
+	mux.HandleFunc("GET /api/web/2/staff/announcements/{postId}", serveFixture("fixtures/announcement_detail.json"))
+
+	// Consent forms
+	mux.HandleFunc("GET /api/web/2/staff/consentForms", serveFixture("fixtures/consent_forms.json"))
+	mux.HandleFunc("GET /api/web/2/staff/consentForms/shared", serveFixture("fixtures/consent_forms.json"))
+	mux.HandleFunc("GET /api/web/2/staff/consentForms/{consentFormId}", serveFixture("fixtures/consent_form_detail.json"))
+
+	// Meetings (PTM)
+	mux.HandleFunc("GET /api/web/2/staff/ptm", serveFixture("fixtures/meetings.json"))
+	mux.HandleFunc("GET /api/web/2/staff/ptm/{eventId}", serveFixture("fixtures/meeting_detail.json"))
+	mux.HandleFunc("GET /api/web/2/staff/ptm/timeslots/{eventId}", serveFixture("fixtures/meeting_timeslots.json"))
+
+	// Groups
+	mux.HandleFunc("GET /api/web/2/staff/groups/assigned", serveFixture("fixtures/groups_assigned.json"))
+	mux.HandleFunc("GET /api/web/2/staff/groups/custom", serveFixture("fixtures/groups_custom.json"))
+	mux.HandleFunc("GET /api/web/2/staff/groups/custom/{customGroupId}", serveFixture("fixtures/group_custom_detail.json"))
+
+	// School data
+	mux.HandleFunc("GET /api/web/2/staff/school/staff", serveFixture("fixtures/school_staff.json"))
+	mux.HandleFunc("GET /api/web/2/staff/school/students", serveFixture("fixtures/school_students.json"))
+	mux.HandleFunc("GET /api/web/2/staff/school/groups", serveFixture("fixtures/school_groups.json"))
+
+	// Account & notification prefs
+	mux.HandleFunc("GET /api/web/2/staff/users/me", serveFixture("fixtures/users_me.json"))
+	mux.HandleFunc("GET /api/web/2/staff/notificationPreference", serveFixture("fixtures/notification_preferences.json"))
 }
 
 func serveFixture(path string) http.HandlerFunc {


### PR DESCRIPTION
## Summary

- Updates `announcements.json` to real PG API shapes (was using Reza's simplified types)
- Adds fixtures for all remaining read endpoints: session, configs, consent forms, meetings, groups, school data, account, notification prefs
- Registers 18 routes in `mock.go`

## Note for Reza

`announcements.json` shape has changed — field names now match real pgw-web responses. Update TypeScript types in `PostsView.tsx` accordingly when wiring up the API call (see `plans/FE-API-WIRING.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)