### PR TITLE
feat(web): route consent-form drafts through their own detail endpoint

### DIFF
--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -1,6 +1,7 @@
 import type {
   AnnouncementDraftId,
   AnnouncementId,
+  ConsentFormDraftId,
   ConsentFormId,
   PGAnnouncementPost,
   PGConsentFormPost,
@@ -13,6 +14,7 @@ import {
   mapAnnouncementDraftDetail,
   mapAnnouncementSummary,
   mapConsentFormDetail,
+  mapConsentFormDraftDetail,
   mapConsentFormSummaryToPost,
   mergeAndDedup,
   toPGConsentFormCreatePayload,
@@ -26,6 +28,7 @@ import type {
   PGApiClassDetail,
   PGApiConfig,
   PGApiConsentFormDetail,
+  PGApiConsentFormDraft,
   PGApiConsentFormList,
   PGApiCreateAnnouncementPayload,
   PGApiCreateConsentFormDraftPayload,
@@ -387,6 +390,23 @@ export async function loadConsentPostsList(): Promise<PGConsentFormPost[]> {
 export async function loadConsentPostDetail(formId: ConsentFormId): Promise<PGConsentFormPost> {
   const detail = await fetchConsentFormDetail(formId);
   return mapConsentFormDetail(detail);
+}
+
+async function fetchConsentFormDraftDetail(
+  draftId: ConsentFormDraftId,
+): Promise<PGApiConsentFormDraft> {
+  // Strip the `cfDraft_` prefix to get the bare numeric ID.
+  const bareId = draftId.replace(/^cfDraft_/, '');
+  // pgw-web wraps single-detail responses as `body: [<detail>]`; unwrap.
+  const arr = await fetchApi<PGApiConsentFormDraft[]>(`/consentForms/drafts/${bareId}`);
+  return arr[0];
+}
+
+export async function loadConsentFormDraftDetail(
+  draftId: ConsentFormDraftId,
+): Promise<PGConsentFormPost> {
+  const draft = await fetchConsentFormDraftDetail(draftId);
+  return mapConsentFormDraftDetail(draft);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/web/api/mappers.test.ts
+++ b/web/api/mappers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { toPGCreatePayload } from './mappers';
-import type { PGApiCreateAnnouncementPayload } from './types';
+import { mapConsentFormSummaryToPost, toPGCreatePayload } from './mappers';
+import type { PGApiConsentFormSummary, PGApiCreateAnnouncementPayload } from './types';
 
 const basePayload: PGApiCreateAnnouncementPayload = {
   title: 'Test',
@@ -43,5 +43,43 @@ describe('toPGCreatePayload', () => {
       { targetType: 'cca', targetId: 3 },
       { targetType: 'level', targetId: 4 },
     ]);
+  });
+});
+
+const baseConsentFormSummary: PGApiConsentFormSummary = {
+  id: 'cf_42',
+  postId: 42,
+  title: 'Test form',
+  date: '2026-04-01T00:00:00.000Z',
+  status: 'OPEN',
+  toParentsOf: [],
+  respondedMetrics: { respondedPerStudent: 0.5, totalStudents: 10 },
+  scheduledSendFailureCode: null,
+  createdByName: 'Teacher A',
+  consentByDate: '2026-05-01T00:00:00.000Z',
+};
+
+describe('mapConsentFormSummaryToPost', () => {
+  it('brands posted rows as cf_<id>', () => {
+    const out = mapConsentFormSummaryToPost(baseConsentFormSummary, 'mine');
+    expect(out.id).toBe('cf_42');
+    expect(out.status).toBe('open');
+  });
+
+  it('brands draft rows as cfDraft_<id>', () => {
+    const draft: PGApiConsentFormSummary = { ...baseConsentFormSummary, status: 'DRAFT' };
+    const out = mapConsentFormSummaryToPost(draft, 'mine');
+    expect(out.id).toBe('cfDraft_42');
+    expect(out.status).toBe('draft');
+  });
+
+  it('brands scheduled rows as cf_<id>', () => {
+    const scheduled: PGApiConsentFormSummary = {
+      ...baseConsentFormSummary,
+      status: 'SCHEDULED',
+    };
+    const out = mapConsentFormSummaryToPost(scheduled, 'mine');
+    expect(out.id).toBe('cf_42');
+    expect(out.status).toBe('scheduled');
   });
 });

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -1,6 +1,7 @@
 import type {
   AnnouncementDraftId,
   AnnouncementId,
+  ConsentFormDraftId,
   ConsentFormId,
   FormQuestion,
   PGAnnouncementPost,
@@ -26,6 +27,7 @@ import type {
   PGApiAnnouncementStudent,
   PGApiAnnouncementSummary,
   PGApiConsentFormDetail,
+  PGApiConsentFormDraft,
   PGApiConsentFormStatus,
   PGApiConsentFormSummary,
   PGApiCreateAnnouncementPayload,
@@ -181,6 +183,54 @@ export function mapAnnouncementDraftDetail(draft: PGApiAnnouncementDraft): PGAnn
   };
 }
 
+/**
+ * Map a consent-form draft-detail response into the unified `PGConsentFormPost`
+ * shape. Minimal mapping — populates title/richText/email/dueDate so the form
+ * hydrates on reload. Recipients, staff, and attachments are left empty because
+ * the `staffGroups`/`studentGroups` shape on the draft endpoint is not yet
+ * documented (arrays were empty in observed samples). Extend as shapes become
+ * verifiable. Mirrors `mapAnnouncementDraftDetail` in structure.
+ */
+export function mapConsentFormDraftDetail(draft: PGApiConsentFormDraft): PGConsentFormPost {
+  // richTextContent arrives as a JSON-encoded string on the draft endpoint
+  // (unlike the posted-form detail which can be an already-parsed object).
+  const richTextContent =
+    draft.richTextContent && typeof draft.richTextContent === 'string'
+      ? (JSON.parse(draft.richTextContent) as Record<string, unknown>)
+      : null;
+
+  const addReminderType: PGApiReminderType =
+    draft.addReminderType === 'ONE_TIME' || draft.addReminderType === 'DAILY'
+      ? draft.addReminderType
+      : 'NONE';
+
+  return {
+    kind: 'form',
+    id: `cfDraft_${draft.consentFormDraftId}` as ConsentFormDraftId,
+    title: draft.title,
+    description: richTextContent ? extractTextFromTiptap(richTextContent) : '',
+    richTextContent,
+    status: 'draft',
+    responseType: draft.responseType === 'YES_NO' ? 'yes-no' : 'acknowledge',
+    ownership: 'mine',
+    recipients: [],
+    stats: {
+      totalCount: 0,
+      yesCount: 0,
+      noCount: 0,
+      pendingCount: 0,
+    },
+    createdAt: draft.updatedAt,
+    createdBy: '',
+    scheduledAt: draft.scheduledDateTime ?? undefined,
+    enquiryEmail: draft.enquiryEmailAddress,
+    consentByDate: draft.consentByDate ?? '',
+    reminder: mapReminder(addReminderType, draft.reminderDate || null),
+    questions: [],
+    history: [],
+  };
+}
+
 // Inbound `targetType` is sent lowercase by pgw-web (`class` | `group` | `cca` | `level`);
 // normalize defensively in case future payloads upcase it.
 const PG_TARGET_TYPE_MAP: Record<string, PGTargetType> = {
@@ -221,9 +271,14 @@ export function mapConsentFormSummaryToPost(
     ? Math.round(api.respondedMetrics.respondedPerStudent * totalCount)
     : 0;
 
+  const id =
+    status === 'draft'
+      ? (`cfDraft_${api.postId}` as ConsentFormDraftId)
+      : (`cf_${api.postId}` as ConsentFormId);
+
   return {
     kind: 'form',
-    id: `cf_${api.postId}` as ConsentFormId,
+    id,
     title: api.title,
     description: '',
     status,

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -91,17 +91,31 @@ export function mapAnnouncementSummary(
 }
 
 /**
- * PG's detail embeds read status on `students[].isRead`; per-student `readAt`
- * is not exposed by PG, so `respondedAt` is left undefined.
+ * Map the announcement-detail response to `PGAnnouncementPost`.
+ *
+ * The wire response (verified via curl 2026-04-23) differs from what our
+ * declared type assumed — tolerate the drift defensively:
+ * - `websiteLinks` → real field is `webLinkList`
+ * - `status`/`responseType`/`scheduledSendAt` → null at the wire; derive
+ * - `students[].readStatus` → real field (not `isRead`)
+ * - `staffOwners`/`target`/`students` → treat as optional, default to `[]`
  */
 export function mapAnnouncementDetail(detail: PGApiAnnouncementDetail): PGAnnouncementPost {
-  const status = toPGStatus(detail.status);
-  const totalCount = detail.students.length;
-  const readCount = detail.students.filter((s) => s.isRead).length;
+  // Detail endpoint doesn't always carry `status`; derive from date fields.
+  const derivedStatus: PGStatus = detail.scheduledSendAt
+    ? 'scheduled'
+    : detail.postedDate
+      ? 'posted'
+      : 'draft';
+  const status = detail.status ? toPGStatus(detail.status) : derivedStatus;
 
-  const recipients: PGRecipient[] = detail.students.map((s) => ({
+  const students = detail.students ?? [];
+  const totalCount = students.length;
+  const readCount = students.filter((s) => s.isRead || s.readStatus === 'READ').length;
+
+  const recipients: PGRecipient[] = students.map((s) => ({
     ...buildRecipientBase(s),
-    readStatus: s.isRead ? ('read' as const) : ('unread' as const),
+    readStatus: s.isRead || s.readStatus === 'READ' ? ('read' as const) : ('unread' as const),
     respondedAt: undefined,
   }));
 
@@ -111,6 +125,10 @@ export function mapAnnouncementDetail(detail: PGApiAnnouncementDetail): PGAnnoun
     detail.richTextContent && typeof detail.richTextContent === 'object'
       ? (detail.richTextContent as Record<string, unknown>)
       : null;
+
+  const targetsRaw = detail.target ?? (detail as { targets?: typeof detail.target }).targets ?? [];
+  const links = detail.webLinkList ?? detail.websiteLinks ?? [];
+  const staffOwners = detail.staffOwners ?? [];
 
   return {
     kind: 'announcement',
@@ -133,16 +151,16 @@ export function mapAnnouncementDetail(detail: PGApiAnnouncementDetail): PGAnnoun
     createdBy: detail.staffName,
     postedAt: detail.postedDate ?? undefined,
     scheduledAt: detail.scheduledSendAt ?? undefined,
-    staffInCharge: detail.staffOwners[0]?.staffName,
-    staffOwnerIds: detail.staffOwners.map((s) => s.staffID),
-    targets: detail.target
+    staffInCharge: staffOwners[0]?.staffName,
+    staffOwnerIds: staffOwners.map((s) => s.staffID),
+    targets: targetsRaw
       .map<PGAnnouncementTarget | null>((t) => {
         const type = toPGTargetType(t.targetType);
         return type ? { type, id: t.targetId, label: t.targetName } : null;
       })
       .filter((t): t is PGAnnouncementTarget => t !== null),
     enquiryEmail: detail.enquiryEmailAddress,
-    websiteLinks: detail.websiteLinks.map((l) => ({ url: l.url, title: l.title })),
+    websiteLinks: links.map((l) => ({ url: l.url, title: l.title })),
   };
 }
 
@@ -436,7 +454,7 @@ const RESPONSE_TYPE_MAP: Record<string, ResponseType> = {
   YES_NO: 'yes-no',
 };
 
-function mapResponseType(apiType?: string): ResponseType {
+function mapResponseType(apiType?: string | null): ResponseType {
   if (!apiType) return 'view-only';
   return RESPONSE_TYPE_MAP[apiType] ?? 'view-only';
 }

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -15,7 +15,10 @@ export interface PGApiAnnouncementStudent {
   studentId: number;
   studentName: string;
   className: string;
-  isRead: boolean;
+  /** Older pgw-web shape (boolean). */
+  isRead?: boolean;
+  /** Current pgw-web shape — `'READ' | null` on each recipient. */
+  readStatus?: 'READ' | null;
 }
 
 /**
@@ -111,12 +114,20 @@ export interface PGApiAnnouncementSummary {
   createdByName: string;
 }
 
+/**
+ * Shape of `GET /announcements/:id` as returned by pgw-web (verified by curl
+ * 2026-04-23). Several fields our older code assumed were always present are
+ * actually optional/nullable on the wire:
+ * - `status`, `responseType`, `scheduledSendAt` → null for posted rows
+ * - Web links live on `webLinkList`; `websiteLinks` is the (absent) older name
+ * - `target` / `staffOwners` / `students` may be absent on minimal responses
+ */
 export interface PGApiAnnouncementDetail {
   announcementId: number;
   title: string;
   content: string | null;
   richTextContent: Record<string, unknown> | string | null;
-  responseType?: PGApiResponseType;
+  responseType?: PGApiResponseType | null;
   staffName: string;
   createdBy: number;
   createdAt: string | null;
@@ -125,13 +136,15 @@ export interface PGApiAnnouncementDetail {
   attachments: PGApiAttachment[];
   images: PGApiImage[];
   shortcutLink: PGApiShortcutLink[];
-  websiteLinks: PGApiWebsiteLink[];
-  target: PGApiAnnouncementTarget[];
-  staffOwners: PGApiStaffOwner[];
-  students: PGApiAnnouncementStudent[];
-  status: PGApiAnnouncementStatus;
-  scheduledSendAt: string | null;
-  scheduledSendFailureCode: string | null;
+  /** pgw-web's current field name. Mapper also accepts the legacy `websiteLinks`. */
+  webLinkList?: PGApiWebsiteLink[];
+  websiteLinks?: PGApiWebsiteLink[];
+  target?: PGApiAnnouncementTarget[];
+  staffOwners?: PGApiStaffOwner[];
+  students?: PGApiAnnouncementStudent[];
+  status?: PGApiAnnouncementStatus | null;
+  scheduledSendAt?: string | null;
+  scheduledSendFailureCode?: string | null;
 }
 
 export interface PGApiAnnouncementDraft {

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -152,6 +152,32 @@ export interface PGApiAnnouncementDraft {
   scheduledDateTime: string | null;
 }
 
+export interface PGApiConsentFormDraft {
+  consentFormDraftId: number;
+  status: 'DRAFT';
+  postedConsentFormId: number | null;
+  title: string;
+  content: string | null;
+  richTextContent: string | null;
+  venue: string;
+  eventStartDate: { date: string; time: string } | null;
+  eventEndDate: { date: string; time: string } | null;
+  reminderDate: string;
+  addReminderType: 'NONE' | 'ONE_TIME' | 'DAILY' | '';
+  enquiryEmailAddress: string;
+  consentByDate: string | null;
+  responseType: 'ACKNOWLEDGEMENT' | 'YES_NO' | '';
+  questions: unknown[];
+  staffGroups: unknown[];
+  studentGroups: unknown[];
+  images: { images: unknown[]; imagesOrigin: string };
+  attachments: unknown[];
+  urls: unknown[];
+  shortcuts: unknown[];
+  updatedAt: string;
+  scheduledDateTime: string | null;
+}
+
 // ─── Announcement write payloads ────────────────────────────────────────────
 
 export interface PGApiCreateAnnouncementPayload {

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -16,6 +16,7 @@ import {
   fetchSession,
   getConfigs,
   loadAnnouncementDraftDetail,
+  loadConsentFormDraftDetail,
   loadConsentPostDetail,
   loadPostDetail,
   updateConsentFormDraft,
@@ -65,6 +66,7 @@ import {
 } from '~/components/ui';
 import {
   isAnnouncementDraftId,
+  isConsentFormDraftId,
   isConsentFormId,
   validatePostRoute,
   type FormQuestion,
@@ -115,6 +117,7 @@ interface CreatePostLoaderData {
 async function loadPostByKind(rawId: string, kindParam: string | null): Promise<PGPost | null> {
   const parsed = validatePostRoute(rawId, kindParam);
   if (!parsed) return null;
+  if (isConsentFormDraftId(parsed)) return loadConsentFormDraftDetail(parsed);
   if (isConsentFormId(parsed)) return loadConsentPostDetail(parsed);
   if (isAnnouncementDraftId(parsed)) return loadAnnouncementDraftDetail(parsed);
   return loadPostDetail(parsed);
@@ -617,9 +620,11 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
   const draftIdRef = useRef<{ kind: 'announcement' | 'form'; id: number } | null>(
     editId?.startsWith('annDraft_')
       ? { kind: 'announcement', id: Number(editId.slice('annDraft_'.length)) }
-      : editId?.startsWith('cf_')
-        ? { kind: 'form', id: Number(editId.slice('cf_'.length)) }
-        : null,
+      : editId?.startsWith('cfDraft_')
+        ? { kind: 'form', id: Number(editId.slice('cfDraft_'.length)) }
+        : editId?.startsWith('cf_')
+          ? { kind: 'form', id: Number(editId.slice('cf_'.length)) }
+          : null,
   );
   const autoSave = useAutoSave({
     payload: state,

--- a/web/containers/PostDetailView.tsx
+++ b/web/containers/PostDetailView.tsx
@@ -13,6 +13,7 @@ import { RecipientReadTable } from '~/components/posts/RecipientReadTable';
 import { Badge, Button } from '~/components/ui';
 import {
   isAnnouncementDraftId,
+  isConsentFormDraftId,
   isConsentFormId,
   PG_CONSENT_FORM_STATUS_BADGE,
   PG_STATUS_BADGE,
@@ -51,9 +52,10 @@ export async function loader({
   const parsed = validatePostRoute(id, url.searchParams.get('kind'));
   if (!parsed) throw new Response('Not Found', { status: 404 });
 
-  // Draft announcements are only accessible via the edit route; a direct detail
-  // request for a draft ID is treated as 404.
+  // Drafts are only accessible via the edit route; a direct detail
+  // request for any draft ID is treated as 404.
   if (isAnnouncementDraftId(parsed)) throw new Response('Not Found', { status: 404 });
+  if (isConsentFormDraftId(parsed)) throw new Response('Not Found', { status: 404 });
 
   const [post, configs] = await Promise.all([
     isConsentFormId(parsed)

--- a/web/containers/PostsView.tsx
+++ b/web/containers/PostsView.tsx
@@ -14,6 +14,7 @@ import { Link, useLoaderData, useNavigate, useRevalidator } from 'react-router';
 import {
   deleteAnnouncement,
   deleteConsentForm,
+  deleteConsentFormDraft,
   deleteDraft,
   duplicateAnnouncement,
   getConfigs,
@@ -46,6 +47,7 @@ import {
 } from '~/components/ui';
 import {
   isAnnouncementDraftId,
+  isConsentFormDraftId,
   PG_CONSENT_FORM_STATUS_BADGE,
   PG_STATUS_BADGE,
   postHref,
@@ -143,7 +145,9 @@ const PostsView: React.FC = () => {
     async (row: PostRowData) => {
       if (!confirm('Delete this post?')) return;
       try {
-        if (row.kind === 'form') {
+        if (isConsentFormDraftId(row.id)) {
+          await deleteConsentFormDraft(Number(row.id.slice('cfDraft_'.length)));
+        } else if (row.kind === 'form') {
           await deleteConsentForm(row.id);
         } else if (isAnnouncementDraftId(row.id)) {
           await deleteDraft(Number(row.id.slice('annDraft_'.length)));

--- a/web/data/mock-pg-announcements.test.ts
+++ b/web/data/mock-pg-announcements.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isAnnouncementDraftId,
+  isConsentFormDraftId,
+  isConsentFormId,
+  parsePostId,
+} from './mock-pg-announcements';
+
+describe('parsePostId', () => {
+  it('returns ConsentFormDraftId for cfDraft_<digits>', () => {
+    const id = parsePostId('cfDraft_42');
+    expect(id).toBe('cfDraft_42');
+    expect(isConsentFormDraftId(id!)).toBe(true);
+  });
+
+  it('returns ConsentFormId for cf_<digits>', () => {
+    const id = parsePostId('cf_42');
+    expect(id).toBe('cf_42');
+    expect(isConsentFormId(id!)).toBe(true);
+  });
+
+  it('returns AnnouncementDraftId for annDraft_<digits>', () => {
+    const id = parsePostId('annDraft_42');
+    expect(id).toBe('annDraft_42');
+    expect(isAnnouncementDraftId(id!)).toBe(true);
+  });
+
+  it('returns AnnouncementId for bare numeric string', () => {
+    const id = parsePostId('123');
+    expect(id).toBe('123');
+    expect(isConsentFormId(id!)).toBe(false);
+    expect(isConsentFormDraftId(id!)).toBe(false);
+    expect(isAnnouncementDraftId(id!)).toBe(false);
+  });
+
+  it('returns null for non-numeric strings', () => {
+    expect(parsePostId('invalid')).toBeNull();
+    expect(parsePostId('')).toBeNull();
+    expect(parsePostId('cf_')).toBeNull();
+    expect(parsePostId('cfDraft_')).toBeNull();
+  });
+});
+
+describe('isConsentFormDraftId', () => {
+  it('is true for cfDraft_ prefixed ids', () => {
+    const id = parsePostId('cfDraft_1007')!;
+    expect(isConsentFormDraftId(id)).toBe(true);
+  });
+
+  it('is false for cf_ prefixed ids', () => {
+    const id = parsePostId('cf_1007')!;
+    expect(isConsentFormDraftId(id)).toBe(false);
+  });
+
+  it('is false for annDraft_ prefixed ids', () => {
+    const id = parsePostId('annDraft_1007')!;
+    expect(isConsentFormDraftId(id)).toBe(false);
+  });
+});
+
+describe('isConsentFormId', () => {
+  it('is true for cf_ prefixed ids', () => {
+    const id = parsePostId('cf_42')!;
+    expect(isConsentFormId(id)).toBe(true);
+  });
+
+  it('is false for cfDraft_ prefixed ids (does not match cf_ branch)', () => {
+    const id = parsePostId('cfDraft_42')!;
+    expect(isConsentFormId(id)).toBe(false);
+  });
+});

--- a/web/data/mock-pg-announcements.ts
+++ b/web/data/mock-pg-announcements.ts
@@ -190,7 +190,7 @@ export const PG_CONSENT_FORM_STATUS_BADGE: Record<
  */
 export interface PGConsentFormPost {
   kind: 'form';
-  id: ConsentFormId;
+  id: ConsentFormId | ConsentFormDraftId;
   title: string;
   description: string;
   richTextContent?: Record<string, unknown> | null;
@@ -240,22 +240,32 @@ export type AnnouncementDraftId = `annDraft_${string}` & {
   readonly __brand: 'AnnouncementDraftId';
 };
 export type ConsentFormId = `cf_${string}` & { readonly __brand: 'ConsentFormId' };
-export type PostId = AnnouncementId | AnnouncementDraftId | ConsentFormId;
+export type ConsentFormDraftId = `cfDraft_${string}` & { readonly __brand: 'ConsentFormDraftId' };
+export type PostId = AnnouncementId | AnnouncementDraftId | ConsentFormId | ConsentFormDraftId;
 
 export function isConsentFormId(id: PostId): id is ConsentFormId {
-  return id.startsWith('cf_');
+  return id.startsWith('cf_') && !id.startsWith('cfDraft_');
 }
 
 export function isAnnouncementDraftId(id: PostId): id is AnnouncementDraftId {
   return id.startsWith('annDraft_');
 }
 
+export function isConsentFormDraftId(id: PostId): id is ConsentFormDraftId {
+  return id.startsWith('cfDraft_');
+}
+
 /**
  * Parse a raw URL segment into a typed `PostId`. Returns `null` for anything
- * that isn't a numeric announcement ID, a `cf_<digits>` consent-form ID, or
- * an `annDraft_<digits>` draft announcement ID — callers treat that as a 404.
+ * that isn't a numeric announcement ID, a `cf_<digits>` consent-form ID, a
+ * `cfDraft_<digits>` consent-form draft ID, or an `annDraft_<digits>` draft
+ * announcement ID — callers treat that as a 404.
+ *
+ * More-specific prefixes are checked first so `cfDraft_` is not accidentally
+ * matched by the `cf_` branch.
  */
 export function parsePostId(raw: string): PostId | null {
+  if (/^cfDraft_\d+$/.test(raw)) return raw as ConsentFormDraftId;
   if (/^cf_\d+$/.test(raw)) return raw as ConsentFormId;
   if (/^annDraft_\d+$/.test(raw)) return raw as AnnouncementDraftId;
   if (/^\d+$/.test(raw)) return raw as AnnouncementId;
@@ -267,7 +277,7 @@ export function parsePostId(raw: string): PostId | null {
  * regex matching at call sites.
  */
 export function postKindFromId(id: PostId): 'announcement' | 'form' {
-  return isConsentFormId(id) ? 'form' : 'announcement';
+  return isConsentFormId(id) || isConsentFormDraftId(id) ? 'form' : 'announcement';
 }
 
 /**
@@ -288,7 +298,8 @@ export function postHref(post: PGPost, opts?: { edit?: boolean }): string {
 export function validatePostRoute(rawId: string, kindParam: string | null): PostId | null {
   const parsed = parsePostId(rawId);
   if (!parsed) return null;
-  if (kindParam === 'form' && !isConsentFormId(parsed)) return null;
-  if (kindParam === 'announcement' && isConsentFormId(parsed)) return null;
+  const isForm = isConsentFormId(parsed) || isConsentFormDraftId(parsed);
+  if (kindParam === 'form' && !isForm) return null;
+  if (kindParam === 'announcement' && isForm) return null;
   return parsed;
 }


### PR DESCRIPTION
## Summary
Mirror the announcement-draft routing fix (`annDraft_` brand) for consent forms. Today, clicking a DRAFT consent form from `/posts` 403s because the FE strips the `cfDraft_` prefix and hits the posted-only `/consentForms/:id` endpoint. This PR brands draft consent forms with `cfDraft_<id>` end-to-end and routes them to `/consentForms/drafts/:id`.

- New branded type `ConsentFormDraftId` + `isConsentFormDraftId` guard
- `parsePostId` recognizes `cfDraft_<digits>` (more-specific check before `cf_`)
- `mapConsentFormSummaryToPost` preserves the `cfDraft_` prefix for DRAFT-status rows
- New `fetchConsentFormDraftDetail` + `loadConsentFormDraftDetail` (minimal mapper — recipient/staff/attachment hydration deferred)
- `loadPostByKind` dispatches `cfDraft_` ids to the draft loader
- `PostDetailView` 404s `cfDraft_` ids defensively (drafts only editable, not viewable)
- `PostsView.handleDelete` routes form drafts to `deleteConsentFormDraft`
- Tests cover the brand parsing + summary mapping

## Test plan
- [ ] `pnpm test` — all green
- [ ] Manually: from `/posts` list, click a DRAFT consent form row → form opens in edit mode (currently 403s without this fix)
- [ ] Manually: delete a DRAFT consent form from list → uses draft endpoint, succeeds
- [ ] No regression: posted consent-form detail still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)