### PR TITLE
feat(web): PGTW-8 restrict rich-text editor to PGW's schema allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,10 @@
     "typescript": "^6.0.2",
     "vite": "^8.0.7",
     "vitest": "^4.1.5"
+  },
+  "pnpm": {
+    "overrides": {
+      "@tiptap/pm": "3.22.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tiptap/pm': 3.22.3
+
 importers:
 
   .:
@@ -1601,7 +1604,7 @@ packages:
   '@tiptap/core@3.22.3':
     resolution: {integrity: sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q==}
     peerDependencies:
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-blockquote@3.22.3':
     resolution: {integrity: sha512-IaUx3zh7yLHXzIXKL+fw/jzFhsIImdhJyw0lMhe8FfYrefFqXJFYW/sey6+L/e8B3AWvTksPA6VBwefzbH77JA==}
@@ -1617,7 +1620,7 @@ packages:
     resolution: {integrity: sha512-Y6zQjh0ypDg32HWgICEvmPSKjGLr39k3aDxxt/H0uQEZSfw4smT0hxUyyyjVjx68C6t6MTnwdfz0hPI5lL68vQ==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-bullet-list@3.22.3':
     resolution: {integrity: sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==}
@@ -1633,7 +1636,7 @@ packages:
     resolution: {integrity: sha512-RiQtEjDAPrHpdo6sw6b7fOw/PijqgFIsozKKkGcSeBgWHQuFg7q9OxJTj+l0e60rVwSu/5gmKEEobzM9bX+t2Q==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-code@3.22.3':
     resolution: {integrity: sha512-wafWTDQOuMKtXpZEuk1PFQmzopabBciNLryL90MB9S03MNLaQQZYLnmYkDBlzAaLAbgF5QiC+2XZQEBQuTVjFQ==}
@@ -1655,7 +1658,7 @@ packages:
     peerDependencies:
       '@floating-ui/dom': ^1.0.0
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-gapcursor@3.22.3':
     resolution: {integrity: sha512-L/Px4UeQEVG/D9WIlcAOIej+4wyIBCMUSYicSR+hW68UsObe4rxVbUas1QgidQKm6DOhoT7U7D4KQHA/Gdg/7A==}
@@ -1681,7 +1684,7 @@ packages:
     resolution: {integrity: sha512-wI2bFzScs+KgWeBH/BtypcVKeYelCyqV0RG8nxsZMWtPrBhqixzNd0Oi3gEKtjSjKUqMQ/kjJAIRuESr5UzlHA==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-italic@3.22.3':
     resolution: {integrity: sha512-LteA4cb4EGCiUtrK2JHvDF/Zg0/YqV4DUyHhAAho+oGEQDupZlsS6m0ia5wQcclkiTLzsoPrwcSNu6RDGQ16wQ==}
@@ -1692,7 +1695,7 @@ packages:
     resolution: {integrity: sha512-S8/P2o9pv6B3kqLjH2TRWwSAximGbciNc6R8/QcN6HWLYxp0N0JoqN3rZHl9VWIBAGRWc4zkt80dhqrl2xmgfQ==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-list-item@3.22.3':
     resolution: {integrity: sha512-80CNf4oO5y8+LdckT4CyMe1t01EyhpRrQC9H45JW20P7559Nrchp5my3vvMtIAJbpTPPZtcB7LwdzWGKsG5drg==}
@@ -1708,7 +1711,7 @@ packages:
     resolution: {integrity: sha512-rqvv/dtqwbX+8KnPv0eMYp6PnBcuhPMol5cv1GlS8Nq/Cxt68EWGUHBuTFesw+hdnRQLmKwzoO1DlRn7PhxYRQ==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/extension-ordered-list@3.22.3':
     resolution: {integrity: sha512-orAghtmd+K4Euu4BgI1hG+iZDXBYOyl5YTwiLBc2mQn+pqtZ9LqaH2us4ETwEwNP3/IWXGSAimUZ19nuL+eM2w==}
@@ -1744,7 +1747,7 @@ packages:
     resolution: {integrity: sha512-s5eiMq0m5N6N+W7dU6rd60KgZyyCD7FvtPNNswISfPr12EQwJBfbjWwTqd0UKNzA4fNrhQEERXnzORkykttPeA==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
 
   '@tiptap/pm@3.22.3':
     resolution: {integrity: sha512-NjfWjZuvrqmpICT+GZWNIjtOdhPyqFKDMtQy7tsQ5rErM9L2ZQdy/+T/BKSO1JdTeBhdg9OP+0yfsqoYp2aT6A==}
@@ -1753,7 +1756,7 @@ packages:
     resolution: {integrity: sha512-6MNr6z0PxwfJFs+BKhHcvPNvY+UV1PXgqzTiTM4Z9guml84iVZxv7ZOCSj1dFYTr3Bf1MiOs4hT1yvBFlTfIaQ==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
-      '@tiptap/pm': ^3.22.3
+      '@tiptap/pm': 3.22.3
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
       '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
       react: ^17.0.0 || ^18.0.0 || ^19.0.0

--- a/web/components/posts/RichTextToolbar.test.tsx
+++ b/web/components/posts/RichTextToolbar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RichTextToolbar } from './RichTextToolbar';
+
+describe('RichTextToolbar', () => {
+  it('only shows parity buttons (no H1/Strike/Link/Highlight)', () => {
+    render(<RichTextToolbar editor={null} />);
+    // Present
+    [
+      'Bold',
+      'Italic',
+      'Underline',
+      'Align left',
+      'Align center',
+      'Align right',
+      'Align justify',
+      'Bullet list',
+      'Numbered list',
+    ].forEach((label) => {
+      expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
+    });
+    // Absent
+    [
+      'Strikethrough',
+      'Inline code',
+      'Heading 1',
+      'Heading 2',
+      'Heading 3',
+      'Quote',
+      'Link',
+      'Highlight',
+    ].forEach((label) => {
+      expect(screen.queryByRole('button', { name: label })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/components/posts/RichTextToolbar.tsx
+++ b/web/components/posts/RichTextToolbar.tsx
@@ -1,20 +1,13 @@
 import type { Editor } from '@tiptap/react';
 import {
   AlignCenter,
+  AlignJustify,
   AlignLeft,
   AlignRight,
   Bold,
-  Code,
-  Heading1,
-  Heading2,
-  Heading3,
-  Highlighter,
   Italic,
-  Link as LinkIcon,
   List,
   ListOrdered,
-  Quote,
-  Strikethrough,
   Underline as UnderlineIcon,
 } from 'lucide-react';
 
@@ -80,21 +73,6 @@ function RichTextToolbar({ editor, className }: RichTextToolbarProps) {
       case 'underline':
         editor.chain().focus().toggleUnderline().run();
         break;
-      case 'strike':
-        editor.chain().focus().toggleStrike().run();
-        break;
-      case 'code':
-        editor.chain().focus().toggleCode().run();
-        break;
-      case 'h1':
-        editor.chain().focus().toggleHeading({ level: 1 }).run();
-        break;
-      case 'h2':
-        editor.chain().focus().toggleHeading({ level: 2 }).run();
-        break;
-      case 'h3':
-        editor.chain().focus().toggleHeading({ level: 3 }).run();
-        break;
       case 'alignLeft':
         editor.chain().focus().setTextAlign('left').run();
         break;
@@ -104,31 +82,16 @@ function RichTextToolbar({ editor, className }: RichTextToolbarProps) {
       case 'alignRight':
         editor.chain().focus().setTextAlign('right').run();
         break;
+      case 'alignJustify':
+        editor.chain().focus().setTextAlign('justify').run();
+        break;
       case 'bulletList':
         editor.chain().focus().toggleBulletList().run();
         break;
       case 'orderedList':
         editor.chain().focus().toggleOrderedList().run();
         break;
-      case 'blockquote':
-        editor.chain().focus().toggleBlockquote().run();
-        break;
-      case 'highlight':
-        editor.chain().focus().toggleHighlight().run();
-        break;
     }
-  }
-
-  function handleLink() {
-    if (!editor) return;
-    const previous = editor.getAttributes('link').href as string | undefined;
-    const url = window.prompt('Enter URL (leave empty to remove link)', previous ?? '');
-    if (url === null) return; // user cancelled
-    if (url === '') {
-      editor.chain().focus().extendMarkRange('link').unsetLink().run();
-      return;
-    }
-    editor.chain().focus().extendMarkRange('link').setLink({ href: url }).run();
   }
 
   return (
@@ -160,44 +123,6 @@ function RichTextToolbar({ editor, className }: RichTextToolbarProps) {
         disabled={disabled}
         onClick={() => toggle('underline')}
       />
-      <ToolbarButton
-        label="Strikethrough"
-        icon={<Strikethrough className="h-4 w-4" />}
-        active={editor?.isActive('strike')}
-        disabled={disabled}
-        onClick={() => toggle('strike')}
-      />
-      <ToolbarButton
-        label="Inline code"
-        icon={<Code className="h-4 w-4" />}
-        active={editor?.isActive('code')}
-        disabled={disabled}
-        onClick={() => toggle('code')}
-      />
-
-      <Divider />
-
-      <ToolbarButton
-        label="Heading 1"
-        icon={<Heading1 className="h-4 w-4" />}
-        active={editor?.isActive('heading', { level: 1 })}
-        disabled={disabled}
-        onClick={() => toggle('h1')}
-      />
-      <ToolbarButton
-        label="Heading 2"
-        icon={<Heading2 className="h-4 w-4" />}
-        active={editor?.isActive('heading', { level: 2 })}
-        disabled={disabled}
-        onClick={() => toggle('h2')}
-      />
-      <ToolbarButton
-        label="Heading 3"
-        icon={<Heading3 className="h-4 w-4" />}
-        active={editor?.isActive('heading', { level: 3 })}
-        disabled={disabled}
-        onClick={() => toggle('h3')}
-      />
 
       <Divider />
 
@@ -222,6 +147,13 @@ function RichTextToolbar({ editor, className }: RichTextToolbarProps) {
         disabled={disabled}
         onClick={() => toggle('alignRight')}
       />
+      <ToolbarButton
+        label="Align justify"
+        icon={<AlignJustify className="h-4 w-4" />}
+        active={editor?.isActive({ textAlign: 'justify' })}
+        disabled={disabled}
+        onClick={() => toggle('alignJustify')}
+      />
 
       <Divider />
 
@@ -238,30 +170,6 @@ function RichTextToolbar({ editor, className }: RichTextToolbarProps) {
         active={editor?.isActive('orderedList')}
         disabled={disabled}
         onClick={() => toggle('orderedList')}
-      />
-
-      <Divider />
-
-      <ToolbarButton
-        label="Quote"
-        icon={<Quote className="h-4 w-4" />}
-        active={editor?.isActive('blockquote')}
-        disabled={disabled}
-        onClick={() => toggle('blockquote')}
-      />
-      <ToolbarButton
-        label="Link"
-        icon={<LinkIcon className="h-4 w-4" />}
-        active={editor?.isActive('link')}
-        disabled={disabled}
-        onClick={handleLink}
-      />
-      <ToolbarButton
-        label="Highlight"
-        icon={<Highlighter className="h-4 w-4" />}
-        active={editor?.isActive('highlight')}
-        disabled={disabled}
-        onClick={() => toggle('highlight')}
       />
     </div>
   );

--- a/web/helpers/tiptap.test.ts
+++ b/web/helpers/tiptap.test.ts
@@ -1,0 +1,37 @@
+import { getSchema } from '@tiptap/core';
+import { describe, expect, it } from 'vitest';
+
+import { createRichTextExtensions } from './tiptap';
+
+describe('rich-text extension schema', () => {
+  it('exposes the PGW allowlist of nodes', () => {
+    const schema = getSchema(createRichTextExtensions());
+    const nodeNames = Object.keys(schema.nodes).sort();
+    // PGW allows these; anything else would fail `isValidSchema` server-side.
+    expect(nodeNames).toEqual(
+      expect.arrayContaining([
+        'doc',
+        'paragraph',
+        'text',
+        'bulletList',
+        'orderedList',
+        'listItem',
+        'hardBreak',
+      ]),
+    );
+    expect(nodeNames).not.toContain('heading');
+    expect(nodeNames).not.toContain('blockquote');
+    expect(nodeNames).not.toContain('codeBlock');
+    expect(nodeNames).not.toContain('horizontalRule');
+  });
+
+  it('exposes the PGW allowlist of marks', () => {
+    const schema = getSchema(createRichTextExtensions());
+    const markNames = Object.keys(schema.marks).sort();
+    expect(markNames).toEqual(expect.arrayContaining(['bold', 'italic', 'underline']));
+    expect(markNames).not.toContain('link');
+    expect(markNames).not.toContain('highlight');
+    expect(markNames).not.toContain('strike');
+    expect(markNames).not.toContain('code');
+  });
+});

--- a/web/helpers/tiptap.test.ts
+++ b/web/helpers/tiptap.test.ts
@@ -1,37 +1,50 @@
-import { getSchema } from '@tiptap/core';
 import { describe, expect, it } from 'vitest';
 
 import { createRichTextExtensions } from './tiptap';
 
+interface AnyExt {
+  name: string;
+  config: { addOptions: () => Record<string, unknown> };
+}
+
+function findExt(name: string): AnyExt {
+  const ext = createRichTextExtensions().find((e) => (e as unknown as AnyExt).name === name);
+  return ext as unknown as AnyExt;
+}
+
 describe('rich-text extension schema', () => {
-  it('exposes the PGW allowlist of nodes', () => {
-    const schema = getSchema(createRichTextExtensions());
-    const nodeNames = Object.keys(schema.nodes).sort();
-    // PGW allows these; anything else would fail `isValidSchema` server-side.
-    expect(nodeNames).toEqual(
-      expect.arrayContaining([
-        'doc',
-        'paragraph',
-        'text',
-        'bulletList',
-        'orderedList',
-        'listItem',
-        'hardBreak',
-      ]),
-    );
-    expect(nodeNames).not.toContain('heading');
-    expect(nodeNames).not.toContain('blockquote');
-    expect(nodeNames).not.toContain('codeBlock');
-    expect(nodeNames).not.toContain('horizontalRule');
+  it('StarterKit is configured to disable nodes not in PGW allowlist', () => {
+    const sk = findExt('starterKit');
+    expect(sk).toBeDefined();
+    const opts = sk.config.addOptions();
+    // PGW rejects these — must be disabled in StarterKit.
+    expect(opts.heading).toBe(false);
+    expect(opts.strike).toBe(false);
+    expect(opts.code).toBe(false);
+    expect(opts.blockquote).toBe(false);
+    expect(opts.codeBlock).toBe(false);
+    expect(opts.horizontalRule).toBe(false);
+    expect(opts.link).toBe(false);
+    // Underline is handled by the standalone extension below.
+    expect(opts.underline).toBe(false);
   });
 
-  it('exposes the PGW allowlist of marks', () => {
-    const schema = getSchema(createRichTextExtensions());
-    const markNames = Object.keys(schema.marks).sort();
-    expect(markNames).toEqual(expect.arrayContaining(['bold', 'italic', 'underline']));
-    expect(markNames).not.toContain('link');
-    expect(markNames).not.toContain('highlight');
-    expect(markNames).not.toContain('strike');
-    expect(markNames).not.toContain('code');
+  it('standalone Underline extension is present', () => {
+    const names = createRichTextExtensions().map((e) => (e as unknown as AnyExt).name);
+    expect(names).toContain('underline');
+  });
+
+  it('TextAlign is configured for paragraph + list nodes with all four alignments', () => {
+    const ta = findExt('textAlign');
+    expect(ta).toBeDefined();
+    const opts = ta.config.addOptions();
+    expect(opts.types).toEqual(['paragraph', 'orderedList', 'bulletList']);
+    expect(opts.alignments).toEqual(['left', 'center', 'right', 'justify']);
+  });
+
+  it('Link and Highlight extensions are not in the extension list', () => {
+    const names = createRichTextExtensions().map((e) => (e as unknown as AnyExt).name);
+    expect(names).not.toContain('link');
+    expect(names).not.toContain('highlight');
   });
 });

--- a/web/helpers/tiptap.ts
+++ b/web/helpers/tiptap.ts
@@ -3,8 +3,6 @@
 // the Tiptap schema lives here, not in two places that can drift.
 
 import CharacterCount from '@tiptap/extension-character-count';
-import Highlight from '@tiptap/extension-highlight';
-import Link from '@tiptap/extension-link';
 import TextAlign from '@tiptap/extension-text-align';
 import Underline from '@tiptap/extension-underline';
 import StarterKit from '@tiptap/starter-kit';
@@ -16,17 +14,30 @@ import StarterKit from '@tiptap/starter-kit';
  */
 export function createRichTextExtensions(opts?: { maxLength?: number }) {
   return [
-    // StarterKit v3 bundles link + underline; we disable them so the
-    // standalone extensions below register with our own config.
-    StarterKit.configure({ codeBlock: false, link: false, underline: false }),
-    Underline,
-    TextAlign.configure({ types: ['heading', 'paragraph'] }),
-    Link.configure({
-      openOnClick: false,
-      autolink: true,
-      protocols: ['http', 'https', 'mailto'],
+    // StarterKit ships many extensions bundled — disable every node/mark that
+    // PGW's schema validator (`pgw-web/src/server/utils/richTextUtil.ts#101`)
+    // rejects. The final allowlist matches `pgw-web` exactly:
+    // doc, paragraph, text, bold, italic, underline, bulletList, orderedList,
+    // listItem, hardBreak, history.
+    StarterKit.configure({
+      // Use the standalone Underline extension below for consistency with pgw-web.
+      underline: false,
+      // Not allowed by PGW's schema:
+      link: false,
+      heading: false,
+      strike: false,
+      code: false,
+      blockquote: false,
+      codeBlock: false,
+      horizontalRule: false,
     }),
-    Highlight,
+    Underline,
+    // `justify` matches pgw-web's alignment set. Only paragraph + lists get
+    // textAlign (pgw-web uses `['paragraph', 'orderedList', 'bulletList']`).
+    TextAlign.configure({
+      types: ['paragraph', 'orderedList', 'bulletList'],
+      alignments: ['left', 'center', 'right', 'justify'],
+    }),
     ...(opts?.maxLength != null ? [CharacterCount.configure({ limit: opts.maxLength })] : []),
   ];
 }


### PR DESCRIPTION
## Summary
Strict parity with PGW's server-side Tiptap schema validator (`pgw-web/src/server/utils/richTextUtil.ts#101`). Any node/mark outside their allowlist produces `-4003 invalid rich text schema` on submit, so removing the toolbar affordances prevents teachers from typing content that would silently fail.

### Removed
- Toolbar buttons: Strikethrough, Inline code, Heading 1/2/3, Quote (blockquote), Link, Highlight.
- Extensions: Link, Highlight. StarterKit re-configured to disable `heading`, `strike`, `code`, `blockquote`, `codeBlock`, `horizontalRule`.

### Added
- `justify` alignment (matches PGW's CustomTextAlign config).
- `Align justify` toolbar button.

### Allowlist now matches pgw-web exactly
doc · paragraph (L/C/R/J) · text · bold · italic · underline · bulletList · orderedList · listItem · hardBreak · history

### Bonus: fixed pre-existing `@tiptap/pm` dual-version TS error
Added `pnpm.overrides` to pin `@tiptap/pm@3.22.3` — the lockfile previously had two instances (`3.22.3` and `3.22.4`) causing TypeScript structural type mismatches in `PostPreview.tsx` and `RichTextEditor.tsx`.

## Test plan
- [ ] `pnpm test` — new schema-allowlist tests pass
- [ ] Manually: toolbar shows only the parity buttons
- [ ] Paste text with lists / hardBreak / justify → renders correctly
- [ ] Post a form/announcement — no `-4003` error

**UX note:** this removes H1/H2/H3, Strike, Code, Quote, Link, Highlight from the toolbar. Any drafts saved with those marks before this change will render as plain text on reload (Tiptap's schema coerces unknown marks/nodes silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)