### PR TITLE
feat(bff): full staff-web mock parity + designer standalone workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,12 @@ A unified platform that consolidates teacher-facing applications into day-to-day
 ### Go
 
 ```bash
-go build -o build/tw ./cmd/tw       # Build binary
-go run ./cmd/tw                     # Run directly
-go test ./...                       # Run all tests
-go test ./path/to/pkg               # Run single package tests
-go test -run TestName ./path/to/pkg # Run a specific test
-golangci-lint run                   # Static analysis
+go build -o build/tw ./server/cmd/tw       # Build binary
+go run ./server/cmd/tw                     # Run directly
+go test ./...                              # Run all tests
+go test ./path/to/pkg                      # Run single package tests
+go test -run TestName ./path/to/pkg        # Run a specific test
+golangci-lint run                          # Static analysis
 ```
 
 ### Frontend
@@ -43,6 +43,52 @@ pnpm build                          # Build production bundle
 pnpm lint                           # Run ESLint
 pnpm format                         # Run Prettier
 ```
+
+## Running locally
+
+Two modes, toggled by `TW_PG_MOCK`. Create a root-level dotenv file at the
+repo root (the loader reads it from cwd; all env files are gitignored by
+policy — see `.gitignore`) with at minimum:
+
+```sh
+TW_ENV=development
+TW_LOG_LEVEL=info
+
+# Mock mode (default) — Go BFF serves fixtures from server/internal/pg/fixtures
+# and stubs writes. Flip to false + set TW_PG_BASE_URL to proxy real PGW.
+TW_PG_MOCK=true
+TW_PG_BASE_URL=https://pg.moe.edu.sg
+TW_PG_TIMEOUT_MS=10000
+
+TW_SERVER_PORT=3000
+TW_SERVER_READ_HEADER_TIMEOUT=2s
+TW_SERVER_READ_TIMEOUT=15s
+TW_SERVER_WRITE_TIMEOUT=30s
+TW_SERVER_IDLE_TIMEOUT=60s
+
+TW_VITE_DEV_SERVER_URL=http://localhost:5173
+TW_BUNDLE_DIRECTORY=dist
+
+# Required only when TW_PG_MOCK=false.
+TW_OTPAAS_HOST=https://otp.techpass.suite.gov.sg
+TW_OTPAAS_ID=
+TW_OTPAAS_NAMESPACE=
+TW_OTPAAS_SECRET=
+TW_OTPAAS_TIMEOUT=10s
+```
+
+**Designer / FE-only (default).** `TW_PG_MOCK=true` — no DB, Redis, or real PGW
+creds required. Start both processes:
+
+```bash
+go run ./server/cmd/tw              # shell 1 — BFF on :3000
+pnpm dev                            # shell 2 — Vite on :5173, proxies /api → :3000
+```
+
+**Owner / real PGW.** Set `TW_PG_MOCK=false`, point `TW_PG_BASE_URL` at a local
+PGW (e.g. `http://localhost:3001`), and fill the `TW_OTPAAS_*` fields
+(validated only in this mode). Start your local PGW stack, then the same two
+commands above — the BFF reverse-proxies `/api/web/*` to the configured PGW.
 
 ## Formatting & Linting
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -114,7 +114,12 @@ func (cfg *Config) Validate() error {
 		}
 	}
 
