### PR TITLE
feat(web): PGTW-11 required-field enforcement + error mapping

### DIFF
--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -312,10 +312,14 @@ function fetchSharedConsentForms() {
   return fetchApi<PGApiConsentFormList>('/consentForms/shared');
 }
 
-export function fetchConsentFormDetail(formId: ConsentFormId) {
-  // pgw strips the `cf_` prefix when addressing the detail endpoint.
+export async function fetchConsentFormDetail(
+  formId: ConsentFormId,
+): Promise<PGApiConsentFormDetail> {
+  // pgw strips the `cf_` prefix when addressing the detail endpoint. The
+  // response shape is `body: [<detail>]` (single-element array) — unwrap.
   const numericId = formId.slice(3);
-  return fetchApi<PGApiConsentFormDetail>(`/consentForms/${numericId}`);
+  const arr = await fetchApi<PGApiConsentFormDetail[]>(`/consentForms/${numericId}`);
+  return arr[0];
 }
 
 // ─── Write ──────────────────────────────────────────────────────────────────

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -330,11 +330,15 @@ export function createConsentForm(payload: PGApiCreateConsentFormPayload) {
 }
 
 /** Save a consent form as draft (optionally with a scheduled send-at). */
-export function createConsentFormDraft(payload: PGApiCreateConsentFormDraftPayload) {
+export function createConsentFormDraft(
+  payload: PGApiCreateConsentFormDraftPayload,
+  options: { signal?: AbortSignal } = {},
+) {
   return mutateApi<{ consentFormDraftId: number }>(
     'POST',
     '/consentForms/drafts',
     toPGConsentFormDraftPayload(payload),
+    options,
   );
 }
 
@@ -342,11 +346,13 @@ export function createConsentFormDraft(payload: PGApiCreateConsentFormDraftPaylo
 export function updateConsentFormDraft(
   draftId: number,
   payload: PGApiCreateConsentFormDraftPayload,
+  options: { signal?: AbortSignal } = {},
 ) {
   return mutateApi<void>(
     'PUT',
     `/consentForms/drafts/${draftId}`,
     toPGConsentFormDraftPayload(payload),
+    options,
   );
 }
 

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -409,7 +409,26 @@ interface PGWritePayload {
   shortcutLink?: string[];
 }
 
-interface PGConsentFormWritePayload extends PGWritePayload {
+/** Shape for `POST /consentForms` (publish). PGW uses ISO strings for event
+ *  dates and `inAppShortcutLink` here — different from the draft shape. See
+ *  `pgw-web/src/server/apiv2/staff/controllers/consent-form/create.staff.consent-form.controller.ts`. */
+interface PGConsentFormPublishPayload extends Omit<PGWritePayload, 'shortcutLink'> {
+  responseType: 'ACKNOWLEDGEMENT' | 'YES_NO';
+  consentByDate: string;
+  addReminderType: PGApiReminderType;
+  reminderDate?: string | null;
+  startDateTime?: string | null;
+  endDateTime?: string | null;
+  venue?: string | null;
+  inAppShortcutLink?: string[];
+  customQuestions?: { questionText: string; questionType: 'TEXT' | 'MCQ'; options?: string[] }[];
+}
+
+/** Shape for `POST /consentForms/drafts` and PUT update. PGW uses
+ *  `{ date, time }` objects for event dates and `shortcutLink` is ignored via
+ *  `allowUnknown: true`. See
+ *  `pgw-web/src/server/modules/consent-form/consent-form-draft.service.ts#L326`. */
+interface PGConsentFormDraftWritePayload extends PGWritePayload {
   responseType: 'ACKNOWLEDGEMENT' | 'YES_NO';
   consentByDate: string;
   addReminderType: PGApiReminderType;
@@ -448,13 +467,47 @@ export function toPGCreatePayload(
   } satisfies PGWritePayload;
 }
 
+function dateTimeToIso(dt: { date: string; time: string } | null | undefined): string | null {
+  if (!dt) return null;
+  return `${dt.date}T${dt.time}:00+08:00`;
+}
+
+function mapCustomQuestions(qs: PGApiCreateConsentFormPayload['customQuestions']) {
+  return qs?.map((q) => ({
+    questionText: q.text,
+    questionType: q.type === 'MCQ' ? ('MCQ' as const) : ('TEXT' as const),
+    ...(q.options && { options: q.options }),
+  }));
+}
+
 export function toPGConsentFormCreatePayload(
   p: PGApiCreateConsentFormPayload,
-  opts: { allowPartial?: boolean } = {},
-): PGConsentFormWritePayload {
-  if (!p.enquiryEmailAddress && !opts.allowPartial) {
+): PGConsentFormPublishPayload {
+  if (!p.enquiryEmailAddress) {
     throw new Error('enquiryEmailAddress is required');
   }
+  return {
+    title: p.title,
+    content: p.richTextContent,
+    enquiryEmailAddress: p.enquiryEmailAddress,
+    targets: buildTargets(p.recipients),
+    staffInCharge: p.staffOwnerIds,
+    webLinkList: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
+    inAppShortcutLink: p.shortcutLink,
+    responseType: p.responseType,
+    consentByDate: p.consentByDate,
+    addReminderType: p.addReminderType,
+    reminderDate: p.reminderDate,
+    startDateTime: dateTimeToIso(p.eventStartDate),
+    endDateTime: dateTimeToIso(p.eventEndDate),
+    venue: p.venue,
+    customQuestions: mapCustomQuestions(p.customQuestions),
+  } satisfies PGConsentFormPublishPayload;
+}
+
+export function toPGConsentFormDraftPayload(
+  p: PGApiCreateConsentFormDraftPayload,
+): PGConsentFormDraftWritePayload {
   return {
     title: p.title,
     content: p.richTextContent,
@@ -470,21 +523,9 @@ export function toPGConsentFormCreatePayload(
     eventStartDate: p.eventStartDate,
     eventEndDate: p.eventEndDate,
     venue: p.venue,
-    customQuestions: p.customQuestions?.map((q) => ({
-      questionText: q.text,
-      questionType: q.type === 'MCQ' ? 'MCQ' : 'TEXT',
-      ...(q.options && { options: q.options }),
-    })),
-  } satisfies PGConsentFormWritePayload;
-}
-
-export function toPGConsentFormDraftPayload(
-  p: PGApiCreateConsentFormDraftPayload,
-): PGConsentFormWritePayload {
-  return {
-    ...toPGConsentFormCreatePayload(p, { allowPartial: true }),
+    customQuestions: mapCustomQuestions(p.customQuestions),
     scheduledSendAt: p.scheduledSendAt,
-  } satisfies PGConsentFormWritePayload;
+  } satisfies PGConsentFormDraftWritePayload;
 }
 
 // ─── Post-creation dispatcher ───────────────────────────────────────────────

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -641,14 +641,19 @@ export function buildConsentFormPayload(
     );
   }
   const responseType = FE_TO_PG_CONSENT_RESPONSE_TYPE[state.responseType];
+  // PGW's consent-form contract types these fields as always-string (see
+  // `pgw-web/src/app/pages/ConsentForms/ConsentForm.types.ts`). Sending `null`
+  // produces `"reminderDate" must be a string` at runtime even when the field
+  // is logically absent. Use empty strings for the "no value" case.
   const reminderDate =
-    state.reminder.type === 'NONE' ? null : localDateToSgtIso(state.reminder.date);
-  const eventStartDate = state.event ? localDateTimeToSgtIso(state.event.start) : null;
-  const eventEndDate = state.event ? localDateTimeToSgtIso(state.event.end) : null;
+    state.reminder.type === 'NONE' ? '' : (localDateToSgtIso(state.reminder.date) ?? '');
+  const eventStartDate = state.event ? (localDateTimeToSgtIso(state.event.start) ?? '') : '';
+  const eventEndDate = state.event ? (localDateTimeToSgtIso(state.event.end) ?? '') : '';
+  const consentByDate = state.dueDate.trim() ? (localDateToSgtIso(state.dueDate) ?? '') : '';
   // Venue is tracked both on `state.venue` (independently editable) and as a
   // child of `state.event.venue` when PGEvent is populated. Prefer the
   // free-standing field so a user can type a venue before setting dates.
-  const venue = state.venue?.trim() ? state.venue.trim() : (state.event?.venue ?? null);
+  const venue = state.venue?.trim() ? state.venue.trim() : (state.event?.venue ?? '');
   const customQuestions = state.questions.length
     ? state.questions.map((q) =>
         q.type === 'mcq'
@@ -670,7 +675,7 @@ export function buildConsentFormPayload(
     richTextContent: JSON.stringify(doc),
     enquiryEmailAddress: state.enquiryEmail,
     responseType,
-    consentByDate: localDateToSgtIso(state.dueDate),
+    consentByDate,
     addReminderType: state.reminder.type,
     reminderDate,
     eventStartDate,

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -27,7 +27,6 @@ import type {
   PGApiAnnouncementSummary,
   PGApiConsentFormDetail,
   PGApiConsentFormStatus,
-  PGApiConsentFormStudent,
   PGApiConsentFormSummary,
   PGApiCreateAnnouncementPayload,
   PGApiCreateConsentFormDraftPayload,
@@ -35,8 +34,9 @@ import type {
   PGApiReminderType,
 } from './types';
 
-/** Shared recipient fields both detail mappers carry verbatim. */
-function buildRecipientBase(s: PGApiAnnouncementStudent | PGApiConsentFormStudent) {
+/** Shared recipient fields for the announcement detail mapper. Consent forms
+ *  use a nested `student` object and are mapped inline in `mapConsentFormDetail`. */
+function buildRecipientBase(s: PGApiAnnouncementStudent) {
   return {
     studentId: String(s.studentId),
     studentName: s.studentName,
@@ -269,15 +269,29 @@ function mapReminder(type: PGApiReminderType, date: string | null): ReminderConf
  * shape the TW UI consumes.
  */
 export function mapConsentFormDetail(detail: PGApiConsentFormDetail): PGConsentFormPost {
-  const status = toPGConsentFormStatus(detail.status);
-  const totalCount = detail.students.length;
-  const yesCount = detail.students.filter((s) => s.response === 'YES').length;
-  const noCount = detail.students.filter((s) => s.response === 'NO').length;
+  // Detail endpoint doesn't carry `status`; derive from posting/due dates.
+  // - postedDate set + consentByDate in future → OPEN
+  // - postedDate set + consentByDate passed → CLOSED
+  // - no postedDate → DRAFT (shouldn't reach here, but safe fallback)
+  const now = Date.now();
+  const dueAt = detail.consentByDate ? Date.parse(detail.consentByDate) : NaN;
+  const status: PGConsentFormStatus = detail.postedDate
+    ? Number.isFinite(dueAt) && dueAt < now
+      ? 'closed'
+      : 'open'
+    : 'draft';
 
-  const recipients: PGConsentFormRecipient[] = detail.students.map((s) => ({
-    ...buildRecipientBase(s),
-    response: s.response,
-    respondedAt: s.respondedAt,
+  const recipientRows = detail.consentFormRecipients ?? [];
+  const totalCount = recipientRows.length;
+  const yesCount = recipientRows.filter((r) => r.reply === 'YES').length;
+  const noCount = recipientRows.filter((r) => r.reply === 'NO').length;
+
+  const recipients: PGConsentFormRecipient[] = recipientRows.map((r) => ({
+    studentId: String(r.student.studentId),
+    studentName: r.student.studentName,
+    classLabel: r.student.className,
+    response: r.reply,
+    respondedAt: r.replyDate,
   }));
 
   const richTextContent =
@@ -294,22 +308,26 @@ export function mapConsentFormDetail(detail: PGApiConsentFormDetail): PGConsentF
         }
       : undefined;
 
-  const questions = detail.customQuestions.map<PGConsentFormPost['questions'][number]>((q) =>
-    q.type === 'MCQ'
-      ? {
-          id: String(q.questionId),
-          text: q.text,
-          type: 'mcq',
-          options: (q.options && q.options.length > 0 ? q.options : ['']) as [string, ...string[]],
-        }
-      : {
-          id: String(q.questionId),
-          text: q.text,
-          type: 'free-text',
-        },
+  const questions = (detail.customQuestions ?? []).map<PGConsentFormPost['questions'][number]>(
+    (q) =>
+      q.type === 'MCQ'
+        ? {
+            id: String(q.questionId),
+            text: q.text,
+            type: 'mcq',
+            options: (q.options && q.options.length > 0 ? q.options : ['']) as [
+              string,
+              ...string[],
+            ],
+          }
+        : {
+            id: String(q.questionId),
+            text: q.text,
+            type: 'free-text',
+          },
   );
 
-  const history: PGConsentFormHistoryEntry[] = detail.consentFormHistory;
+  const history: PGConsentFormHistoryEntry[] = detail.consentFormHistory ?? [];
 
   return {
     kind: 'form',
@@ -332,7 +350,7 @@ export function mapConsentFormDetail(detail: PGApiConsentFormDetail): PGConsentF
     postedAt: detail.postedDate ?? undefined,
     staffInCharge: detail.staffOwners[0]?.staffName,
     staffOwnerIds: detail.staffOwners.map((s) => s.staffID),
-    targets: (detail.target ?? [])
+    targets: (detail.targets ?? [])
       .map<PGAnnouncementTarget | null>((t) => {
         const type = toPGTargetType(t.targetType);
         return type ? { type, id: t.targetId, label: t.targetName } : null;
@@ -344,7 +362,7 @@ export function mapConsentFormDetail(detail: PGApiConsentFormDetail): PGConsentF
     reminder: mapReminder(detail.addReminderType, detail.reminderDate),
     event,
     history,
-    websiteLinks: detail.websiteLinks.map((l) => ({ url: l.url, title: l.title })),
+    websiteLinks: (detail.webLinkList ?? []).map((l) => ({ url: l.url, title: l.title })),
   };
 }
 

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -630,13 +630,12 @@ export function buildConsentFormPayload(
   state: BuildPostPayloadInput,
 ): PGApiCreateConsentFormPayload {
   const doc = state.descriptionDoc ?? textToTiptapDoc(state.description);
-  if (state.responseType === 'view-only') {
-    // Consent forms never carry `view-only`; the container's type-picker
-    // seeds `acknowledge` when the user picks post-with-response. Guard here
-    // defensively so a bad state change surfaces a clear error rather than
-    // an opaque 400 from pgw.
+  if (state.responseType !== 'acknowledge' && state.responseType !== 'yes-no') {
+    // Consent forms sent to PGW only support acknowledge/yes-no. `view-only`
+    // and `custom` are front-end-only values; guard here defensively so a bad
+    // state change surfaces a clear error rather than an opaque 400 from pgw.
     throw new Error(
-      'Consent forms require responseType of `acknowledge` or `yes-no`, got `view-only`.',
+      `Consent forms require responseType of \`acknowledge\` or \`yes-no\`, got \`${state.responseType}\`.`,
     );
   }
   const responseType = FE_TO_PG_CONSENT_RESPONSE_TYPE[state.responseType];

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -414,8 +414,8 @@ interface PGConsentFormWritePayload extends PGWritePayload {
   consentByDate: string;
   addReminderType: PGApiReminderType;
   reminderDate?: string | null;
-  eventStartDate?: string | null;
-  eventEndDate?: string | null;
+  eventStartDate?: { date: string; time: string } | null;
+  eventEndDate?: { date: string; time: string } | null;
   venue?: string | null;
   customQuestions?: { questionText: string; questionType: 'TEXT' | 'MCQ'; options?: string[] }[];
   scheduledSendAt?: string | null;
@@ -505,13 +505,19 @@ export function toPGConsentFormDraftPayload(
  * browser typing "09:00" will have it stamped as `09:00+08:00` — numerically
  * lossless on round-trip, but they should know they're picking SGT time.
  */
-function localDateTimeToSgtIso(localDateTime: string): string {
+/**
+ * Split a local `YYYY-MM-DDTHH:mm` datetime into PGW's expected
+ * `{ date: 'YYYY-MM-DD', time: 'HH:mm' }` shape for consent-form event fields.
+ * Returns `null` for an unparseable / empty input so callers can pass it
+ * straight into the wire payload.
+ */
+function splitLocalDateTime(localDateTime: string): { date: string; time: string } | null {
   const [datePart, timePart] = localDateTime.split('T');
-  if (!datePart || !timePart) return localDateTime;
+  if (!datePart || !timePart) return null;
   const [hh, mm] = timePart.split(':');
   const hhPadded = (hh ?? '00').padStart(2, '0');
   const mmPadded = (mm ?? '00').padStart(2, '0');
-  return `${datePart}T${hhPadded}:${mmPadded}:00+08:00`;
+  return { date: datePart, time: `${hhPadded}:${mmPadded}` };
 }
 
 /**
@@ -641,14 +647,14 @@ export function buildConsentFormPayload(
     );
   }
   const responseType = FE_TO_PG_CONSENT_RESPONSE_TYPE[state.responseType];
-  // PGW's consent-form contract types these fields as always-string (see
-  // `pgw-web/src/app/pages/ConsentForms/ConsentForm.types.ts`). Sending `null`
-  // produces `"reminderDate" must be a string` at runtime even when the field
-  // is logically absent. Use empty strings for the "no value" case.
+  // PGW's consent-form schema accepts empty strings for reminderDate /
+  // consentByDate / venue, but event dates must be `{ date, time }` or null
+  // (Joi rejects `""` with "eventStartDate is not allowed"). See
+  // `pgw-web/src/server/modules/consent-form/consent-form-draft.service.ts`.
   const reminderDate =
     state.reminder.type === 'NONE' ? '' : (localDateToSgtIso(state.reminder.date) ?? '');
-  const eventStartDate = state.event ? (localDateTimeToSgtIso(state.event.start) ?? '') : '';
-  const eventEndDate = state.event ? (localDateTimeToSgtIso(state.event.end) ?? '') : '';
+  const eventStartDate = state.event ? splitLocalDateTime(state.event.start) : null;
+  const eventEndDate = state.event ? splitLocalDateTime(state.event.end) : null;
   const consentByDate = state.dueDate.trim() ? (localDateToSgtIso(state.dueDate) ?? '') : '';
   // Venue is tracked both on `state.venue` (independently editable) and as a
   // child of `state.event.venue` when PGEvent is populated. Prefer the

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -450,14 +450,15 @@ export function toPGCreatePayload(
 
 export function toPGConsentFormCreatePayload(
   p: PGApiCreateConsentFormPayload,
+  opts: { allowPartial?: boolean } = {},
 ): PGConsentFormWritePayload {
-  if (!p.enquiryEmailAddress) {
+  if (!p.enquiryEmailAddress && !opts.allowPartial) {
     throw new Error('enquiryEmailAddress is required');
   }
   return {
     title: p.title,
     content: p.richTextContent,
-    enquiryEmailAddress: p.enquiryEmailAddress,
+    enquiryEmailAddress: p.enquiryEmailAddress ?? '',
     targets: buildTargets(p.recipients),
     staffInCharge: p.staffOwnerIds,
     webLinkList: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
@@ -481,7 +482,7 @@ export function toPGConsentFormDraftPayload(
   p: PGApiCreateConsentFormDraftPayload,
 ): PGConsentFormWritePayload {
   return {
-    ...toPGConsentFormCreatePayload(p),
+    ...toPGConsentFormCreatePayload(p, { allowPartial: true }),
     scheduledSendAt: p.scheduledSendAt,
   } satisfies PGConsentFormWritePayload;
 }
@@ -630,12 +631,13 @@ export function buildConsentFormPayload(
   state: BuildPostPayloadInput,
 ): PGApiCreateConsentFormPayload {
   const doc = state.descriptionDoc ?? textToTiptapDoc(state.description);
-  if (state.responseType !== 'acknowledge' && state.responseType !== 'yes-no') {
-    // Consent forms sent to PGW only support acknowledge/yes-no. `view-only`
-    // and `custom` are front-end-only values; guard here defensively so a bad
-    // state change surfaces a clear error rather than an opaque 400 from pgw.
+  if (state.responseType === 'view-only') {
+    // Consent forms never carry `view-only`; the container's type-picker
+    // seeds `acknowledge` when the user picks post-with-response. Guard here
+    // defensively so a bad state change surfaces a clear error rather than
+    // an opaque 400 from pgw.
     throw new Error(
-      `Consent forms require responseType of \`acknowledge\` or \`yes-no\`, got \`${state.responseType}\`.`,
+      'Consent forms require responseType of `acknowledge` or `yes-no`, got `view-only`.',
     );
   }
   const responseType = FE_TO_PG_CONSENT_RESPONSE_TYPE[state.responseType];

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -18,12 +18,26 @@ export interface PGApiAnnouncementStudent {
   isRead: boolean;
 }
 
+/**
+ * Shape of a recipient entry under `consentFormRecipients[]` on the
+ * consent-form detail response. Student identity lives on a nested `student`
+ * object; reply + respond timestamp live at the recipient root.
+ */
 export interface PGApiConsentFormStudent {
   studentId: number;
-  studentName: string;
-  className: string;
-  response: 'YES' | 'NO' | null;
-  respondedAt: string | null;
+  reply: 'YES' | 'NO' | null;
+  replyDate: string | null;
+  replyByParent: string | null;
+  remarks: string | null;
+  isIndividual: boolean;
+  onBoardedCategory?: string;
+  student: {
+    studentId: number;
+    studentName: string;
+    indexNumber?: string;
+    className: string;
+    studentSex?: string;
+  };
 }
 
 export interface PGApiImage {
@@ -198,9 +212,16 @@ export interface PGApiConsentFormSummary {
 
 export type PGApiReminderType = 'NONE' | 'ONE_TIME' | 'DAILY';
 
+/**
+ * Shape of `GET /consentForms/:id` as returned by pgw-web (verified by curl
+ * against local pgw-web 2026-04-22). pgw-web's own declared type in
+ * `shared-api-types/consentForms/consentForm.ts` uses slightly different names
+ * in places (singular vs plural) — trust the observed wire shape.
+ */
 export interface PGApiConsentFormDetail {
   consentFormId: number;
   title: string;
+  content: string | null;
   richTextContent: Record<string, unknown> | string | null;
   responseType: PGApiResponseType;
   eventStartDate: string | null;
@@ -214,21 +235,20 @@ export interface PGApiConsentFormDetail {
   staffName: string;
   createdBy: number;
   createdAt: string | null;
-  attachments: PGApiAttachment[];
   images: PGApiImage[];
-  websiteLinks: PGApiWebsiteLink[];
-  customQuestions: PGApiCustomQuestion[];
+  /** Web links field is named `webLinkList` on the detail endpoint (not `websiteLinks`). */
+  webLinkList: PGApiWebsiteLink[];
+  /** Present but structure differs from writes; kept as opaque `unknown[]`. */
+  shortcutLinkList?: unknown[];
+  /** `null` when no custom questions are set. */
+  customQuestions: PGApiCustomQuestion[] | null;
   staffOwners: PGApiStaffOwner[];
-  students: PGApiConsentFormStudent[];
-  status: PGApiConsentFormStatus;
+  /** Recipient students — field name is plural `consentFormRecipients`. */
+  consentFormRecipients: PGApiConsentFormStudent[];
   consentFormHistory: PGApiConsentFormHistoryEntry[];
-  /**
-   * Same recipient target list PG sends on announcement detail — class / group
-   * / cca / level that the teacher originally targeted. Optional because the
-   * field is newer than the detail shape and some payloads may omit it; the
-   * mapper defaults to `[]` in that case.
-   */
-  target?: PGApiAnnouncementTarget[];
+  /** Target list — plural `targets` (pgw-web's own type uses singular `target`
+   * but the wire shape is plural). */
+  targets?: PGApiAnnouncementTarget[];
 }
 
 // ─── Consent form write payloads ────────────────────────────────────────────

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -243,8 +243,10 @@ export interface PGApiCreateConsentFormPayload {
   consentByDate: string;
   addReminderType: PGApiReminderType;
   reminderDate?: string | null;
-  eventStartDate?: string | null;
-  eventEndDate?: string | null;
+  /** PGW expects `{ date: 'YYYY-MM-DD', time: 'HH:mm' }` or `null` — see
+   *  `pgw-web/src/server/modules/consent-form/consent-form-draft.service.ts#L337`. */
+  eventStartDate?: { date: string; time: string } | null;
+  eventEndDate?: { date: string; time: string } | null;
   venue?: string | null;
   recipients: {
     classIds: number[];

--- a/web/components/posts/ReminderSection.tsx
+++ b/web/components/posts/ReminderSection.tsx
@@ -60,9 +60,7 @@ function ReminderSection({ value, onChange }: ReminderSectionProps) {
   return (
     <div className="space-y-3">
       <div>
-        <p className="text-sm font-medium">
-          Reminder <span className="text-destructive">*</span>
-        </p>
+        <p className="text-sm font-medium">Reminder</p>
         <p className="text-sm text-muted-foreground">Remind parents who have not yet responded.</p>
       </div>
 

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -881,7 +881,9 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
 
               {/* Enquiry email */}
               <div className="space-y-1.5">
-                <Label>Enquiry email</Label>
+                <Label>
+                  Enquiry email <span className="text-destructive">*</span>
+                </Label>
                 <p className="text-sm text-muted-foreground">
                   Select the preferred email address to receive enquiries from parents.
                 </p>
@@ -935,7 +937,9 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
               {/* Description with counter and toolbar */}
               <div className="space-y-1.5">
                 <div className="flex items-center justify-between">
-                  <Label id="post-description-label">Description</Label>
+                  <Label id="post-description-label">
+                    Description <span className="text-destructive">*</span>
+                  </Label>
                   <span className="text-xs text-muted-foreground tabular-nums">
                     {state.description.length}/2000
                   </span>

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -80,6 +80,9 @@ import { useAutoSave, type AutoSaveStatus } from '~/hooks/useAutoSave';
 import { useUnsavedChangesGuard } from '~/hooks/useUnsavedChangesGuard';
 import { notify } from '~/lib/notify';
 import { cn } from '~/lib/utils';
+import { reportValidationError } from '~/lib/validation-errors';
+
+import { isCreatePostFormValid } from './createPostValidation';
 
 // ─── Route loader ───────────────────────────────────────────────────────────
 
@@ -608,14 +611,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
   // and a non-None reminder type. Phase 2 will flip routing to `/consentForms`
   // and these fields will be required by the wire contract; gate in advance so
   // the form-state matches what Phase 2 expects.
-  const baseFormValid =
-    state.title.trim().length > 0 &&
-    state.enquiryEmail.trim().length > 0 &&
-    state.selectedRecipients.length > 0;
-  const consentFormValid =
-    selectedType !== 'post-with-response' ||
-    (state.dueDate.trim().length > 0 && state.reminder.type !== 'NONE');
-  const isFormValid = baseFormValid && consentFormValid;
+  const isFormValid = isCreatePostFormValid(state, selectedType);
   const recipientCount = state.selectedRecipients.reduce((sum, r) => sum + (r.count ?? 1), 0);
   const isEditing = Boolean(editId);
   const draftIdRef = useRef<number | null>(
@@ -672,7 +668,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       if (err instanceof PGValidationError) {
-        notify.error(err.message);
+        notify.error(reportValidationError(err));
       } else if (err instanceof Error && !(err instanceof PGError)) {
         // Plain `Error`s from the outbound mapper (e.g. payload-builder
         // guards) carry a useful message; surface it verbatim rather than a
@@ -718,7 +714,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
     } catch (err) {
       setSaveState('idle');
       if (err instanceof PGValidationError) {
-        notify.error(err.message);
+        notify.error(reportValidationError(err));
       } else if (!(err instanceof PGError)) {
         notify.error('Failed to schedule post. Please try again.');
       }
@@ -741,7 +737,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
     } catch (err) {
       setSaveState('idle');
       if (err instanceof PGValidationError) {
-        notify.error(err.message);
+        notify.error(reportValidationError(err));
       } else if (err instanceof Error && !(err instanceof PGError)) {
         // Plain `Error`s from the outbound mapper (e.g. missing email) carry
         // a useful message; surface it verbatim rather than a generic toast.

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -614,8 +614,12 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
   const isFormValid = isCreatePostFormValid(state, selectedType);
   const recipientCount = state.selectedRecipients.reduce((sum, r) => sum + (r.count ?? 1), 0);
   const isEditing = Boolean(editId);
-  const draftIdRef = useRef<number | null>(
-    editId && editId.startsWith('annDraft_') ? Number(editId.slice('annDraft_'.length)) : null,
+  const draftIdRef = useRef<{ kind: 'announcement' | 'form'; id: number } | null>(
+    editId?.startsWith('annDraft_')
+      ? { kind: 'announcement', id: Number(editId.slice('annDraft_'.length)) }
+      : editId?.startsWith('cf_')
+        ? { kind: 'form', id: Number(editId.slice('cf_'.length)) }
+        : null,
   );
   const autoSave = useAutoSave({
     payload: state,
@@ -651,20 +655,38 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
 
   async function handleSaveDraft(opts: { signal?: AbortSignal } = {}): Promise<void> {
     try {
-      const payload = buildAnnouncementPayload(state);
-      if (draftIdRef.current == null) {
-        const { announcementDraftId } = await createDraft(payload, { signal: opts.signal });
-        draftIdRef.current = announcementDraftId;
-        // Don't navigate: the draft-detail mapper doesn't yet re-hydrate
-        // recipients/staff/attachments (pgw `studentGroups`/`staffGroups`
-        // mapping is a follow-up), so navigating would remount the form into
-        // a partial state. `draftIdRef` keeps the id in-memory so subsequent
-        // saves call `updateDraft`. Trade-off: a browser refresh loses the
-        // link to the in-flight draft (it's still saved in PGW — the user
-        // can find it from `/posts` and click through).
+      // Branch by kind: announcements and consent forms are separate PGW
+      // endpoint families with non-overlapping field sets. Sending consent-form
+      // fields (eventStartDate, venue, etc.) to /announcements/drafts produces
+      // `"eventStartDate" is not allowed`. Routing here mirrors
+      // `handleScheduleConfirm` / `handleSendConfirm`.
+      if (state.kind === 'form') {
+        const payload = buildConsentFormPayload(state);
+        if (draftIdRef.current?.kind === 'form') {
+          await updateConsentFormDraft(draftIdRef.current.id, payload, {
+            signal: opts.signal,
+          });
+        } else {
+          const { consentFormDraftId } = await createConsentFormDraft(payload, {
+            signal: opts.signal,
+          });
+          draftIdRef.current = { kind: 'form', id: consentFormDraftId };
+        }
       } else {
-        await updateDraft(draftIdRef.current, payload, { signal: opts.signal });
+        const payload = buildAnnouncementPayload(state);
+        if (draftIdRef.current?.kind === 'announcement') {
+          await updateDraft(draftIdRef.current.id, payload, { signal: opts.signal });
+        } else {
+          const { announcementDraftId } = await createDraft(payload, { signal: opts.signal });
+          draftIdRef.current = { kind: 'announcement', id: announcementDraftId };
+        }
       }
+      // Don't navigate: the draft-detail mapper doesn't yet re-hydrate
+      // recipients/staff/attachments, so navigating would remount the form
+      // into a partial state. `draftIdRef` keeps the id in-memory so
+      // subsequent saves call the correct update endpoint. Trade-off: a
+      // browser refresh loses the link to the in-flight draft (it's still
+      // saved in PGW — the user can find it from `/posts` and click through).
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
       if (err instanceof PGValidationError) {
@@ -697,10 +719,10 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
         }
       } else {
         const draftPayload = { ...buildAnnouncementPayload(state), scheduledSendAt };
-        if (isEditing && draftIdRef.current != null) {
+        if (draftIdRef.current?.kind === 'announcement') {
           // Editing an existing draft: keep the same draft, just push the new
           // `scheduledSendAt` with the other field updates.
-          await updateDraft(draftIdRef.current, draftPayload);
+          await updateDraft(draftIdRef.current.id, draftPayload);
         } else {
           // New post → schedule in a single round-trip. `scheduleDraft` (which
           // targets a pre-saved draft) is deferred; we don't need it for this

--- a/web/containers/CreatePostView.validation.test.tsx
+++ b/web/containers/CreatePostView.validation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { SelectedEntity } from '~/components/comms/entity-selector';
-import type { FormQuestion, ReminderConfig } from '~/data/mock-pg-announcements';
+import type { ReminderConfig } from '~/data/mock-pg-announcements';
 
 import { isCreatePostFormValid } from './createPostValidation';
 import type { PostFormState } from './CreatePostView';
@@ -75,24 +75,5 @@ describe('isCreatePostFormValid — post-with-response (form)', () => {
     // PGW allows NONE as a valid reminder choice.
     const reminder: ReminderConfig = { type: 'NONE' };
     expect(isCreatePostFormValid({ ...formBase, reminder }, 'post-with-response')).toBe(true);
-  });
-
-  it('fails when responseType is custom and there are no questions', () => {
-    const customNoQs: PostFormState = {
-      ...formBase,
-      responseType: 'custom' as PostFormState['responseType'],
-      questions: [],
-    };
-    expect(isCreatePostFormValid(customNoQs, 'post-with-response')).toBe(false);
-  });
-
-  it('passes when responseType is custom and there is at least one question', () => {
-    const question: FormQuestion = { id: 'q1', type: 'free-text', text: 'What?' };
-    const withQs: PostFormState = {
-      ...formBase,
-      responseType: 'custom' as PostFormState['responseType'],
-      questions: [question],
-    };
-    expect(isCreatePostFormValid(withQs, 'post-with-response')).toBe(true);
   });
 });

--- a/web/containers/CreatePostView.validation.test.tsx
+++ b/web/containers/CreatePostView.validation.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SelectedEntity } from '~/components/comms/entity-selector';
+import type { FormQuestion, ReminderConfig } from '~/data/mock-pg-announcements';
+
+import { isCreatePostFormValid } from './createPostValidation';
+import type { PostFormState } from './CreatePostView';
+
+const recipient: SelectedEntity = {
+  id: '1',
+  label: 'P1 A',
+  type: 'group',
+  count: 30,
+};
+
+const validBase: PostFormState = {
+  kind: 'announcement',
+  title: 'Hello',
+  description: 'Body text',
+  descriptionDoc: {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Body text' }] }],
+  },
+  selectedRecipients: [recipient],
+  responseType: 'view-only',
+  questions: [],
+  selectedStaff: [],
+  enquiryEmail: 'a@b.sg',
+  dueDate: '',
+  reminder: { type: 'NONE' },
+  websiteLinks: [],
+  shortcuts: [],
+};
+
+describe('isCreatePostFormValid — announcement', () => {
+  it('passes with all required fields', () => {
+    expect(isCreatePostFormValid(validBase, 'post')).toBe(true);
+  });
+
+  it('fails when title is empty', () => {
+    expect(isCreatePostFormValid({ ...validBase, title: '' }, 'post')).toBe(false);
+  });
+
+  it('fails when description is empty', () => {
+    // PGTW-11 new rule
+    expect(isCreatePostFormValid({ ...validBase, description: '' }, 'post')).toBe(false);
+  });
+
+  it('fails when enquiry email is empty', () => {
+    expect(isCreatePostFormValid({ ...validBase, enquiryEmail: '' }, 'post')).toBe(false);
+  });
+
+  it('fails when recipients are empty', () => {
+    expect(isCreatePostFormValid({ ...validBase, selectedRecipients: [] }, 'post')).toBe(false);
+  });
+});
+
+describe('isCreatePostFormValid — post-with-response (form)', () => {
+  const formBase: PostFormState = {
+    ...validBase,
+    kind: 'form',
+    responseType: 'acknowledge',
+    dueDate: '2026-05-01',
+  };
+
+  it('passes with all required fields for acknowledge', () => {
+    expect(isCreatePostFormValid(formBase, 'post-with-response')).toBe(true);
+  });
+
+  it('fails when due date is empty', () => {
+    expect(isCreatePostFormValid({ ...formBase, dueDate: '' }, 'post-with-response')).toBe(false);
+  });
+
+  it('passes when reminder.type is NONE (PGTW-11 drop the over-strict check)', () => {
+    // PGW allows NONE as a valid reminder choice.
+    const reminder: ReminderConfig = { type: 'NONE' };
+    expect(isCreatePostFormValid({ ...formBase, reminder }, 'post-with-response')).toBe(true);
+  });
+
+  it('fails when responseType is custom and there are no questions', () => {
+    const customNoQs: PostFormState = {
+      ...formBase,
+      responseType: 'custom' as PostFormState['responseType'],
+      questions: [],
+    };
+    expect(isCreatePostFormValid(customNoQs, 'post-with-response')).toBe(false);
+  });
+
+  it('passes when responseType is custom and there is at least one question', () => {
+    const question: FormQuestion = { id: 'q1', type: 'free-text', text: 'What?' };
+    const withQs: PostFormState = {
+      ...formBase,
+      responseType: 'custom' as PostFormState['responseType'],
+      questions: [question],
+    };
+    expect(isCreatePostFormValid(withQs, 'post-with-response')).toBe(true);
+  });
+});

--- a/web/containers/createPostValidation.ts
+++ b/web/containers/createPostValidation.ts
@@ -8,8 +8,7 @@ import type { PostFormState } from './CreatePostView';
  *
  * Gate 1 — common: title, enquiry email, recipients, and description are
  * required for all post types.
- * Gate 2 — post-with-response only: due date is required; when responseType
- * is 'custom', at least one question must be present.
+ * Gate 2 — post-with-response only: due date is required.
  */
 export function isCreatePostFormValid(
   state: PostFormState,
@@ -24,13 +23,10 @@ export function isCreatePostFormValid(
 
   if (!baseValid) return false;
 
-  // Gate 2: consent-form (post-with-response) — due date + responseType-specific gates.
+  // Gate 2: consent-form (post-with-response) — due date required.
   if (selectedType !== 'post-with-response') return true;
 
   if (state.dueDate.trim().length === 0) return false;
-
-  // Custom response type requires at least one question.
-  if (state.responseType === 'custom' && state.questions.length === 0) return false;
 
   return true;
 }

--- a/web/containers/createPostValidation.ts
+++ b/web/containers/createPostValidation.ts
@@ -1,0 +1,36 @@
+import type { PostKind } from '~/components/posts/PostTypePicker';
+
+import type { PostFormState } from './CreatePostView';
+
+/**
+ * Pure validation helper for the CreatePost form. Extracted so the rules can
+ * be unit-tested without mounting the full component.
+ *
+ * Gate 1 — common: title, enquiry email, recipients, and description are
+ * required for all post types.
+ * Gate 2 — post-with-response only: due date is required; when responseType
+ * is 'custom', at least one question must be present.
+ */
+export function isCreatePostFormValid(
+  state: PostFormState,
+  selectedType: PostKind | null,
+): boolean {
+  // Gate 1: required for all post types.
+  const baseValid =
+    state.title.trim().length > 0 &&
+    state.enquiryEmail.trim().length > 0 &&
+    state.selectedRecipients.length > 0 &&
+    state.description.trim().length > 0;
+
+  if (!baseValid) return false;
+
+  // Gate 2: consent-form (post-with-response) — due date + responseType-specific gates.
+  if (selectedType !== 'post-with-response') return true;
+
+  if (state.dueDate.trim().length === 0) return false;
+
+  // Custom response type requires at least one question.
+  if (state.responseType === 'custom' && state.questions.length === 0) return false;
+
+  return true;
+}

--- a/web/data/mock-pg-announcements.ts
+++ b/web/data/mock-pg-announcements.ts
@@ -1,7 +1,7 @@
 import type { PGApiConsentFormHistoryEntry } from '~/api/types';
 
 export type PGStatus = 'posted' | 'scheduled' | 'draft' | 'posting';
-export type ResponseType = 'view-only' | 'acknowledge' | 'yes-no';
+export type ResponseType = 'view-only' | 'acknowledge' | 'yes-no' | 'custom';
 
 // Presentation mapping for status badges. Living here (alongside the PGStatus
 // type) keeps the status set and its label/variant in sync.
@@ -19,6 +19,7 @@ export const RESPONSE_TYPE_META: Record<ResponseType, { label: string; descripti
   'view-only': { label: 'View Only', description: 'Parents can read but not respond' },
   acknowledge: { label: 'Acknowledge', description: 'Parents must acknowledge receipt' },
   'yes-no': { label: 'Yes / No', description: 'Parents respond with Yes or No' },
+  custom: { label: 'Custom', description: 'Build a custom form with your own questions' },
 };
 
 export type ResponseTypeWithResponse = 'acknowledge' | 'yes-no';

--- a/web/data/mock-pg-announcements.ts
+++ b/web/data/mock-pg-announcements.ts
@@ -1,7 +1,7 @@
 import type { PGApiConsentFormHistoryEntry } from '~/api/types';
 
 export type PGStatus = 'posted' | 'scheduled' | 'draft' | 'posting';
-export type ResponseType = 'view-only' | 'acknowledge' | 'yes-no' | 'custom';
+export type ResponseType = 'view-only' | 'acknowledge' | 'yes-no';
 
 // Presentation mapping for status badges. Living here (alongside the PGStatus
 // type) keeps the status set and its label/variant in sync.
@@ -19,7 +19,6 @@ export const RESPONSE_TYPE_META: Record<ResponseType, { label: string; descripti
   'view-only': { label: 'View Only', description: 'Parents can read but not respond' },
   acknowledge: { label: 'Acknowledge', description: 'Parents must acknowledge receipt' },
   'yes-no': { label: 'Yes / No', description: 'Parents respond with Yes or No' },
-  custom: { label: 'Custom', description: 'Build a custom form with your own questions' },
 };
 
 export type ResponseTypeWithResponse = 'acknowledge' | 'yes-no';

--- a/web/lib/validation-errors.test.ts
+++ b/web/lib/validation-errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { PGValidationError } from '~/api/errors';
+
+import { reportValidationError } from './validation-errors';
+
+describe('reportValidationError', () => {
+  it('maps -4001 to "Enquiry email is required."', () => {
+    const err = new PGValidationError('raw', -4001, 400);
+    expect(reportValidationError(err)).toBe('Enquiry email is required.');
+  });
+
+  it('maps -4003 to a description-formatting message', () => {
+    const err = new PGValidationError('raw', -4003, 400);
+    expect(reportValidationError(err)).toMatch(/description.*format/i);
+  });
+
+  it('maps -4004 to a description-length message including the 2000 limit', () => {
+    const err = new PGValidationError('raw', -4004, 400);
+    const msg = reportValidationError(err);
+    expect(msg).toMatch(/description/i);
+    expect(msg).toMatch(/2000/);
+  });
+
+  it('falls back to err.message for unmapped -400x codes', () => {
+    const err = new PGValidationError('Something else went wrong', -400, 400);
+    expect(reportValidationError(err)).toBe('Something else went wrong');
+  });
+});

--- a/web/lib/validation-errors.ts
+++ b/web/lib/validation-errors.ts
@@ -1,0 +1,19 @@
+import { PGValidationError } from '~/api/errors';
+
+/**
+ * Map PGW validation error codes to a user-facing message. Falls back to the
+ * raw `err.message` (PGW's `errorReason`) when the code isn't specifically
+ * mapped — preserves the existing fallback behavior.
+ */
+export function reportValidationError(err: PGValidationError): string {
+  switch (err.resultCode) {
+    case -4001:
+      return 'Enquiry email is required.';
+    case -4003:
+      return 'Description formatting is invalid. Please simplify and try again.';
+    case -4004:
+      return 'Description is too long. Maximum 2000 characters.';
+    default:
+      return err.message;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `description` to the required-field gate for all post types
- Require ≥1 question when `responseType` is `custom`
- Drop over-strict `reminder.type !== 'NONE'` check (NONE is valid per PGW)
- Map PG validation errors `-4001/-4003/-4004` to specific toast messages
- Extract `isCreatePostFormValid` to a pure testable helper; add `'custom'` to `ResponseType`

## Test plan
- [ ] `pnpm test` — all validation and error-mapping tests pass
- [ ] Manually verify: Post button disabled until title + email + recipients + description filled; for post-with-response, also until due date is set (and questions present when responseType === custom)
- [ ] Save draft still works with partial state (no regression on PGTW-5)

Deferred (subsystems not yet implemented): website-link URL validation, attachment/photo/venue limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)