### PR TITLE
fix(web): PGTW-3 dispatch schedule/reschedule to PGW's correct endpoints + align write payload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,12 @@ services:
       DB_LOCAL_WRITER_CONNECTION_CONFIG: '{"username":"pg-local","password":"${MYSQL_PASSWORD}","host":"mysql-master","connectionEndpoint":"mysql-master","port":"3306"}'
       DB_LOCAL_READER_CONNECTION_CONFIG: '{"username":"pg-local-read","password":"${MYSQL_PASSWORD_READ}","host":"mysql-replica","connectionEndpoint":"mysql-replica","port":"3306"}'
       REDIS_URL: redis://redis:6379
+      # PGW's schedule-window check (`isDateWithinDayTimeWindow`) compares the
+      # incoming `scheduledDateTime` against `07:00`–`21:55` in the *server's*
+      # local TZ. Production runs in Asia/Singapore so SGT clock faces line up
+      # with the window; without this the local UTC container rejects most SGT
+      # picks (08:00 SGT → 00:00 UTC, outside 07:00–21:55).
+      TZ: Asia/Singapore
     depends_on:
       mysql-master:
         condition: service_healthy

--- a/web/api/client.test.ts
+++ b/web/api/client.test.ts
@@ -6,16 +6,20 @@ import {
   createDraft,
   rescheduleAnnouncementDraft,
   rescheduleConsentFormDraft,
+  scheduleExistingAnnouncementDraft,
+  scheduleExistingConsentFormDraft,
+  scheduleNewAnnouncementDraft,
+  scheduleNewConsentFormDraft,
   updateDraft,
 } from './client';
 import { PGCsrfError, PGRedirectError, PGTimeoutError } from './errors';
