### PR TITLE
fix(web): PGTW-4 dispatch duplicate to PGW's 4 endpoints + deep-link toast

### DIFF
--- a/server/internal/pg/mock.go
+++ b/server/internal/pg/mock.go
@@ -81,7 +81,7 @@ func registerMockAnnouncements(mux *http.ServeMux) {
 	// 2-segment POSTs
 	mux.HandleFunc("POST /api/web/2/staff/announcements", jsonStub(http.StatusCreated, `{"postId":1041}`))
 	mux.HandleFunc("POST /api/web/2/staff/announcements/drafts", jsonStub(http.StatusCreated, `{"announcementDraftId":202}`))
-	mux.HandleFunc("POST /api/web/2/staff/announcements/duplicate", jsonStub(http.StatusCreated, `{"postId":1042}`))
+	mux.HandleFunc("POST /api/web/2/staff/announcements/duplicate", jsonStub(http.StatusCreated, `{"announcementDraftId":1042,"updatedAt":"2026-04-28T00:00:00.000Z"}`))
 
 	// 3-segment POST dispatcher: drafts/schedule | drafts/duplicate | {id}/addStaffInCharge
 	mux.HandleFunc("POST /api/web/2/staff/announcements/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
@@ -90,7 +90,7 @@ func registerMockAnnouncements(mux *http.ServeMux) {
 		case first == "drafts" && second == "schedule":
 			jsonStub(http.StatusOK, `{}`)(w, r)
 		case first == "drafts" && second == "duplicate":
-			jsonStub(http.StatusCreated, `{"announcementDraftId":203}`)(w, r)
+			jsonStub(http.StatusCreated, `{"announcementDraftId":203,"updatedAt":"2026-04-28T00:00:00.000Z"}`)(w, r)
 		case second == "addStaffInCharge":
 			jsonStub(http.StatusOK, `{}`)(w, r)
 		default:
@@ -151,7 +151,7 @@ func registerMockConsentForms(mux *http.ServeMux) {
 	// 2-segment POSTs
 	mux.HandleFunc("POST /api/web/2/staff/consentForms", jsonStub(http.StatusCreated, `{"consentFormId":301}`))
 	mux.HandleFunc("POST /api/web/2/staff/consentForms/drafts", jsonStub(http.StatusCreated, `{"consentFormDraftId":401}`))
-	mux.HandleFunc("POST /api/web/2/staff/consentForms/duplicate", jsonStub(http.StatusCreated, `{"consentFormDraftId":402}`))
+	mux.HandleFunc("POST /api/web/2/staff/consentForms/duplicate", jsonStub(http.StatusCreated, `{"consentFormDraftId":402,"updatedAt":"2026-04-28T00:00:00.000Z"}`))
 
 	// 3-segment POST dispatcher: drafts/schedule | drafts/duplicate | {id}/addStaffInCharge
 	mux.HandleFunc("POST /api/web/2/staff/consentForms/{first}/{second}", func(w http.ResponseWriter, r *http.Request) {
@@ -160,7 +160,7 @@ func registerMockConsentForms(mux *http.ServeMux) {
 		case first == "drafts" && second == "schedule":
 			jsonStub(http.StatusOK, `{}`)(w, r)
 		case first == "drafts" && second == "duplicate":
-			jsonStub(http.StatusCreated, `{"consentFormDraftId":403}`)(w, r)
+			jsonStub(http.StatusCreated, `{"consentFormDraftId":403,"updatedAt":"2026-04-28T00:00:00.000Z"}`)(w, r)
 		case second == "addStaffInCharge":
 			jsonStub(http.StatusOK, `{}`)(w, r)
 		default:

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -43,7 +43,8 @@ import type {
   PGApiCreateConsentFormPayload,
   PGApiCreateDraftPayload,
   PGApiCustomGroupsList,
-  PGApiDuplicatePayload,
+  PGApiDuplicateAnnouncementResponse,
+  PGApiDuplicateConsentFormResponse,
   PGApiGroupsAssigned,
   PGApiScheduleDraftPayload,
   PGApiSchoolClass,
@@ -480,9 +481,18 @@ export function updateDraft(
   return mutateApi('PUT', `/announcements/drafts/${draftId}`, body, options);
 }
 
-/** Duplicate an existing announcement. */
-export function duplicateAnnouncement(payload: PGApiDuplicatePayload) {
-  return mutateApi<{ postId: number }>('POST', '/announcements/duplicate', payload);
+/** Duplicate a posted announcement. PGW returns the new draft id. */
+export function duplicateAnnouncement(announcementId: number) {
+  return mutateApi<PGApiDuplicateAnnouncementResponse>('POST', '/announcements/duplicate', {
+    announcementId,
+  });
+}
+
+/** Duplicate an existing announcement draft. PGW returns the new draft id. */
+export function duplicateAnnouncementDraft(announcementDraftId: number) {
+  return mutateApi<PGApiDuplicateAnnouncementResponse>('POST', '/announcements/drafts/duplicate', {
+    announcementDraftId,
+  });
 }
 
 /** Delete a posted announcement. */
@@ -601,8 +611,18 @@ export function cancelConsentFormSchedule(draftId: number, options: { signal?: A
 }
 
 /** Duplicate an existing consent form. Returns the new draft id. */
-export function duplicateConsentForm(payload: { consentFormId: number }) {
-  return mutateApi<{ consentFormDraftId: number }>('POST', '/consentForms/duplicate', payload);
+/** Duplicate a posted consent form. PGW returns the new draft id. */
+export function duplicateConsentForm(consentFormId: number) {
+  return mutateApi<PGApiDuplicateConsentFormResponse>('POST', '/consentForms/duplicate', {
+    consentFormId,
+  });
+}
+
+/** Duplicate an existing consent-form draft. PGW returns the new draft id. */
+export function duplicateConsentFormDraft(consentFormDraftId: number) {
+  return mutateApi<PGApiDuplicateConsentFormResponse>('POST', '/consentForms/drafts/duplicate', {
+    consentFormDraftId,
+  });
 }
 
 export function deleteConsentForm(formId: ConsentFormId) {

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -226,8 +226,20 @@ export interface PGApiScheduleDraftPayload {
   scheduledSendAt: string;
 }
 
-export interface PGApiDuplicatePayload {
-  postId: number;
+/**
+ * PGW returns the same envelope shape for all four duplicate endpoints
+ * (`/announcements/duplicate`, `/announcements/drafts/duplicate`,
+ * `/consentForms/duplicate`, `/consentForms/drafts/duplicate`): the new draft's
+ * id and an `updatedAt` timestamp. Field name varies by post kind.
+ */
+export interface PGApiDuplicateAnnouncementResponse {
+  announcementDraftId: number;
+  updatedAt: string;
+}
+
+export interface PGApiDuplicateConsentFormResponse {
+  consentFormDraftId: number;
+  updatedAt: string;
 }
 
 // ─── Consent Forms ──────────────────────────────────────────────────────────

--- a/web/containers/PostsView.test.tsx
+++ b/web/containers/PostsView.test.tsx
@@ -9,7 +9,7 @@ import type {
   PGPost,
 } from '~/data/mock-pg-announcements';
 
-import { matchesPostFilters } from './PostsView';
+import { __duplicateDraftHref as duplicateDraftHref, matchesPostFilters } from './PostsView';
 
 const baseFilter = { ...DEFAULT_POST_FILTERS, tab: 'view-only' as const, query: '' };
 
@@ -161,5 +161,17 @@ describe('matchesPostFilters', () => {
     expect(matchesPostFilters(dated, { ...baseFilter, dateTo: '2026-04-14' })).toBe(false);
     // Rows with no date are excluded when any bound is set
     expect(matchesPostFilters(row(mine), { ...baseFilter, dateFrom: '2026-04-01' })).toBe(false);
+  });
+});
+
+describe('duplicateDraftHref', () => {
+  it('builds the announcement-draft edit URL for the announcement kind', () => {
+    expect(duplicateDraftHref('announcement', 42)).toBe(
+      '/posts/annDraft_42/edit?kind=announcement',
+    );
+  });
+
+  it('builds the consent-form-draft edit URL for the form kind', () => {
+    expect(duplicateDraftHref('form', 99)).toBe('/posts/cfDraft_99/edit?kind=form');
   });
 });

--- a/web/containers/PostsView.tsx
+++ b/web/containers/PostsView.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, Copy, MoreHorizontal, Plus, Search, Trash2, Users } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { Link, useLoaderData, useNavigate, useRevalidator } from 'react-router';
+import { toast } from 'sonner';
 
 import {
   deleteAnnouncement,
@@ -8,7 +9,9 @@ import {
   deleteConsentFormDraft,
   deleteDraft,
   duplicateAnnouncement,
+  duplicateAnnouncementDraft,
   duplicateConsentForm,
+  duplicateConsentFormDraft,
   getConfigs,
   loadConsentPostsList,
   loadPostsList,
@@ -53,6 +56,14 @@ import {
 import type { AnnouncementId, PGPost } from '~/data/mock-pg-announcements';
 import { formatDate, getRelevantDate, isLowReadRate } from '~/helpers/dateTime';
 import { notify } from '~/lib/notify';
+
+function duplicateDraftHref(kind: 'announcement' | 'form', draftId: number): string {
+  return kind === 'announcement'
+    ? `/posts/annDraft_${draftId}/edit?kind=announcement`
+    : `/posts/cfDraft_${draftId}/edit?kind=form`;
+}
+
+export const __duplicateDraftHref = duplicateDraftHref;
 
 type PostTab = 'view-only' | 'with-responses';
 
@@ -154,6 +165,7 @@ export function matchesPostFilters(row: PostRowData, filters: PostFilterQuery): 
 const PostsView: React.FC = () => {
   const { rows: posts, configs } = useLoaderData<PostsLoaderData>();
   const revalidator = useRevalidator();
+  const navigate = useNavigate();
   const [tab, setTab] = useState<PostTab>('view-only');
   const [filters, setFilters] = useState<PostFilters>(DEFAULT_POST_FILTERS);
   const [searchQuery, setSearchQuery] = useState('');
@@ -185,23 +197,28 @@ const PostsView: React.FC = () => {
       // `annDraft_`, or bare digits for posted announcements). Strip the prefix
       // per brand so the numeric id we send upstream is never NaN.
       const numericTail = (id: string, prefix: string) => Number(id.slice(prefix.length));
-      const promise =
+      // PGW exposes four duplicate endpoints — posted vs draft × ann vs form —
+      // each with a distinct request body field name and response field name.
+      // Dispatch in two parallel branches so TypeScript narrows the response
+      // shape cleanly per kind.
+      const promise: Promise<number> =
         row.kind === 'announcement'
-          ? duplicateAnnouncement({
-              postId: isAnnouncementDraftId(row.id)
-                ? numericTail(row.id, 'annDraft_')
-                : Number(row.id),
-            })
-          : duplicateConsentForm({
-              consentFormId: isConsentFormDraftId(row.id)
-                ? numericTail(row.id, 'cfDraft_')
-                : numericTail(row.id, 'cf_'),
-            });
+          ? (isAnnouncementDraftId(row.id)
+              ? duplicateAnnouncementDraft(numericTail(row.id, 'annDraft_'))
+              : duplicateAnnouncement(Number(row.id))
+            ).then((r) => r.announcementDraftId)
+          : (isConsentFormDraftId(row.id)
+              ? duplicateConsentFormDraft(numericTail(row.id, 'cfDraft_'))
+              : duplicateConsentForm(numericTail(row.id, 'cf_'))
+            ).then((r) => r.consentFormDraftId);
 
       promise
-        .then(() => {
+        .then((draftId) => {
           revalidator.revalidate();
-          notify.success('Post duplicated.');
+          const href = duplicateDraftHref(row.kind, draftId);
+          toast.success(`'${row.title}' has been duplicated.`, {
+            action: { label: 'View draft', onClick: () => navigate(href) },
+          });
         })
         .catch(() => {
           // Surface every failure, including PGError — the global handler
@@ -210,7 +227,7 @@ const PostsView: React.FC = () => {
           notify.error('Failed to duplicate post.');
         });
     },
-    [revalidator],
+    [revalidator, navigate],
   );
 
   const [pendingDelete, setPendingDelete] = useState<PostRowData | null>(null);


### PR DESCRIPTION
## Summary
- Pre-existing bug: duplicate has been broken in proxy mode against real PGW. We sent `{postId}` but PGW expects `{announcementId}` / `{consentFormId}` / `{announcementDraftId}` / `{consentFormDraftId}` depending on which of the 4 endpoints we hit
- Replaced single client method with 4 typed methods matching PGW's 4 endpoints (posted × draft × announcement × consent-form)
- `handleDuplicate` now dispatches to the right endpoint by post kind × draft-ness, reads the right response field, and shows a toast with a "View draft" deep-link to the new draft's edit page (mirrors PGW's "view it here" link)
- Mock BFF response shapes updated to match real PGW (`{announcementDraftId, updatedAt}` / `{consentFormDraftId, updatedAt}`)

## Test Plan
- [x] Click Duplicate on a posted announcement → toast appears with "View draft" → click navigates to `/posts/annDraft_<id>/edit?kind=announcement`
- [x] Click Duplicate on a draft announcement → routes to `/announcements/drafts/duplicate`
- [x] Click Duplicate on a posted consent form → toast deep-links to `/posts/cfDraft_<id>/edit?kind=form`
- [x] Click Duplicate on a draft consent form → routes to `/consentForms/drafts/duplicate`
- [x] Unit tests cover `duplicateDraftHref` URL builder