-	return errors.Join(append(errs, cfg.Server.validate(), cfg.OTPaaS.validate())...)
+	errs = append(errs, cfg.Server.validate())
+	// OTPaaS is only contacted when proxying to real PGW; mock mode needs no creds.
+	if !cfg.PG.Mock {
+		errs = append(errs, cfg.OTPaaS.validate())
+	}
+	return errors.Join(errs...)
 }
 
 func (c ServerConfig) validate() error {

--- a/server/internal/pg/fixtures/feature_flags.json
+++ b/server/internal/pg/fixtures/feature_flags.json
@@ -1,0 +1,14 @@
+{
+  "flags": {
+    "absence_submission": { "enabled": true },
+    "duplicate_announcement_form_post": { "enabled": true },
+    "heytalia_chat": { "enabled": true },
+    "schedule_announcement_form_post": { "enabled": true },
+    "web_notification": {
+      "enabled": false,
+      "message": "",
+      "startDateTime": "2026-03-01T00:00:00.000Z",
+      "endDateTime": "2026-04-01T00:00:00.000Z"
+    }
+  }
+}

--- a/server/internal/pg/fixtures/heytalia_conversation.json
+++ b/server/internal/pg/fixtures/heytalia_conversation.json
@@ -1,0 +1,23 @@
+{
+  "conversation": {
+    "conversationId": "mock-conversation-1",
+    "sessionId": "mock-session-1",
+    "pgStaffId": "1013",
+    "pgSchoolId": "2001",
+    "platform": "PGW",
+    "platformMetadata": {},
+    "title": "Mocked conversation",
+    "messages": [
+      {
+        "role": "assistant",
+        "content": "HeyTalia is disabled in the tw-pg-experiment mock mode.",
+        "timestamp": "2026-04-22T00:00:00.000Z"
+      }
+    ],
+    "createdAt": "2026-04-22T00:00:00.000Z",
+    "updatedAt": "2026-04-22T00:00:00.000Z",
+    "lastUpdated": 1777641600000,
+    "messageCount": 1,
+    "ttl": 86400
+  }
+}

--- a/server/internal/pg/fixtures/heytalia_conversations.json
+++ b/server/internal/pg/fixtures/heytalia_conversations.json
@@ -1,0 +1,5 @@
+{
+  "conversations": [],
+  "count": 0,
+  "staffId": "1013"
+}

--- a/server/internal/pg/fixtures/heytalia_email_recipients_history.json
+++ b/server/internal/pg/fixtures/heytalia_email_recipients_history.json
@@ -1,0 +1,4 @@
+{
+  "recipients": [],
+  "count": 0
+}

--- a/server/internal/pg/fixtures/meeting_booking.json
+++ b/server/internal/pg/fixtures/meeting_booking.json
@@ -1,0 +1,19 @@
+{
+  "bookingId": 10,
+  "slotId": 2,
+  "startDateTime": "2026-04-10T01:10:00.000Z",
+  "endDateTime": "2026-04-10T01:20:00.000Z",
+  "status": "unavailable",
+  "eventStudent": {
+    "eventStudentId": 5001,
+    "studentName": "TAN XIAO MING",
+    "targetName": "4A",
+    "className": "4A",
+    "classSerialNo": "15",
+    "ccaName": "BOXING",
+    "remarks": "",
+    "respondedBy": "TAN AH KOW",
+    "respondedDate": "2026-04-06T09:00:00.000Z",
+    "responderType": "custodian"
+  }
+}

--- a/server/internal/pg/fixtures/meeting_schedule.json
+++ b/server/internal/pg/fixtures/meeting_schedule.json
@@ -1,0 +1,54 @@
+{
+  "title": "Parent-Teacher Meeting Term 2 2026",
+  "targets": ["4A"],
+  "dates": [
+    {
+      "date": "2026-04-10T00:00:00.000Z",
+      "confirmedCount": 1,
+      "dateSlots": [
+        {
+          "slotId": 1,
+          "startDateTime": "2026-04-10T01:00:00.000Z",
+          "endDateTime": "2026-04-10T01:10:00.000Z",
+          "slots": [
+            {
+              "bookingId": 9,
+              "status": "available"
+            }
+          ]
+        },
+        {
+          "slotId": 2,
+          "startDateTime": "2026-04-10T01:10:00.000Z",
+          "endDateTime": "2026-04-10T01:20:00.000Z",
+          "slots": [
+            {
+              "bookingId": 10,
+              "status": "unavailable",
+              "eventStudent": {
+                "eventStudentId": 5001,
+                "studentName": "TAN XIAO MING",
+                "targetName": "4A",
+                "className": "4A",
+                "classSerialNo": "15",
+                "ccaName": "BOXING",
+                "remarks": ""
+              }
+            }
+          ]
+        },
+        {
+          "slotId": 3,
+          "startDateTime": "2026-04-10T01:20:00.000Z",
+          "endDateTime": "2026-04-10T01:30:00.000Z",
+          "slots": [
+            {
+              "bookingId": 11,
+              "status": "available"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/server/internal/pg/fixtures/meeting_target_students.json
+++ b/server/internal/pg/fixtures/meeting_target_students.json
@@ -1,0 +1,36 @@
+{
+  "eventStudents": [
+    {
+      "eventStudentId": 5001,
+      "studentName": "TAN XIAO MING",
+      "className": "4A",
+      "classSerialNo": "15",
+      "ccaName": "BOXING",
+      "remarks": ""
+    },
+    {
+      "eventStudentId": 5002,
+      "studentName": "LEE WEI LIANG",
+      "className": "4A",
+      "classSerialNo": "8",
+      "ccaName": "",
+      "remarks": ""
+    },
+    {
+      "eventStudentId": 5003,
+      "studentName": "CAROL CHEN HUI",
+      "className": "4A",
+      "classSerialNo": "3",
+      "ccaName": "CHOIR",
+      "remarks": ""
+    },
+    {
+      "eventStudentId": 5004,
+      "studentName": "DAVID NG JUN WEI",
+      "className": "4A",
+      "classSerialNo": "5",
+      "ccaName": "",
+      "remarks": "Called sick"
+    }
+  ]
+}

--- a/server/internal/pg/fixtures/message_groups.json
+++ b/server/internal/pg/fixtures/message_groups.json
@@ -1,0 +1,24 @@
+[
+  {
+    "staffMessageGroupId": 1,
+    "groupId": 101,
+    "groupType": "class",
+    "groupName": "4A (2026)",
+    "numberOfStudents": 30,
+    "staffMessageGroupRoleName": "Form Teacher",
+    "isDeleted": false,
+    "createdAt": "2026-01-15T08:30:00.000Z",
+    "updatedAt": "2026-03-20T14:45:00.000Z"
+  },
+  {
+    "staffMessageGroupId": 2,
+    "groupId": 2001,
+    "groupType": "cca",
+    "groupName": "Boxing Club",
+    "numberOfStudents": 12,
+    "staffMessageGroupRoleName": "CCA Teacher",
+    "isDeleted": false,
+    "createdAt": "2026-02-01T09:00:00.000Z",
+    "updatedAt": "2026-03-18T11:20:00.000Z"
+  }
+]

--- a/server/internal/pg/fixtures/school_student_groups.json
+++ b/server/internal/pg/fixtures/school_student_groups.json
@@ -1,0 +1,84 @@
+{
+  "schoolId": 2001,
+  "acadYear": "2026",
+  "categories": [
+    { "type": "CLASS", "groups": ["class-101", "class-102"] },
+    { "type": "LEVEL", "groups": ["level-4"] },
+    { "type": "CCA", "groups": ["cca-boxing", "cca-choir"] }
+  ],
+  "groups": {
+    "class-101": {
+      "id": "class-101",
+      "type": "CLASS",
+      "label": "4A (2026)",
+      "description": "SECONDARY 4",
+      "students": [1, 2, 3, 4]
+    },
+    "class-102": {
+      "id": "class-102",
+      "type": "CLASS",
+      "label": "4B (2026)",
+      "description": "SECONDARY 4",
+      "students": []
+    },
+    "level-4": {
+      "id": "level-4",
+      "type": "LEVEL",
+      "label": "Secondary 4",
+      "students": [1, 2, 3, 4]
+    },
+    "cca-boxing": {
+      "id": "cca-boxing",
+      "type": "CCA",
+      "label": "Boxing",
+      "students": [1]
+    },
+    "cca-choir": {
+      "id": "cca-choir",
+      "type": "CCA",
+      "label": "Choir",
+      "students": [3]
+    }
+  },
+  "students": {
+    "1": {
+      "id": 1,
+      "name": "TAN XIAO MING",
+      "nric": "T0412345A",
+      "levelId": 4,
+      "classId": 101,
+      "index": "15"
+    },
+    "2": {
+      "id": 2,
+      "name": "LEE WEI LIANG",
+      "nric": "T0412346B",
+      "levelId": 4,
+      "classId": 101,
+      "index": "8"
+    },
+    "3": {
+      "id": 3,
+      "name": "CAROL CHEN HUI",
+      "nric": "T0412347C",
+      "levelId": 4,
+      "classId": 101,
+      "index": "3"
+    },
+    "4": {
+      "id": 4,
+      "name": "DAVID NG JUN WEI",
+      "nric": "T0412348D",
+      "levelId": 4,
+      "classId": 101,
+      "index": "5"
+    }
+  },
+  "levels": {
+    "4": { "id": 4, "label": "Secondary 4" }
+  },
+  "classes": {
+    "101": { "id": 101, "label": "4A (2026)", "description": "SECONDARY 4" },
+    "102": { "id": 102, "label": "4B (2026)", "description": "SECONDARY 4" }
+  }
+}

--- a/server/internal/pg/fixtures/web_notifications.json
+++ b/server/internal/pg/fixtures/web_notifications.json
@@ -1,0 +1,4 @@
+{
+  "hasActiveNotificationMessage": false,
+  "message": ""
+}

--- a/server/internal/pg/mock.go
+++ b/server/internal/pg/mock.go
@@ -27,11 +27,31 @@ var consentFormDetailByID = map[string]string{
 }
 
 func (h *Handler) registerMock(mux *http.ServeMux) {
-	// Session & config
+	registerMockSession(mux)
+	registerMockAnnouncements(mux)
+	registerMockConsentForms(mux)
+	registerMockPTM(mux)
+	registerMockGroups(mux)
+	registerMockSchool(mux)
+	registerMockMessageGroups(mux)
+	registerMockHQDownloads(mux)
+	registerMockAccount(mux)
+	registerMockHeyTalia(mux)
+	registerMockFiles(mux)
+	registerMockPlatform(mux)
+}
+
+// ─── Session & config ───────────────────────────────────────────────────────
+
+func registerMockSession(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/web/2/staff/session/current", serveFixture("fixtures/session_current.json"))
 	mux.HandleFunc("GET /api/configs", serveFixture("fixtures/configs.json"))
+}
 
-	// Announcements
+// ─── Announcements ──────────────────────────────────────────────────────────
+
+func registerMockAnnouncements(mux *http.ServeMux) {
+	// Reads
 	mux.HandleFunc("GET /api/web/2/staff/announcements", serveFixture("fixtures/announcements.json"))
 	mux.HandleFunc("GET /api/web/2/staff/announcements/shared", serveFixture("fixtures/announcements_shared.json"))
 	mux.HandleFunc("GET /api/web/2/staff/announcements/{postId}", func(w http.ResponseWriter, r *http.Request) {
@@ -42,8 +62,12 @@ func (h *Handler) registerMock(mux *http.ServeMux) {
 		}
 		serveFixture(path)(w, r)
 	})
+
+	// 3-segment GET dispatcher: drafts/{id} | prefilled/{id}.
+	// (PGW does not expose a standalone `/{postId}/readStatus`; read status is embedded in
+	// the detail response — see docs/audits/pg-backend-contract.md.)
 	mux.HandleFunc("GET /api/web/2/staff/announcements/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
-		switch first := r.PathValue("first"); first {
+		switch r.PathValue("first") {
 		case "drafts", "prefilled":
 			serveFixture("fixtures/announcement_draft.json")(w, r)
 		default:
@@ -51,7 +75,64 @@ func (h *Handler) registerMock(mux *http.ServeMux) {
 		}
 	})
 
-	// Consent forms
+	// 2-segment POSTs
+	mux.HandleFunc("POST /api/web/2/staff/announcements", jsonStub(http.StatusCreated, `{"postId":1041}`))
+	mux.HandleFunc("POST /api/web/2/staff/announcements/drafts", jsonStub(http.StatusCreated, `{"announcementDraftId":202}`))
+	mux.HandleFunc("POST /api/web/2/staff/announcements/duplicate", jsonStub(http.StatusCreated, `{"postId":1042}`))
+
+	// 3-segment POST dispatcher: drafts/schedule | drafts/duplicate | {id}/addStaffInCharge
+	mux.HandleFunc("POST /api/web/2/staff/announcements/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
+		first, second := r.PathValue("first"), r.PathValue("second")
+		switch {
+		case first == "drafts" && second == "schedule":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case first == "drafts" && second == "duplicate":
+			jsonStub(http.StatusCreated, `{"announcementDraftId":203}`)(w, r)
+		case second == "addStaffInCharge":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// 4-segment POST: drafts/{id}/cancelSchedule
+	mux.HandleFunc("POST /api/web/2/staff/announcements/drafts/{announcementDraftId}/cancelSchedule", jsonStub(http.StatusOK, `{}`))
+
+	// 3-segment PUT dispatcher: drafts/{id} | {id}/enquiryEmailAddress | {id}/removeAccess
+	mux.HandleFunc("PUT /api/web/2/staff/announcements/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
+		first, second := r.PathValue("first"), r.PathValue("second")
+		switch {
+		case first == "drafts":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case second == "enquiryEmailAddress", second == "removeAccess":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// 4-segment PUT dispatcher: drafts/schedule/{id} | drafts/{id}/rescheduleSchedule
+	mux.HandleFunc("PUT /api/web/2/staff/announcements/{a}/{b}/{c}", func(w http.ResponseWriter, r *http.Request) {
+		a, b, c := r.PathValue("a"), r.PathValue("b"), r.PathValue("c")
+		switch {
+		case a == "drafts" && b == "schedule":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case a == "drafts" && c == "rescheduleSchedule":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// Deletes
+	mux.HandleFunc("DELETE /api/web/2/staff/announcements/{postId}", noContent)
+	mux.HandleFunc("DELETE /api/web/2/staff/announcements/drafts/{announcementDraftId}", noContent)
+}
+
+// ─── Consent forms ──────────────────────────────────────────────────────────
+
+func registerMockConsentForms(mux *http.ServeMux) {
+	// Reads
 	mux.HandleFunc("GET /api/web/2/staff/consentForms", serveFixture("fixtures/consent_forms.json"))
 	mux.HandleFunc("GET /api/web/2/staff/consentForms/shared", serveFixture("fixtures/consent_forms.json"))
 	mux.HandleFunc("GET /api/web/2/staff/consentForms/drafts/{consentFormDraftId}", serveFixture("fixtures/consent_form_draft.json"))
@@ -64,92 +145,205 @@ func (h *Handler) registerMock(mux *http.ServeMux) {
 		serveFixture(path)(w, r)
 	})
 
-	// Meetings (PTM)
+	// 2-segment POSTs
+	mux.HandleFunc("POST /api/web/2/staff/consentForms", jsonStub(http.StatusCreated, `{"consentFormId":301}`))
+	mux.HandleFunc("POST /api/web/2/staff/consentForms/drafts", jsonStub(http.StatusCreated, `{"consentFormDraftId":401}`))
+	mux.HandleFunc("POST /api/web/2/staff/consentForms/duplicate", jsonStub(http.StatusCreated, `{"consentFormDraftId":402}`))
+
+	// 3-segment POST dispatcher: drafts/schedule | drafts/duplicate | {id}/addStaffInCharge
+	mux.HandleFunc("POST /api/web/2/staff/consentForms/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
+		first, second := r.PathValue("first"), r.PathValue("second")
+		switch {
+		case first == "drafts" && second == "schedule":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case first == "drafts" && second == "duplicate":
+			jsonStub(http.StatusCreated, `{"consentFormDraftId":403}`)(w, r)
+		case second == "addStaffInCharge":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// 4-segment POST: drafts/{id}/cancelSchedule
+	mux.HandleFunc("POST /api/web/2/staff/consentForms/drafts/{consentFormDraftId}/cancelSchedule", jsonStub(http.StatusOK, `{}`))
+
+	// 3-segment PUT dispatcher: drafts/{id} | {id}/updateDueDate | {id}/updateEnquiryEmail | {id}/removeAccess
+	mux.HandleFunc("PUT /api/web/2/staff/consentForms/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
+		first, second := r.PathValue("first"), r.PathValue("second")
+		switch {
+		case first == "drafts":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case second == "updateDueDate", second == "updateEnquiryEmail", second == "removeAccess":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// 4-segment PUT dispatcher: drafts/schedule/{id} | drafts/{id}/rescheduleSchedule
+	mux.HandleFunc("PUT /api/web/2/staff/consentForms/{a}/{b}/{c}", func(w http.ResponseWriter, r *http.Request) {
+		a, b, c := r.PathValue("a"), r.PathValue("b"), r.PathValue("c")
+		switch {
+		case a == "drafts" && b == "schedule":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case a == "drafts" && c == "rescheduleSchedule":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// 5-segment PUT: {id}/student/{studentId}/reply
+	mux.HandleFunc("PUT /api/web/2/staff/consentForms/{consentFormId}/student/{studentId}/reply", jsonStub(http.StatusOK, `{}`))
+
+	// Deletes
+	mux.HandleFunc("DELETE /api/web/2/staff/consentForms/{consentFormId}", noContent)
+	mux.HandleFunc("DELETE /api/web/2/staff/consentForms/drafts/{consentFormDraftId}", noContent)
+}
+
+// ─── Meetings (PTM) ─────────────────────────────────────────────────────────
+
+func registerMockPTM(mux *http.ServeMux) {
+	// Top-level GETs
 	mux.HandleFunc("GET /api/web/2/staff/ptm", serveFixture("fixtures/meetings.json"))
 	mux.HandleFunc("GET /api/web/2/staff/ptm/serverdatetime", serveFixture("fixtures/ptm_serverdatetime.json"))
-	mux.HandleFunc("GET /api/web/2/staff/ptm/timeslots/{eventId}", serveFixture("fixtures/meeting_timeslots.json"))
-	mux.HandleFunc("GET /api/web/2/staff/ptm/bookings/{eventId}", serveFixture("fixtures/meeting_bookings.json"))
 	mux.HandleFunc("GET /api/web/2/staff/ptm/{eventId}", serveFixture("fixtures/meeting_detail.json"))
 
-	// Groups
+	// 3-segment GET dispatcher: {literal}/{id} routes conflict with {eventId}/targetStudents
+	// (e.g. `timeslots/targetStudents` would match both patterns). Use explicit dispatch.
+	mux.HandleFunc("GET /api/web/2/staff/ptm/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
+		switch r.PathValue("first") {
+		case "timeslots":
+			serveFixture("fixtures/meeting_timeslots.json")(w, r)
+		case "bookings":
+			serveFixture("fixtures/meeting_bookings.json")(w, r)
+		case "schedule":
+			serveFixture("fixtures/meeting_schedule.json")(w, r)
+		case "booking":
+			serveFixture("fixtures/meeting_booking.json")(w, r)
+		default:
+			if r.PathValue("second") == "targetStudents" {
+				serveFixture("fixtures/meeting_target_students.json")(w, r)
+				return
+			}
+			http.NotFound(w, r)
+		}
+	})
+
+	// Writes
+	mux.HandleFunc("POST /api/web/2/staff/ptm", jsonStub(http.StatusCreated, `{"eventId":1002}`))
+	mux.HandleFunc("DELETE /api/web/2/staff/ptm/{eventId}", noContent)
+
+	// 3-segment POST dispatcher: booking/{action} | {eventId}/addStaffInCharge
+	mux.HandleFunc("POST /api/web/2/staff/ptm/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
+		first, second := r.PathValue("first"), r.PathValue("second")
+		switch {
+		case first == "booking" && (second == "block" || second == "unblock" || second == "add" || second == "change" || second == "remove"):
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		case first == "booking" && second == "validate":
+			jsonStub(http.StatusOK, `{"valid":true}`)(w, r)
+		case second == "addStaffInCharge":
+			jsonStub(http.StatusOK, `{}`)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	// 3-segment PUT: {eventId}/removeAccess | {eventId}/updateEnquiryEmail
+	mux.HandleFunc("PUT /api/web/2/staff/ptm/{eventId}/removeAccess", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("PUT /api/web/2/staff/ptm/{eventId}/updateEnquiryEmail", jsonStub(http.StatusOK, `{}`))
+}
+
+// ─── Groups ─────────────────────────────────────────────────────────────────
+
+func registerMockGroups(mux *http.ServeMux) {
+	// Reads
 	mux.HandleFunc("GET /api/web/2/staff/groups/assigned", serveFixture("fixtures/groups_assigned.json"))
 	mux.HandleFunc("GET /api/web/2/staff/groups/custom", serveFixture("fixtures/groups_custom.json"))
 	mux.HandleFunc("GET /api/web/2/staff/groups/custom/{customGroupId}", serveFixture("fixtures/group_custom_detail.json"))
 	mux.HandleFunc("GET /api/web/2/staff/groups/classes/{classId}", serveFixture("fixtures/class_detail.json"))
 	mux.HandleFunc("GET /api/web/2/staff/groups/cca/students/{ccaId}", serveFixture("fixtures/cca_students.json"))
 
-	// School data
-	mux.HandleFunc("GET /api/web/2/staff/school/staff", serveFixture("fixtures/school_staff.json"))
-	mux.HandleFunc("GET /api/web/2/staff/school/students", serveFixture("fixtures/school_students.json"))
-	mux.HandleFunc("GET /api/web/2/staff/school/groups", serveFixture("fixtures/school_groups.json"))
-
-	// Account & notification prefs
-	mux.HandleFunc("GET /api/web/2/staff/users/me", serveFixture("fixtures/users_me.json"))
-	mux.HandleFunc("GET /api/web/2/staff/notificationPreference", serveFixture("fixtures/notification_preferences.json"))
-
-	// ── Write stubs (stateless — return realistic status codes + shapes) ──
-
-	// Announcements — write
-	mux.HandleFunc("POST /api/web/2/staff/announcements", jsonStub(http.StatusCreated, `{"postId":1041}`))
-	mux.HandleFunc("POST /api/web/2/staff/announcements/drafts", jsonStub(http.StatusCreated, `{"announcementDraftId":202}`))
-	mux.HandleFunc("POST /api/web/2/staff/announcements/drafts/schedule", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("POST /api/web/2/staff/announcements/duplicate", jsonStub(http.StatusCreated, `{"postId":1042}`))
-	mux.HandleFunc("PUT /api/web/2/staff/announcements/drafts/{announcementDraftId}", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("DELETE /api/web/2/staff/announcements/{postId}", noContent)
-	mux.HandleFunc("DELETE /api/web/2/staff/announcements/drafts/{announcementDraftId}", noContent)
-
-	// Consent forms — write
-	mux.HandleFunc("POST /api/web/2/staff/consentForms", jsonStub(http.StatusCreated, `{"consentFormId":301}`))
-	mux.HandleFunc("POST /api/web/2/staff/consentForms/drafts", jsonStub(http.StatusCreated, `{"consentFormDraftId":401}`))
-	mux.HandleFunc("POST /api/web/2/staff/consentForms/drafts/schedule", jsonStub(http.StatusOK, `{}`))
-	// Dispatched: Go ServeMux rejects overlapping wildcards
-	// (`drafts/{id}` vs `{id}/updateDueDate` both match
-	// `/consentForms/drafts/updateDueDate`), so match `{first}/{second}` once
-	// and route by which segment we got — positive match, no catch-all 200.
-	mux.HandleFunc("PUT /api/web/2/staff/consentForms/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
-		first := r.PathValue("first")
-		second := r.PathValue("second")
-		if first == "drafts" || second == "updateDueDate" {
-			jsonStub(http.StatusOK, `{}`)(w, r)
-			return
-		}
-		http.NotFound(w, r)
-	})
-	mux.HandleFunc("DELETE /api/web/2/staff/consentForms/{consentFormId}", noContent)
-	mux.HandleFunc("DELETE /api/web/2/staff/consentForms/drafts/{consentFormDraftId}", noContent)
-
-	// Meetings (PTM) — write
-	mux.HandleFunc("POST /api/web/2/staff/ptm", jsonStub(http.StatusCreated, `{"eventId":1002}`))
-	mux.HandleFunc("DELETE /api/web/2/staff/ptm/{eventId}", noContent)
-	mux.HandleFunc("POST /api/web/2/staff/ptm/booking/block", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("POST /api/web/2/staff/ptm/booking/unblock", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("POST /api/web/2/staff/ptm/booking/add", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("POST /api/web/2/staff/ptm/booking/change", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("POST /api/web/2/staff/ptm/booking/remove", jsonStub(http.StatusOK, `{}`))
-
-	// Groups — write
+	// Writes
 	mux.HandleFunc("POST /api/web/2/staff/groups/custom", jsonStub(http.StatusCreated, `{"customGroupId":6}`))
 	mux.HandleFunc("POST /api/web/2/staff/groups/custom/validateStudents", jsonStub(http.StatusOK, `{"valid":true}`))
+	mux.HandleFunc("POST /api/web/2/staff/groups/custom/validateStudents/results", jsonStub(http.StatusOK, `{"valid":true,"errors":[]}`))
 	mux.HandleFunc("POST /api/web/2/staff/groups/student/count", jsonStub(http.StatusOK, `{"count":30}`))
 	mux.HandleFunc("PUT /api/web/2/staff/groups/custom/{customGroupId}", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("PUT /api/web/2/staff/groups/custom/{customGroupId}/share", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("PUT /api/web/2/staff/groups/custom/{customGroupId}/removeAccess", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("DELETE /api/web/2/staff/groups/custom/{customGroupId}", noContent)
+}
 
-	// School data — write
-	mux.HandleFunc("POST /api/web/2/staff/school/travelDeclaration", jsonStub(http.StatusOK, `{}`))
+// ─── School data ────────────────────────────────────────────────────────────
+
+func registerMockSchool(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/web/2/staff/school/staff", serveFixture("fixtures/school_staff.json"))
+	mux.HandleFunc("GET /api/web/2/staff/school/students", serveFixture("fixtures/school_students.json"))
+	mux.HandleFunc("GET /api/web/2/staff/school/groups", serveFixture("fixtures/school_groups.json"))
+	mux.HandleFunc("GET /api/web/2/staff/school/studentGroups", serveFixture("fixtures/school_student_groups.json"))
 	mux.HandleFunc("GET /api/web/2/staff/school/students/retrieveReport", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("POST /api/web/2/staff/school/travelDeclaration", jsonStub(http.StatusOK, `{}`))
+}
 
-	// Account — write
+// ─── Message groups ─────────────────────────────────────────────────────────
+
+func registerMockMessageGroups(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/web/2/staff/messageGroups", serveFixture("fixtures/message_groups.json"))
+	mux.HandleFunc("POST /api/web/2/staff/messageGroups", jsonStub(http.StatusCreated, `{"staffMessageGroupId":10}`))
+	mux.HandleFunc("DELETE /api/web/2/staff/messageGroups/{staffMessageGroupId}", noContent)
+}
+
+// ─── HQ announcement downloads ──────────────────────────────────────────────
+
+func registerMockHQDownloads(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/web/2/staff/hq-announcement-downloads/{code}", jsonStub(http.StatusOK, `{}`))
+}
+
+// ─── Account & notification prefs ───────────────────────────────────────────
+
+func registerMockAccount(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/web/2/staff/users/me", serveFixture("fixtures/users_me.json"))
+	mux.HandleFunc("GET /api/web/2/staff/notificationPreference", serveFixture("fixtures/notification_preferences.json"))
+	mux.HandleFunc("PUT /api/web/2/staff/notificationPreference", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("PUT /api/web/2/staff/{staffId}/updateDisplayEmail", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("PUT /api/web/2/staff/{staffId}/updateDisplayName", jsonStub(http.StatusOK, `{}`))
-	mux.HandleFunc("PUT /api/web/2/staff/notificationPreference", jsonStub(http.StatusOK, `{}`))
+}
 
-	// Files
+// ─── HeyTalia (AI chat) ─────────────────────────────────────────────────────
+
+func registerMockHeyTalia(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/chat", jsonStub(http.StatusOK, `{"response":"mocked — HeyTalia disabled in experiment."}`))
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/feedback", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/email", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("GET /api/web/2/staff/heytalia/email/recipients/history", serveFixture("fixtures/heytalia_email_recipients_history.json"))
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/upload-file", jsonStub(http.StatusOK, `{"fileId":"mock-file-1"}`))
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/metrics", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("GET /api/web/2/staff/heytalia/conversations", serveFixture("fixtures/heytalia_conversations.json"))
+	mux.HandleFunc("GET /api/web/2/staff/heytalia/conversations/{conversationId}", serveFixture("fixtures/heytalia_conversation.json"))
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/conversations/delete", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("POST /api/web/2/staff/heytalia/conversations/system-message", jsonStub(http.StatusOK, `{}`))
+}
+
+// ─── Files ──────────────────────────────────────────────────────────────────
+
+func registerMockFiles(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/files/2/preUploadValidation", jsonStub(http.StatusOK, `{"valid":true}`))
 	mux.HandleFunc("GET /api/files/2/postUploadVerification", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("GET /api/files/2/handleDownloadAttachment", jsonStub(http.StatusOK, `{}`))
+	mux.HandleFunc("GET /api/files/2/scanResult", jsonStub(http.StatusOK, `{"status":"clean"}`))
+	mux.HandleFunc("GET /api/files/2/handleResizeImageNotFound", noContent)
 }
+
+// ─── Platform (feature flags, web notifications) ────────────────────────────
+
+func registerMockPlatform(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/feature/2/flags", serveFixture("fixtures/feature_flags.json"))
+	mux.HandleFunc("GET /api/web/2/webNotification", serveFixture("fixtures/web_notifications.json"))
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
 func serveFixture(path string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -6,10 +6,6 @@ import type {
 } from '~/data/mock-pg-announcements';
 import { notify } from '~/lib/notify';
 
-import detailFixture from '../../server/internal/pg/fixtures/announcement_detail.json';
-import announcementsFixture from '../../server/internal/pg/fixtures/announcements.json';
-import sharedFixture from '../../server/internal/pg/fixtures/announcements_shared.json';
-import consentFormsFixture from '../../server/internal/pg/fixtures/consent_forms.json';
 import { PGError, PGNotFoundError, PGSessionExpiredError, PGValidationError } from './errors';
 import {
   mapAnnouncementDetail,
@@ -153,21 +149,6 @@ async function deleteApi(path: string): Promise<void> {
   if (!res.ok) await handleErrorResponse(res);
 }
 
-/** Returns fallback on network errors; re-throws HTTP and abort errors. */
-async function fetchApiSafe<T>(path: string, fallback: T): Promise<T> {
-  try {
-    return await fetchApi<T>(path);
-  } catch (err) {
-    // Re-throw AbortError so React Router's navigation cancellation works
-    if (err instanceof DOMException && err.name === 'AbortError') throw err;
-    // Re-throw HTTP errors so they surface to error boundaries / containers
-    if (err instanceof PGError) throw err;
-    // Only fall back for network-level failures (server unreachable)
-    console.warn(`[PG API] Network error fetching ${path}, using fixture fallback`);
-    return fallback;
-  }
-}
-
 // ═══════════════════════════════════════════════════════════════════════════
 // CONFIGS (feature flags)
 // ═══════════════════════════════════════════════════════════════════════════
@@ -213,26 +194,16 @@ export function getConfigs(): Promise<PGApiConfig> {
 // ─── Read ───────────────────────────────────────────────────────────────────
 
 function fetchAnnouncements() {
-  return fetchApiSafe<PGApiAnnouncementList>(
-    '/announcements',
-    announcementsFixture as unknown as PGApiAnnouncementList,
-  );
+  return fetchApi<PGApiAnnouncementList>('/announcements');
 }
 
 function fetchSharedAnnouncements() {
-  return fetchApiSafe<PGApiAnnouncementList>(
-    '/announcements/shared',
-    sharedFixture as unknown as PGApiAnnouncementList,
-  );
+  return fetchApi<PGApiAnnouncementList>('/announcements/shared');
 }
 
 async function fetchAnnouncementDetail(postId: AnnouncementId): Promise<PGApiAnnouncementDetail> {
   // pgw-web wraps single-detail responses as `body: [<detail>]`; unwrap the array.
-  // Fixture mirrors that shape so mock mode stays in lockstep.
-  const arr = await fetchApiSafe<PGApiAnnouncementDetail[]>(
-    `/announcements/${postId}`,
-    detailFixture as unknown as PGApiAnnouncementDetail[],
-  );
+  const arr = await fetchApi<PGApiAnnouncementDetail[]>(`/announcements/${postId}`);
   return arr[0];
 }
 
@@ -296,17 +267,11 @@ export async function loadPostDetail(postId: AnnouncementId): Promise<PGAnnounce
 // ─── Read ───────────────────────────────────────────────────────────────────
 
 function fetchConsentForms() {
-  return fetchApiSafe<PGApiConsentFormList>(
-    '/consentForms',
-    consentFormsFixture as unknown as PGApiConsentFormList,
-  );
+  return fetchApi<PGApiConsentFormList>('/consentForms');
 }
 
 function fetchSharedConsentForms() {
-  return fetchApiSafe<PGApiConsentFormList>(
-    '/consentForms/shared',
-    consentFormsFixture as unknown as PGApiConsentFormList,
-  );
+  return fetchApi<PGApiConsentFormList>('/consentForms/shared');
 }
 
 export function fetchConsentFormDetail(formId: ConsentFormId) {


### PR DESCRIPTION
## Summary

Goal: let designers run the FE standalone via `pnpm dev` + `go run ./server/cmd/tw`, while owner mode (`TW_PG_MOCK=false`) still proxies real PGW. Decision from Slack: Go BFF is the canonical mock source — no FE-side toggle, single env var flip.

- **Full staff-web mock parity.** Cross-referenced `/Users/shin/Desktop/projects/pgw-web` (108 PGW staff-web endpoints) against `mock.go` (~42 handlers). Rewrote `mock.go` into domain-split `registerMockX(mux)` helpers with explicit `{first}/{second}` dispatchers where Go 1.22+ ServeMux conflicts would otherwise panic. Added ~25 new handlers + 10 new fixtures (PTM schedule/booking/targetStudents, school studentGroups, messageGroups, HeyTalia conversations/email/recipients, feature flags, web notifications) and forward-looking writes (reschedule/cancel/addStaffInCharge/removeAccess across announcements/forms/PTM).
- **OTPaaS validation gated by `!PG.Mock`.** Designers can start the BFF with empty `TW_OTPAAS_*` — the creds are only required in owner mode. Verified both paths: mock mode starts cleanly from an empty env; real-PGW mode refuses with `TW_OTPAAS_{ID,NAMESPACE,SECRET} is required`.
- **Dropped FE `fetchApiSafe` soft-fallback.** Removed the four `server/internal/pg/fixtures/*.json` ESM imports and the network-error fixture fallback in `web/api/client.ts`. With the Go BFF as the sole mock source, silent fallback was masking misconfigurations.
- **`CLAUDE.md` "Running locally" section.** Documents the two modes with an inline dotenv template (all env files are gitignored by policy, including `.env.example`). Also fixed stale `./cmd/tw` paths to `./server/cmd/tw`.

One scope change from the plan: `GET /announcements/:postId/readStatus` was dropped — PGW doesn't expose it standalone (read status is embedded in the detail response per `docs/audits/pg-backend-contract.md`). Rebased cleanly on top of Reza's 55 commits; kept Reza's map-based detail dispatcher for `GET /announcements/{postId}` and `GET /consentForms/{consentFormId}` over my flat `serveFixture` version.

## Test plan

- [ ] `go build ./... && go test ./...` green
- [ ] `pnpm build && pnpm lint` green
- [ ] Copy template from `CLAUDE.md § Running locally` into a root dotenv file with `TW_PG_MOCK=true` and empty OTPaaS fields; `go run ./server/cmd/tw` starts without validation errors
- [ ] From an empty env + `TW_PG_MOCK=false`, `go run ./server/cmd/tw` refuses to start with OTPaaS missing-field errors
- [ ] With both servers running in mock mode: Posts list + detail (1036/1037/1038/1039 each render with their expected status), create/schedule/duplicate/delete round-trip, consent-form detail for 1038/1039/1040/1041 render; unknown IDs return 404
- [ ] `GET /api/web/2/staff/school/studentGroups`, `GET /api/web/2/staff/ptm/schedule/1001`, `GET /api/web/2/staff/ptm/1001/targetStudents`, `GET /api/feature/2/flags`, `GET /api/web/2/webNotification` each return the new fixtures
- [ ] Regression: existing 3-segment PTM GETs (`/ptm/timeslots/{id}`, `/ptm/bookings/{id}`) still route correctly via the new dispatcher
- [ ] Regression: existing `PUT /consentForms/drafts/{id}` and `PUT /consentForms/{id}/updateDueDate` continue to return 200