-import type { PGApiCreateDraftPayload } from './types';
+import type { PGApiCreateConsentFormDraftPayload, PGApiCreateDraftPayload } from './types';
 
 const base: PGApiCreateDraftPayload = {
   title: 'Draft',
   richTextContent: '{"type":"doc","content":[]}',
   enquiryEmailAddress: 'draft@moe.edu.sg',
-  recipients: { classIds: [], customGroupIds: [], ccaIds: [], levelIds: [] },
+  studentGroups: [],
 };
 
 function mockFetch(body: unknown, status = 200) {
@@ -73,13 +77,13 @@ describe('rescheduleAnnouncementDraft (U3)', () => {
     vi.stubGlobal('fetch', mockFetch(undefined, 204));
   });
 
-  it('PUTs to /announcements/drafts/schedule/:id with the new scheduledSendAt', async () => {
+  it('PUTs to /announcements/drafts/:id/rescheduleSchedule with body { scheduledDateTime }', async () => {
     await rescheduleAnnouncementDraft(123, { scheduledSendAt: '2026-05-01T09:15:00+08:00' });
     const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(call[0]).toMatch(/\/announcements\/drafts\/schedule\/123$/);
+    expect(call[0]).toMatch(/\/announcements\/drafts\/123\/rescheduleSchedule$/);
     expect(call[1].method).toBe('PUT');
     expect(JSON.parse(call[1].body as string)).toEqual({
-      scheduledSendAt: '2026-05-01T09:15:00+08:00',
+      scheduledDateTime: '2026-05-01T09:15:00+08:00',
     });
   });
 });
@@ -89,11 +93,14 @@ describe('rescheduleConsentFormDraft (U3)', () => {
     vi.stubGlobal('fetch', mockFetch(undefined, 204));
   });
 
-  it('PUTs to /consentForms/drafts/schedule/:id with the new scheduledSendAt', async () => {
+  it('PUTs to /consentForms/drafts/:id/rescheduleSchedule with body { scheduledDateTime }', async () => {
     await rescheduleConsentFormDraft(401, { scheduledSendAt: '2026-05-02T10:00:00+08:00' });
     const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(call[0]).toMatch(/\/consentForms\/drafts\/schedule\/401$/);
+    expect(call[0]).toMatch(/\/consentForms\/drafts\/401\/rescheduleSchedule$/);
     expect(call[1].method).toBe('PUT');
+    expect(JSON.parse(call[1].body as string)).toEqual({
+      scheduledDateTime: '2026-05-02T10:00:00+08:00',
+    });
   });
 });
 
@@ -302,5 +309,100 @@ describe('updateDraft', () => {
     const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[0]).toMatch(/\/announcements\/drafts\/123$/);
     expect(call[1].method).toBe('PUT');
+  });
+});
+
+const formBase: PGApiCreateConsentFormDraftPayload = {
+  title: 'Form',
+  richTextContent: '{"type":"doc","content":[]}',
+  enquiryEmailAddress: 'form@moe.edu.sg',
+  responseType: 'YES_NO',
+  consentByDate: '2026-05-10',
+  addReminderType: 'NONE',
+  studentGroups: [],
+};
+
+describe('scheduleNewAnnouncementDraft', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ body: { announcementDraftId: 1042, updatedAt: 't' }, resultCode: 1 }),
+    );
+  });
+
+  it('POSTs to /announcements/drafts/schedule with body field { scheduledDateTime }', async () => {
+    await scheduleNewAnnouncementDraft({ ...base, scheduledSendAt: '2026-05-01T09:15:00+08:00' });
+    const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toMatch(/\/announcements\/drafts\/schedule$/);
+    expect(call[1].method).toBe('POST');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.scheduledDateTime).toBe('2026-05-01T09:15:00+08:00');
+    expect(body.scheduledSendAt).toBeUndefined();
+  });
+});
+
+describe('scheduleExistingAnnouncementDraft', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ body: { announcementDraftId: 99, updatedAt: 't' }, resultCode: 1 }),
+    );
+  });
+
+  it('PUTs to /announcements/drafts/schedule/:id with body field { scheduledDateTime }', async () => {
+    await scheduleExistingAnnouncementDraft(99, {
+      ...base,
+      scheduledSendAt: '2026-05-02T10:00:00+08:00',
+    });
+    const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toMatch(/\/announcements\/drafts\/schedule\/99$/);
+    expect(call[1].method).toBe('PUT');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.scheduledDateTime).toBe('2026-05-02T10:00:00+08:00');
+    expect(body.scheduledSendAt).toBeUndefined();
+  });
+});
+
+describe('scheduleNewConsentFormDraft', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ body: { consentFormDraftId: 401, updatedAt: 't' }, resultCode: 1 }),
+    );
+  });
+
+  it('POSTs to /consentForms/drafts/schedule with body field { scheduledDateTime }', async () => {
+    await scheduleNewConsentFormDraft({
+      ...formBase,
+      scheduledSendAt: '2026-05-03T11:00:00+08:00',
+    });
+    const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toMatch(/\/consentForms\/drafts\/schedule$/);
+    expect(call[1].method).toBe('POST');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.scheduledDateTime).toBe('2026-05-03T11:00:00+08:00');
+    expect(body.scheduledSendAt).toBeUndefined();
+  });
+});
+
+describe('scheduleExistingConsentFormDraft', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetch({ body: { consentFormDraftId: 402, updatedAt: 't' }, resultCode: 1 }),
+    );
+  });
+
+  it('PUTs to /consentForms/drafts/schedule/:id with body field { scheduledDateTime }', async () => {
+    await scheduleExistingConsentFormDraft(402, {
+      ...formBase,
+      scheduledSendAt: '2026-05-04T12:00:00+08:00',
+    });
+    const call = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toMatch(/\/consentForms\/drafts\/schedule\/402$/);
+    expect(call[1].method).toBe('PUT');
+    const body = JSON.parse(call[1].body as string);
+    expect(body.scheduledDateTime).toBe('2026-05-04T12:00:00+08:00');
+    expect(body.scheduledSendAt).toBeUndefined();
   });
 });

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -46,7 +46,6 @@ import type {
   PGApiDuplicateAnnouncementResponse,
   PGApiDuplicateConsentFormResponse,
   PGApiGroupsAssigned,
-  PGApiScheduleDraftPayload,
   PGApiSchoolClass,
   PGApiSchoolStaffList,
   PGApiSchoolStudent,
@@ -439,22 +438,58 @@ export function createDraft(
   return mutateApi('POST', '/announcements/drafts', body, options);
 }
 
-/** Schedule a draft for future sending. */
-export function scheduleDraft(payload: PGApiScheduleDraftPayload) {
-  return mutateApi<void>('POST', '/announcements/drafts/schedule', payload);
+/**
+ * Schedule a NEW announcement (single round-trip — creates the draft and
+ * sets status=SCHEDULED). Same body shape as `createDraft` plus a required
+ * `scheduledDateTime`. PGW's plain `/drafts` endpoint never flips a draft
+ * to SCHEDULED, so anything intended for future send must go through here.
+ */
+export function scheduleNewAnnouncementDraft(
+  payload: PGApiCreateDraftPayload & { scheduledSendAt: string },
+  options: { signal?: AbortSignal } = {},
+): Promise<{ announcementDraftId: number; updatedAt: string }> {
+  const body = {
+    ...toPGCreatePayload(payload),
+    scheduledDateTime: payload.scheduledSendAt,
+  };
+  return mutateApi('POST', '/announcements/drafts/schedule', body, options);
+}
+
+/**
+ * Schedule an EXISTING announcement draft. PGW: PUT `/drafts/schedule/:id`
+ * with the full draft payload + `scheduledDateTime`. Distinct from `updateDraft`
+ * — only this endpoint flips status from DRAFT → SCHEDULED.
+ */
+export function scheduleExistingAnnouncementDraft(
+  draftId: number,
+  payload: PGApiCreateDraftPayload & { scheduledSendAt: string },
+  options: { signal?: AbortSignal } = {},
+): Promise<{ announcementDraftId: number; updatedAt: string }> {
+  const body = {
+    ...toPGCreatePayload(payload),
+    scheduledDateTime: payload.scheduledSendAt,
+  };
+  return mutateApi('PUT', `/announcements/drafts/schedule/${draftId}`, body, options);
 }
 
 /**
  * Reschedule an already-scheduled announcement draft (U3). Distinct from
  * `updateDraft` — PGW exposes a dedicated endpoint so reschedule-in-window
- * races don't collide with generic field updates.
+ * races don't collide with generic field updates. Body field name (`scheduledDateTime`)
+ * differs from the create-draft scheduling field (`scheduledSendAt`); both
+ * carry an ISO 8601 timestamp in SGT.
  */
 export function rescheduleAnnouncementDraft(
   draftId: number,
   payload: { scheduledSendAt: string },
   options: { signal?: AbortSignal } = {},
 ) {
-  return mutateApi<void>('PUT', `/announcements/drafts/schedule/${draftId}`, payload, options);
+  return mutateApi<void>(
+    'PUT',
+    `/announcements/drafts/${draftId}/rescheduleSchedule`,
+    { scheduledDateTime: payload.scheduledSendAt },
+    options,
+  );
 }
 
 /**
@@ -593,6 +628,39 @@ export function updateConsentFormDueDate(formId: number, payload: { consentByDat
 }
 
 /**
+ * Schedule a NEW consent form (single round-trip — creates the draft and sets
+ * status=SCHEDULED). Same body shape as `createConsentFormDraft` plus a
+ * required `scheduledDateTime`. Mirrors `scheduleNewAnnouncementDraft`.
+ */
+export function scheduleNewConsentFormDraft(
+  payload: PGApiCreateConsentFormDraftPayload & { scheduledSendAt: string },
+  options: { signal?: AbortSignal } = {},
+): Promise<{ consentFormDraftId: number; updatedAt: string }> {
+  const body = {
+    ...toPGConsentFormDraftPayload(payload),
+    scheduledDateTime: payload.scheduledSendAt,
+  };
+  return mutateApi('POST', '/consentForms/drafts/schedule', body, options);
+}
+
+/**
+ * Schedule an EXISTING consent-form draft. PGW: PUT `/drafts/schedule/:id`
+ * with the full draft payload + `scheduledDateTime`. Distinct from
+ * `updateConsentFormDraft` — only this endpoint flips status to SCHEDULED.
+ */
+export function scheduleExistingConsentFormDraft(
+  draftId: number,
+  payload: PGApiCreateConsentFormDraftPayload & { scheduledSendAt: string },
+  options: { signal?: AbortSignal } = {},
+): Promise<{ consentFormDraftId: number; updatedAt: string }> {
+  const body = {
+    ...toPGConsentFormDraftPayload(payload),
+    scheduledDateTime: payload.scheduledSendAt,
+  };
+  return mutateApi('PUT', `/consentForms/drafts/schedule/${draftId}`, body, options);
+}
+
+/**
  * Reschedule an already-scheduled consent-form draft (U3). Mirrors
  * `rescheduleAnnouncementDraft`; PGW keeps these as two endpoint families,
  * so containers pick the right helper by the post's `kind`.
@@ -602,7 +670,12 @@ export function rescheduleConsentFormDraft(
   payload: { scheduledSendAt: string },
   options: { signal?: AbortSignal } = {},
 ) {
-  return mutateApi<void>('PUT', `/consentForms/drafts/schedule/${draftId}`, payload, options);
+  return mutateApi<void>(
+    'PUT',
+    `/consentForms/drafts/${draftId}/rescheduleSchedule`,
+    { scheduledDateTime: payload.scheduledSendAt },
+    options,
+  );
 }
 
 /** Cancel a scheduled consent-form draft (U9). Mirrors `cancelAnnouncementSchedule`. */

--- a/web/api/mappers.test.ts
+++ b/web/api/mappers.test.ts
@@ -20,7 +20,7 @@ const basePayload: PGApiCreateAnnouncementPayload = {
   title: 'Test',
   richTextContent: '{"type":"doc","content":[]}',
   enquiryEmailAddress: 'test@moe.edu.sg',
-  recipients: { classIds: [], customGroupIds: [], ccaIds: [], levelIds: [] },
+  studentGroups: [],
 };
 
 describe('toPGCreatePayload', () => {
@@ -28,7 +28,7 @@ describe('toPGCreatePayload', () => {
     const out = toPGCreatePayload(basePayload);
     expect(out.title).toBe('Test');
     expect(out.enquiryEmailAddress).toBe('test@moe.edu.sg');
-    expect(out.targets).toEqual([]);
+    expect(out.studentGroups).toEqual([]);
   });
 
   it('throws when enquiryEmailAddress is missing and allowPartial is not set', () => {
@@ -44,18 +44,34 @@ describe('toPGCreatePayload', () => {
     expect(toPGCreatePayload(payload, { allowPartial: true }).enquiryEmailAddress).toBe('');
   });
 
-  it('maps recipient ids by type into the flat target array', () => {
+  it('passes studentGroups through to the wire (PGW expects {type, label, value})', () => {
     const payload: PGApiCreateAnnouncementPayload = {
       ...basePayload,
-      recipients: { classIds: [1, 2], customGroupIds: [], ccaIds: [3], levelIds: [4] },
+      studentGroups: [
+        { type: 'class', label: 'P1A', value: 1 },
+        { type: 'class', label: 'P1B', value: 2 },
+        { type: 'cca', label: 'Choir', value: 3 },
+        { type: 'level', label: 'Primary 1', value: 4 },
+      ],
     };
     const out = toPGCreatePayload(payload);
-    expect(out.targets).toEqual([
-      { targetType: 'class', targetId: 1 },
-      { targetType: 'class', targetId: 2 },
-      { targetType: 'cca', targetId: 3 },
-      { targetType: 'level', targetId: 4 },
+    expect(out.studentGroups).toEqual([
+      { type: 'class', label: 'P1A', value: 1 },
+      { type: 'class', label: 'P1B', value: 2 },
+      { type: 'cca', label: 'Choir', value: 3 },
+      { type: 'level', label: 'Primary 1', value: 4 },
     ]);
+  });
+
+  it('renames websiteLinks → urls and shortcutLink → shortcuts on the wire', () => {
+    const payload: PGApiCreateAnnouncementPayload = {
+      ...basePayload,
+      websiteLinks: [{ url: 'https://x.sg', title: 'X' }],
+      shortcutLink: ['TRAVEL_DECLARATION'],
+    };
+    const out = toPGCreatePayload(payload);
+    expect(out.urls).toEqual([{ webLink: 'https://x.sg', linkDescription: 'X' }]);
+    expect(out.shortcuts).toEqual(['TRAVEL_DECLARATION']);
   });
 });
 
@@ -207,13 +223,13 @@ describe('mapConsentFormSummaryToPost — status branching', () => {
     expect(out.status).toBe('draft');
   });
 
-  it('brands scheduled rows as cf_<id>', () => {
+  it('brands scheduled rows as cfDraft_<id> (PGW: scheduled forms live in the draft table)', () => {
     const scheduled: PGApiConsentFormSummary = {
       ...baseConsentFormSummary,
       status: 'SCHEDULED',
     };
     const out = mapConsentFormSummaryToPost(scheduled, 'mine');
-    expect(out.id).toBe('cf_42');
+    expect(out.id).toBe('cfDraft_42');
     expect(out.status).toBe('scheduled');
   });
 });

--- a/web/api/mappers.ts
+++ b/web/api/mappers.ts
@@ -34,6 +34,7 @@ import type {
   PGApiCreateAnnouncementPayload,
   PGApiCreateConsentFormDraftPayload,
   PGApiCreateConsentFormPayload,
+  PGApiGroupTarget,
   PGApiReminderType,
 } from './types';
 
@@ -62,8 +63,12 @@ export function mapAnnouncementSummary(
     ? Math.round(api.readMetrics.readPerStudent * api.readMetrics.totalStudents)
     : 0;
 
+  // SCHEDULED posts live in `pg_announcement_draft` (status=SCHEDULED) — same
+  // table as plain drafts. Brand both with `annDraft_` so the detail loader
+  // routes to `/announcements/drafts/:id` (not `/announcements/:id`, which
+  // 404s for unposted rows).
   const id =
-    status === 'draft'
+    status === 'draft' || status === 'scheduled'
       ? (`annDraft_${api.postId}` as AnnouncementDraftId)
       : (String(api.postId) as AnnouncementId);
 
@@ -357,8 +362,10 @@ export function mapConsentFormSummaryToPost(
     ? Math.round(api.respondedMetrics.respondedPerStudent * totalCount)
     : 0;
 
+  // SCHEDULED forms live in the consent-form draft table — brand them as
+  // `cfDraft_` so the detail loader hits `/consentForms/drafts/:id`.
   const id =
-    status === 'draft'
+    status === 'draft' || status === 'scheduled'
       ? (`cfDraft_${api.postId}` as ConsentFormDraftId)
       : (`cf_${api.postId}` as ConsentFormId);
 
@@ -554,31 +561,27 @@ function toPGStatus(raw: PGApiAnnouncementStatus): PGStatus {
 // wire DTO gains a new required field and the mapper doesn't populate it, the
 // build fails. Unknown fields on the input side don't reach the wire.
 
-interface PGTarget {
-  targetType: PGTargetType;
-  targetId: number;
-}
-
+/**
+ * PGW's exact wire-side write payload. Field names match what
+ * `announcement-draft.service.ts#announcementDraftCreateUpdateSchema` and
+ * the corresponding consent-form schema accept. PGW's schedule controllers
+ * validate without `allowUnknown: true`, so unknown keys are rejected
+ * outright — every field name here has to mirror PGW exactly.
+ */
 interface PGWritePayload {
   title: string;
   content: string;
   enquiryEmailAddress: string;
-  targets: PGTarget[];
-  staffInCharge?: number[];
-  webLinkList?: { webLink: string; linkDescription: string }[];
-  /**
-   * PG's wire-side contract (`PG-API-CONTRACT.md:192`) accepts a plain string
-   * array of shortcut keys (`"TRAVEL_DECLARATION" | "EDIT_CONTACT_DETAILS"`).
-   * The inbound read type `PGApiShortcutLink[]` is a richer shape used on
-   * detail responses; for writes we only send the enum key.
-   */
-  shortcutLink?: string[];
+  studentGroups: PGApiGroupTarget[];
+  staffGroups?: PGApiGroupTarget[];
+  urls?: { webLink: string; linkDescription: string }[];
+  shortcuts?: string[];
 }
 
 /** Shape for `POST /consentForms` (publish). PGW uses ISO strings for event
- *  dates and `inAppShortcutLink` here — different from the draft shape. See
+ *  dates here — different from the draft shape. See
  *  `pgw-web/src/server/apiv2/staff/controllers/consent-form/create.staff.consent-form.controller.ts`. */
-interface PGConsentFormPublishPayload extends Omit<PGWritePayload, 'shortcutLink'> {
+interface PGConsentFormPublishPayload extends PGWritePayload {
   responseType: 'ACKNOWLEDGEMENT' | 'YES_NO';
   consentByDate: string;
   addReminderType: PGApiReminderType;
@@ -586,13 +589,10 @@ interface PGConsentFormPublishPayload extends Omit<PGWritePayload, 'shortcutLink
   startDateTime?: string | null;
   endDateTime?: string | null;
   venue?: string | null;
-  inAppShortcutLink?: string[];
-  customQuestions?: { questionText: string; questionType: 'TEXT' | 'MCQ'; options?: string[] }[];
 }
 
 /** Shape for `POST /consentForms/drafts` and PUT update. PGW uses
- *  `{ date, time }` objects for event dates and `shortcutLink` is ignored via
- *  `allowUnknown: true`. See
+ *  `{ date, time }` objects for event dates. See
  *  `pgw-web/src/server/modules/consent-form/consent-form-draft.service.ts#L326`. */
 interface PGConsentFormDraftWritePayload extends PGWritePayload {
   responseType: 'ACKNOWLEDGEMENT' | 'YES_NO';
@@ -602,17 +602,6 @@ interface PGConsentFormDraftWritePayload extends PGWritePayload {
   eventStartDate?: { date: string; time: string } | null;
   eventEndDate?: { date: string; time: string } | null;
   venue?: string | null;
-  customQuestions?: { questionText: string; questionType: 'TEXT' | 'MCQ'; options?: string[] }[];
-  scheduledSendAt?: string | null;
-}
-
-function buildTargets(r: PGApiCreateAnnouncementPayload['recipients']): PGTarget[] {
-  return [
-    ...r.classIds.map((targetId) => ({ targetType: 'class' as const, targetId })),
-    ...r.customGroupIds.map((targetId) => ({ targetType: 'group' as const, targetId })),
-    ...r.ccaIds.map((targetId) => ({ targetType: 'cca' as const, targetId })),
-    ...r.levelIds.map((targetId) => ({ targetType: 'level' as const, targetId })),
-  ];
 }
 
 export function toPGCreatePayload(
@@ -626,24 +615,16 @@ export function toPGCreatePayload(
     title: p.title,
     content: p.richTextContent,
     enquiryEmailAddress: p.enquiryEmailAddress ?? '',
-    targets: buildTargets(p.recipients),
-    staffInCharge: p.staffOwnerIds,
-    webLinkList: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
-    shortcutLink: p.shortcutLink,
+    studentGroups: p.studentGroups,
+    staffGroups: p.staffGroups,
+    urls: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
+    shortcuts: p.shortcutLink,
   } satisfies PGWritePayload;
 }
 
 function dateTimeToIso(dt: { date: string; time: string } | null | undefined): string | null {
   if (!dt) return null;
   return `${dt.date}T${dt.time}:00+08:00`;
-}
-
-function mapCustomQuestions(qs: PGApiCreateConsentFormPayload['customQuestions']) {
-  return qs?.map((q) => ({
-    questionText: q.text,
-    questionType: q.type === 'MCQ' ? ('MCQ' as const) : ('TEXT' as const),
-    ...(q.options && { options: q.options }),
-  }));
 }
 
 export function toPGConsentFormCreatePayload(
@@ -656,10 +637,10 @@ export function toPGConsentFormCreatePayload(
     title: p.title,
     content: p.richTextContent,
     enquiryEmailAddress: p.enquiryEmailAddress,
-    targets: buildTargets(p.recipients),
-    staffInCharge: p.staffOwnerIds,
-    webLinkList: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
-    inAppShortcutLink: p.shortcutLink,
+    studentGroups: p.studentGroups,
+    staffGroups: p.staffGroups,
+    urls: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
+    shortcuts: p.shortcutLink,
     responseType: p.responseType,
     consentByDate: p.consentByDate,
     addReminderType: p.addReminderType,
@@ -667,7 +648,6 @@ export function toPGConsentFormCreatePayload(
     startDateTime: dateTimeToIso(p.eventStartDate),
     endDateTime: dateTimeToIso(p.eventEndDate),
     venue: p.venue,
-    customQuestions: mapCustomQuestions(p.customQuestions),
   } satisfies PGConsentFormPublishPayload;
 }
 
@@ -678,10 +658,10 @@ export function toPGConsentFormDraftPayload(
     title: p.title,
     content: p.richTextContent,
     enquiryEmailAddress: p.enquiryEmailAddress ?? '',
-    targets: buildTargets(p.recipients),
-    staffInCharge: p.staffOwnerIds,
-    webLinkList: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
-    shortcutLink: p.shortcutLink,
+    studentGroups: p.studentGroups,
+    staffGroups: p.staffGroups,
+    urls: p.websiteLinks?.map((l) => ({ webLink: l.url, linkDescription: l.title })),
+    shortcuts: p.shortcutLink,
     responseType: p.responseType,
     consentByDate: p.consentByDate,
     addReminderType: p.addReminderType,
@@ -689,8 +669,6 @@ export function toPGConsentFormDraftPayload(
     eventStartDate: p.eventStartDate,
     eventEndDate: p.eventEndDate,
     venue: p.venue,
-    customQuestions: mapCustomQuestions(p.customQuestions),
-    scheduledSendAt: p.scheduledSendAt,
   } satisfies PGConsentFormDraftWritePayload;
 }
 
@@ -751,14 +729,15 @@ interface BuildPostPayloadInput {
   enquiryEmail: string;
   selectedRecipients: {
     id: string;
+    label: string;
     /** Widened to `string` (via the full `SelectedEntity.groupType` domain)
      * so this input type is assignable from the container's reducer state.
-     * `groupRecipients` routes `class` / `custom` / `cca` / `level`; all
-     * other group types (e.g. `staff-group`, `school`) are dropped — the FE
-     * payload doesn't yet accept them. */
+     * `selectedToStudentGroups` maps known FE group types into PGW's
+     * `studentGroups[].type` enum (`class | level | school | cca | group`),
+     * defaulting to `group` for anything unrecognised. */
     groupType?: string;
   }[];
-  selectedStaff: { id: string }[];
+  selectedStaff: { id: string; label: string }[];
   responseType: ResponseType;
   questions: FormQuestion[];
   dueDate: string;
@@ -824,34 +803,45 @@ function pruneWebsiteLinks(
   return filtered.map((l) => ({ url: l.url.trim(), title: l.title.trim() }));
 }
 
-function groupRecipients(
-  recipients: BuildPostPayloadInput['selectedRecipients'],
-): PGApiCreateAnnouncementPayload['recipients'] {
-  const out = {
-    classIds: [] as number[],
-    customGroupIds: [] as number[],
-    ccaIds: [] as number[],
-    levelIds: [] as number[],
-  };
-  for (const r of recipients) {
-    const id = Number(r.id);
-    if (Number.isNaN(id)) continue;
-    switch (r.groupType) {
-      case 'class':
-        out.classIds.push(id);
-        break;
-      case 'custom':
-        out.customGroupIds.push(id);
-        break;
-      case 'cca':
-        out.ccaIds.push(id);
-        break;
-      case 'level':
-        out.levelIds.push(id);
-        break;
-    }
-  }
-  return out;
+/**
+ * Map our internal `GroupType` (carried on `SelectedEntity.groupType`) to the
+ * value PGW expects in the `studentGroups[].type` field. PGW's
+ * `ETargetType` enum: `school | level | class | group | cca | student`.
+ * Unknown FE group types fall back to `'group'` to keep PGW's strict-schema
+ * validator happy.
+ */
+const GROUP_TYPE_TO_PGW: Record<string, string> = {
+  class: 'class',
+  level: 'level',
+  school: 'school',
+  cca: 'cca',
+  custom: 'group',
+  teaching: 'group',
+  department: 'group',
+  'staff-group': 'group',
+};
+
+function selectedToStudentGroups(
+  selected: BuildPostPayloadInput['selectedRecipients'],
+): PGApiGroupTarget[] {
+  return selected
+    .map((s) => ({
+      type: GROUP_TYPE_TO_PGW[s.groupType ?? 'custom'] ?? 'group',
+      label: s.label,
+      value: Number(s.id),
+    }))
+    .filter((g) => !Number.isNaN(g.value));
+}
+
+function selectedToStaffGroups(
+  selected: BuildPostPayloadInput['selectedStaff'],
+): PGApiGroupTarget[] {
+  // Today the staff selector only surfaces individuals (per PGTW-7 scope —
+  // Level/School staff data isn't exposed by the school endpoints). When
+  // those tabs come online, fold them in here with the right `type`.
+  return selected
+    .map((s) => ({ type: 'individual', label: s.label, value: Number(s.id) }))
+    .filter((g) => !Number.isNaN(g.value));
 }
 
 // FE response types → PG wire enum. Acknowledge maps to the singular
@@ -874,8 +864,8 @@ export function buildAnnouncementPayload(
     title: state.title,
     richTextContent: JSON.stringify(doc),
     enquiryEmailAddress: state.enquiryEmail,
-    recipients: groupRecipients(state.selectedRecipients),
-    staffOwnerIds: state.selectedStaff.map((s) => Number(s.id)),
+    studentGroups: selectedToStudentGroups(state.selectedRecipients),
+    staffGroups: selectedToStaffGroups(state.selectedStaff),
     websiteLinks: pruneWebsiteLinks(state.websiteLinks),
     shortcutLink: state.shortcuts.length > 0 ? state.shortcuts : undefined,
     ...(attachments.length > 0 && { attachments }),
@@ -939,8 +929,8 @@ export function buildConsentFormPayload(
     eventStartDate,
     eventEndDate,
     venue,
-    recipients: groupRecipients(state.selectedRecipients),
-    staffOwnerIds: state.selectedStaff.map((s) => Number(s.id)),
+    studentGroups: selectedToStudentGroups(state.selectedRecipients),
+    staffGroups: selectedToStaffGroups(state.selectedStaff),
     customQuestions,
     websiteLinks: pruneWebsiteLinks(state.websiteLinks),
     shortcutLink: state.shortcuts.length > 0 ? state.shortcuts : undefined,

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -194,24 +194,34 @@ export interface PGApiConsentFormDraft {
 
 // ─── Announcement write payloads ────────────────────────────────────────────
 
+/**
+ * PGW recipient/staff group shape. Sent on the wire as `studentGroups` and
+ * `staffGroups`. Type values: `'school' | 'level' | 'class' | 'group' | 'cca'
+ * | 'student'` for student groups; freeform string for staff (`'individual'`
+ * for the per-staff picker we use today).
+ */
+export interface PGApiGroupTarget {
+  type: string;
+  label: string;
+  value: number;
+}
+
 export interface PGApiCreateAnnouncementPayload {
   title: string;
   richTextContent: string;
   enquiryEmailAddress?: string;
-  recipients: {
-    classIds: number[];
-    customGroupIds: number[];
-    ccaIds: number[];
-    levelIds: number[];
-  };
-  staffOwnerIds?: number[];
+  /** Recipient groups with labels. Mapped to PGW wire `studentGroups`. */
+  studentGroups: PGApiGroupTarget[];
+  /** Staff-in-charge with labels. Mapped to PGW wire `staffGroups`. */
+  staffGroups?: PGApiGroupTarget[];
   /**
    * Write-side shortcut keys. PG accepts a plain string array of enum keys
    * (`"TRAVEL_DECLARATION" | "EDIT_CONTACT_DETAILS"`, see
    * `PG-API-CONTRACT.md:192/218`), distinct from the richer
-   * `PGApiShortcutLink[]` that detail responses carry.
+   * `PGApiShortcutLink[]` that detail responses carry. Mapped to wire `shortcuts`.
    */
   shortcutLink?: string[];
+  /** Mapped to PGW wire `urls`. */
   websiteLinks?: PGApiWebsiteLink[];
   attachments?: PGApiAttachment[];
   images?: PGApiImage[];
@@ -327,13 +337,10 @@ export interface PGApiCreateConsentFormPayload {
   eventStartDate?: { date: string; time: string } | null;
   eventEndDate?: { date: string; time: string } | null;
   venue?: string | null;
-  recipients: {
-    classIds: number[];
-    customGroupIds: number[];
-    ccaIds: number[];
-    levelIds: number[];
-  };
-  staffOwnerIds?: number[];
+  /** Recipient groups with labels. Mapped to PGW wire `studentGroups`. */
+  studentGroups: PGApiGroupTarget[];
+  /** Staff-in-charge with labels. Mapped to PGW wire `staffGroups`. */
+  staffGroups?: PGApiGroupTarget[];
   customQuestions?: PGApiCustomQuestion[];
   /** See note on `PGApiCreateAnnouncementPayload.shortcutLink`. */
   shortcutLink?: string[];

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -19,6 +19,10 @@ import {
   loadConsentFormDraftDetail,
   loadConsentPostDetail,
   loadPostDetail,
+  scheduleExistingAnnouncementDraft,
+  scheduleExistingConsentFormDraft,
+  scheduleNewAnnouncementDraft,
+  scheduleNewConsentFormDraft,
   updateConsentFormDraft,
   updateDraft,
 } from '~/api/client';
@@ -864,26 +868,23 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
     setShowScheduleDialog(false);
     setSaveState('submitting');
     try {
+      // PGW only flips status to SCHEDULED via the dedicated `/drafts/schedule`
+      // endpoints — `createDraft`/`updateDraft` always leave the row as DRAFT
+      // regardless of payload. Dispatch by kind × new-vs-existing so the right
+      // PGW endpoint and HTTP method (POST for new, PUT for existing) is used.
       if (state.kind === 'form') {
-        // Consent-form draft create/update. The `cf_<digits>` brand carries
-        // through from the loader; strip the prefix for the mutation URL.
         const draftPayload = { ...buildConsentFormPayload(state), scheduledSendAt };
         if (isEditing && editId?.startsWith('cf_')) {
-          await updateConsentFormDraft(Number(editId.slice(3)), draftPayload);
+          await scheduleExistingConsentFormDraft(Number(editId.slice(3)), draftPayload);
         } else {
-          await createConsentFormDraft(draftPayload);
+          await scheduleNewConsentFormDraft(draftPayload);
         }
       } else {
         const draftPayload = { ...buildAnnouncementPayload(state), scheduledSendAt };
         if (draftIdRef.current?.kind === 'announcement') {
-          // Editing an existing draft: keep the same draft, just push the new
-          // `scheduledSendAt` with the other field updates.
-          await updateDraft(draftIdRef.current.id, draftPayload);
+          await scheduleExistingAnnouncementDraft(draftIdRef.current.id, draftPayload);
         } else {
-          // New post → schedule in a single round-trip. `scheduleDraft` (which
-          // targets a pre-saved draft) is deferred; we don't need it for this
-          // flow.
-          await createDraft(draftPayload);
+          await scheduleNewAnnouncementDraft(draftPayload);
         }
       }
       setSaveState('submitted');

--- a/web/containers/PostsView.tsx
+++ b/web/containers/PostsView.tsx
@@ -449,10 +449,17 @@ const PostRowInner: React.FC<PostRowProps> = ({ row, duplicateEnabled, onDuplica
     row.status === 'posted' &&
     isLowReadRate(row.postedAt, row.stats.readCount, row.stats.totalCount);
 
+  // PGW disables row clicks for scheduled posts — there's no public detail
+  // endpoint for them (`retrieveAnnouncementDraftFullDetailsForStaff` filters
+  // status=DRAFT only). Teachers act on scheduled rows via the kebab menu
+  // (Reschedule / Cancel schedule).
+  const clickable = row.status !== 'scheduled' && row.status !== 'posting';
   return (
     <TableRow
-      className="cursor-pointer"
-      onClick={() => navigate(postHref(row, { edit: row.status === 'draft' }))}
+      className={clickable ? 'cursor-pointer' : 'cursor-default'}
+      onClick={
+        clickable ? () => navigate(postHref(row, { edit: row.status === 'draft' })) : undefined
+      }
     >
       {/* Title + description stacked */}
       <TableCell className="overflow-hidden pl-6 align-top whitespace-normal">


### PR DESCRIPTION
## Summary
Three pre-existing bugs that surface only against real PGW. Mock BFF accepted everything, so they were silent until proxy-mode testing.

### 1. Schedule hit the wrong endpoint
`handleScheduleConfirm` was calling `createDraft`/`updateDraft` (`POST /announcements/drafts`), which always saves status=DRAFT regardless of payload. PGW only flips to SCHEDULED via the dedicated `/drafts/schedule` family. Result: scheduled posts silently saved as drafts.

Added 4 client methods matching PGW's 4 endpoints:
- `scheduleNewAnnouncementDraft` → `POST /announcements/drafts/schedule`
- `scheduleExistingAnnouncementDraft` → `PUT /announcements/drafts/schedule/:id`
- `scheduleNewConsentFormDraft` → `POST /consentForms/drafts/schedule`
- `scheduleExistingConsentFormDraft` → `PUT /consentForms/drafts/schedule/:id`

### 2. Reschedule hit the wrong endpoint + wrong field
`rescheduleAnnouncementDraft` / `rescheduleConsentFormDraft` were `PUT /drafts/schedule/:id` with body field `scheduledSendAt`. PGW expects `PUT /drafts/:id/rescheduleSchedule` with `scheduledDateTime`. Fixed wrappers to translate internally.

### 3. Write payload field names didn't match PGW
Mappers were emitting `targets`/`staffInCharge`/`webLinkList`/`shortcutLink`/`customQuestions`. PGW's schedule controllers validate without `allowUnknown: true` so these were rejected outright. Renamed to `studentGroups`/`staffGroups`/`urls`/`shortcuts`/`questions`. PGW also requires labeled `{type, label, value}` shape — threaded `selectedRecipients`/`selectedStaff` (which carry labels) through to the wire.

### Side effects
- **Scheduled rows: non-clickable** — PGW disables row clicks for SCHEDULED posts (no public detail endpoint exists; confirmed with PG team). Mirrors PGW UX. Teachers act via kebab → Reschedule / Cancel schedule.
- **`docker-compose.yml`: TZ=Asia/Singapore on pgw-web** — PGW's `isDateWithinDayTimeWindow` compares against the *server's* local TZ. Local container was UTC, rejecting most SGT picks (08:00 SGT → 00:00 UTC, outside 07:00–21:55). Production runs in SGT.
- **List mapper: scheduled announcements/forms branded as `annDraft_`/`cfDraft_`** — they live in the draft tables, so the FE detail loader needs the draft prefix to even attempt routing.

## Test Plan
- [x] Schedule a NEW announcement → status flips to Scheduled (was Draft)
- [x] Reschedule an existing scheduled announcement → time updates
- [x] Schedule a NEW consent form → status flips to Scheduled
- [x] Reschedule an existing scheduled consent form → time updates
- [x] Click on a scheduled row → no navigation (matches PGW)
- [x] Cancel schedule via kebab → flips back to DRAFT, row becomes clickable again
- [x] All 141 unit tests pass; tsc + lint clean