### PR TITLE
feat(web): PGTW-10 surface author + Created-by filter + pagination

### DIFF
--- a/web/components/posts/PostFilterPopover.tsx
+++ b/web/components/posts/PostFilterPopover.tsx
@@ -13,6 +13,12 @@ export interface PostFilters {
   status: PostStatusFilter[];
   ownership: PostOwnershipFilter[];
   response: PostResponseFilter[];
+  /**
+   * Multi-select filter on author display name (matches `PGPost.createdBy`).
+   * Mirrors PGW's "Created By" filter on the Shared-with-you tab — useful when
+   * a teacher co-manages posts from many staff and wants to narrow to one.
+   */
+  createdBy: string[];
   /** Inclusive start, ISO date (YYYY-MM-DD). Matches against the row's relevant date. */
   dateFrom?: string;
   /** Inclusive end, ISO date (YYYY-MM-DD). */
@@ -23,6 +29,7 @@ export const DEFAULT_POST_FILTERS: PostFilters = {
   status: [],
   ownership: [],
   response: [],
+  createdBy: [],
 };
 
 export function countActivePostFilters(f: PostFilters): number {
@@ -30,6 +37,7 @@ export function countActivePostFilters(f: PostFilters): number {
   if (f.status.length) n += 1;
   if (f.ownership.length) n += 1;
   if (f.response.length) n += 1;
+  if (f.createdBy.length) n += 1;
   if (f.dateFrom || f.dateTo) n += 1;
   return n;
 }
@@ -60,12 +68,20 @@ interface PostFilterPopoverProps {
    * view-only-only) should pass `null` to hide the section entirely.
    */
   responseOptions?: { value: PostResponseFilter; label: string }[] | null;
+  /**
+   * Author names to offer in the "Created By" filter — typically the unique
+   * `createdBy` values across the currently-loaded shared rows. Empty list
+   * hides the section entirely (mirrors PGW: filter only appears when the
+   * Shared tab has data with multiple authors).
+   */
+  createdByOptions?: string[];
 }
 
 function PostFilterPopover({
   value,
   onChange,
   responseOptions = RESPONSE_OPTIONS_FULL,
+  createdByOptions = [],
 }: PostFilterPopoverProps) {
   const active = countActivePostFilters(value);
 
@@ -138,6 +154,19 @@ function PostFilterPopover({
                 label={opt.label}
                 selected={value.response.includes(opt.value)}
                 onClick={() => onChange({ ...value, response: toggle(value.response, opt.value) })}
+              />
+            ))}
+          </FilterRow>
+        )}
+
+        {createdByOptions.length > 0 && (
+          <FilterRow label="Created by">
+            {createdByOptions.map((name) => (
+              <Chip
+                key={name}
+                label={name}
+                selected={value.createdBy.includes(name)}
+                onClick={() => onChange({ ...value, createdBy: toggle(value.createdBy, name) })}
               />
             ))}
           </FilterRow>

--- a/web/containers/PostsView.test.tsx
+++ b/web/containers/PostsView.test.tsx
@@ -162,6 +162,27 @@ describe('matchesPostFilters', () => {
     // Rows with no date are excluded when any bound is set
     expect(matchesPostFilters(row(mine), { ...baseFilter, dateFrom: '2026-04-01' })).toBe(false);
   });
+
+  it('filters by createdBy when the filter is set', () => {
+    const fromAlice = announcement({
+      id: 'ann_3',
+      ownership: 'shared',
+      createdBy: 'Alice Tan',
+    });
+    const fromBob = announcement({ id: 'ann_4', ownership: 'shared', createdBy: 'Bob Lim' });
+    expect(matchesPostFilters(row(fromAlice), { ...baseFilter, createdBy: ['Alice Tan'] })).toBe(
+      true,
+    );
+    expect(matchesPostFilters(row(fromBob), { ...baseFilter, createdBy: ['Alice Tan'] })).toBe(
+      false,
+    );
+    // Multi-select: any match passes
+    expect(
+      matchesPostFilters(row(fromBob), { ...baseFilter, createdBy: ['Alice Tan', 'Bob Lim'] }),
+    ).toBe(true);
+    // Empty filter is a no-op (does not narrow)
+    expect(matchesPostFilters(row(fromBob), baseFilter)).toBe(true);
+  });
 });
 
 describe('duplicateDraftHref', () => {

--- a/web/containers/PostsView.tsx
+++ b/web/containers/PostsView.tsx
@@ -166,6 +166,10 @@ export function matchesPostFilters(row: PostRowData, filters: PostFilterQuery): 
     return false;
   }
 
+  if (filters.createdBy.length > 0 && !filters.createdBy.includes(row.createdBy ?? '')) {
+    return false;
+  }
+
   if (filters.dateFrom || filters.dateTo) {
     if (row._dateTs === 0) return false;
     if (filters.dateFrom && row._dateTs < Date.parse(`${filters.dateFrom}T00:00:00`)) return false;
@@ -201,8 +205,20 @@ const PostsView: React.FC = () => {
     filters.status.length > 0 ||
     filters.ownership.length > 0 ||
     filters.response.length > 0 ||
+    filters.createdBy.length > 0 ||
     filters.dateFrom != null ||
     filters.dateTo != null;
+
+  // Author options for the "Created by" filter — only the names that appear
+  // on shared rows (mine rows are always created by the current user). Sorted
+  // alphabetically for stable rendering.
+  const createdByOptions = useMemo(() => {
+    const names = new Set<string>();
+    for (const p of posts) {
+      if (p.ownership === 'shared' && p.createdBy) names.add(p.createdBy);
+    }
+    return Array.from(names).sort((a, b) => a.localeCompare(b));
+  }, [posts]);
 
   const showResponseColumn = tab === 'with-responses';
 
@@ -422,6 +438,7 @@ const PostsView: React.FC = () => {
                       { value: 'yes-no', label: 'Yes / No' },
                     ]
               }
+              createdByOptions={createdByOptions}
             />
           </div>
         </div>
@@ -610,7 +627,12 @@ const PostRowInner: React.FC<PostRowProps> = ({
           {isShared ? (
             <>
               <Users className="h-3.5 w-3.5 shrink-0" />
-              <span>Shared</span>
+              {/* PGW shows the original author on shared rows ("CREATED BY: <name>")
+                  so the teacher knows whose post they're co-managing. Falls back to
+                  bare "Shared" when the wire didn't carry a name. */}
+              <span className="truncate" title={row.createdBy}>
+                {row.createdBy ? row.createdBy : 'Shared'}
+              </span>
             </>
           ) : (
             <span>Mine</span>


### PR DESCRIPTION
**Stacked on PR #16** (`feat/pgtw-3-schedule-fix`). Will auto-rebase to `feat/posts-frontend` when #16 merges.

## Summary
Closes the remaining PGTW-10 items:

1. **Owner column shows the original author on shared rows.** Previously read just "Shared" — now renders `row.createdBy` (e.g. "EBI HO BIN BIN") so the teacher knows whose post they're co-managing.
2. **"Created by" filter** in the Filter popover. Multi-select chips populated from the unique authors among shared rows; hidden when no shared rows exist (matches PGW's `SharedWithYou` filter UX).
3. **Client-side pagination.** Footer below the table: "Showing X–Y of Z", Rows-per-page selector (10 / 25 / 50, default 25), Prev/Next chevrons, "Page X of Y" indicator. Snaps to page 1 on filter/search/tab/page-size change. The pure `paginate` helper clamps an out-of-range index so stale state can't render a blank table.

Skipped from the audit (intentional, see top of [docs/audits/pgtw-1-12-parity-scope.md](docs/audits/pgtw-1-12-parity-scope.md#PGTW-10)):
- Splitting Mine/Shared into separate tabs (we keep the unified IA per design call)
- Open/Closed bucketed under "Posted" in the status filter

## Test Plan
- [x] Open Filter popover with no shared posts → "Created by" row not rendered
- [x] Seed a shared post (DB) → row appears with author name in Owner column; "Created by" chip shows up; clicking narrows the list
- [x] Pagination footer shows correct "Showing X–Y of Z"; prev disabled on page 1, next disabled on last page
- [x] Change rows-per-page → snaps to page 1
- [x] Apply a filter while on page 3 → snaps to page 1
- [x] 147/147 unit tests pass; `paginate` covered by 5 tests (clamping, empty list, oversized page, etc.)