### PR TITLE
feat(web): PGTW-7 staff-in-charge helper text + unknown-staff chip

### DIFF
--- a/web/containers/CreatePostView.reducer.test.ts
+++ b/web/containers/CreatePostView.reducer.test.ts
@@ -1,10 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
+import type { PGApiSchoolStaff } from '~/api/types';
+
 import {
   __formReducer as formReducer,
   __INITIAL_STATE as INITIAL_STATE,
+  __ownerIdsToSelectedStaff as ownerIdsToSelectedStaff,
+  __staffHelperText as staffHelperText,
   type UploadingFile,
 } from './CreatePostView';
+
+const alice: PGApiSchoolStaff = {
+  staffId: 1,
+  name: 'Alice Tan',
+  className: 'P1A',
+  email: 'alice@school.sg',
+};
 
 function makeFileUpload(partial: Partial<UploadingFile> = {}): UploadingFile {
   return {
@@ -130,5 +141,44 @@ describe('formReducer — uploads', () => {
     const next = formReducer(state, { type: 'SET_COVER_PHOTO', localId: 'p2' });
     expect(next.photos[0].isCover).toBe(false);
     expect(next.photos[1].isCover).toBe(true);
+  });
+});
+
+describe('staffHelperText', () => {
+  it('returns announcement text for announcement kind', () => {
+    expect(staffHelperText('announcement')).toBe(
+      'These staff will be able to view read status, and delete the announcement.',
+    );
+  });
+
+  it('returns form text for form kind', () => {
+    expect(staffHelperText('form')).toBe(
+      'These staff will be able to view and edit responses, and delete the form.',
+    );
+  });
+});
+
+describe('ownerIdsToSelectedStaff', () => {
+  it('maps known staff IDs to chips using the roster', () => {
+    const result = ownerIdsToSelectedStaff([1], [alice], undefined);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: '1', label: 'Alice Tan' });
+  });
+
+  it('shows unknown-staff placeholder chip for IDs absent from the roster', () => {
+    const result = ownerIdsToSelectedStaff([1, 999], [alice], undefined);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toMatchObject({ id: '999', label: 'Unknown staff' });
+  });
+
+  it('falls back to name-match when ownerIds is empty and fallbackName matches a roster entry', () => {
+    const result = ownerIdsToSelectedStaff([], [alice], 'Alice Tan');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: '1', label: 'Alice Tan' });
+  });
+
+  it('returns empty array when ownerIds is empty and fallbackName has no roster match', () => {
+    const result = ownerIdsToSelectedStaff([], [alice], 'Bob Lim');
+    expect(result).toHaveLength(0);
   });
 });

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -541,15 +541,12 @@ function ownerIdsToSelectedStaff(
 ): SelectedEntity[] {
   if (ownerIds && ownerIds.length > 0) {
     const byId = new Map(staff.map((s) => [s.staffId, s]));
-    return ownerIds
-      .map((id) => byId.get(id))
-      .filter((s): s is PGApiSchoolStaff => s !== undefined)
-      .map((s) => ({
-        id: s.staffId.toString(),
-        label: s.name,
-        type: 'individual',
-        count: 1,
-      }));
+    return ownerIds.map((id) => {
+      const s = byId.get(id);
+      return s
+        ? { id: s.staffId.toString(), label: s.name, type: 'individual' as const, count: 1 }
+        : { id: id.toString(), label: 'Unknown staff', type: 'individual' as const, count: 1 };
+    });
   }
   // Fallback: detail response only carried `staffName`. Match by name so
   // legacy/summary-only payloads still hydrate the staff selector.
@@ -558,6 +555,16 @@ function ownerIdsToSelectedStaff(
     ? [{ id: match.staffId.toString(), label: match.name, type: 'individual', count: 1 }]
     : [];
 }
+
+export const __ownerIdsToSelectedStaff = ownerIdsToSelectedStaff;
+
+function staffHelperText(kind: 'announcement' | 'form'): string {
+  return kind === 'announcement'
+    ? 'These staff will be able to view read status, and delete the announcement.'
+    : 'These staff will be able to view and edit responses, and delete the form.';
+}
+
+export const __staffHelperText = staffHelperText;
 
 /**
  * Convert a `PGConsentFormPost.event` (ISO timestamps from PG) back to the
@@ -1023,9 +1030,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
               {/* Staff in charge */}
               <div className="space-y-1.5">
                 <Label>Staff in charge</Label>
-                <p className="text-sm text-muted-foreground">
-                  These staff will be able to view read status, and delete the post.
-                </p>
+                <p className="text-sm text-muted-foreground">{staffHelperText(state.kind)}</p>
                 <StaffSelector
                   value={state.selectedStaff}
                   onChange={(sel) => dispatch({ type: 'SET_STAFF', payload: sel })}


### PR DESCRIPTION
## Summary
- Helper text under "Staff in charge" now varies by post kind: announcements say "view read status, and delete the announcement"; forms say "view and edit responses, and delete the form"
- Staff IDs that no longer exist in the school roster now produce an "Unknown staff" chip instead of being silently dropped on edit-mode rehydration

## Test Plan
- [ ] Create post → switch between Post and Post with Response → confirm helper text updates
- [ ] Unknown-staff chip covered by unit tests (`ownerIdsToSelectedStaff` — ghost chip case)