### PR TITLE
feat(groups): PGTW-13a..14 custom groups — overview, CRUD, share

### DIFF
--- a/docs/audits/pgtw-13-20-custom-groups-parity-scope.md
+++ b/docs/audits/pgtw-13-20-custom-groups-parity-scope.md
@@ -1,0 +1,213 @@
+# PGTW-13/14/15/20 Parity Scoping — Custom Groups
+
+## Context
+
+Gap-analysis / scoping doc for the **custom-groups** subsystem of PGTW-13..25 (see [pgtw-13-25-decomposition.md](pgtw-13-25-decomposition.md) for the cross-subsystem index). Same shape as [pgtw-1-12-parity-scope.md](pgtw-1-12-parity-scope.md): for each Jira ticket, what PGW does today, what `tw-pg-experiment` does on `feat/posts-frontend`, and what's still missing to reach parity.
+
+**IA decision (Phase 1):** custom groups live at the **platform level** at `/groups`, as a peer of `/posts`, mirroring PGW's own IA. They are a shared primitive — already consumed read-only by the posts recipient picker, likely consumed by Meetings/Reports later — so the canonical CRUD UI is **not** nested inside any one consuming app. Consuming apps deep-link in or open `/groups/customGroups/new` in a modal.
+
+**Sources:** [docs/references/pg-api-contract.md §8-9 (lines 880-1000)](../references/pg-api-contract.md), [docs/references/pg-specs.md §7 (lines 1207-1392)](../references/pg-specs.md), [docs/references/pg-bff-design.md](../references/pg-bff-design.md), and direct inspection of `web/`, `server/internal/pg/mock.go`, and the existing fixtures `groups_custom.json` / `group_custom_detail.json`.
+
+**Hard constraint — "PGW backend is untouchable":** every gap is resolved on our side. Endpoints, error codes, enums, field shapes are fixed. If a parity item would require a PGW change, it's out of scope for Phase 1.
+
+**Current high-level state.**
+
+- BFF mock has **all** custom-group endpoints stubbed in [server/internal/pg/mock.go:266-279](../../server/internal/pg/mock.go#L266-L279): list, detail, create, update, delete, share, removeAccess — plus `validateStudents` / `validateStudents/results` (the Excel-upload two-step flow) and `student/count`.
+- FE consumes only the **list-summary** endpoint via `loadCustomGroups()` in [web/api/client.ts:767](../../web/api/client.ts#L767), feeding the `Custom Groups` tab in [student-recipient-selector.tsx:99-106](../../web/components/comms/student-recipient-selector.tsx#L99-L106).
+- Types defined: `PGApiCustomGroupSummary` and `PGApiCustomGroupsList` in [web/api/types.ts:408-420](../../web/api/types.ts#L408-L420). No detail / share / staff-list types yet.
+- **No FE module:** no `/groups` route in [web/App.tsx](../../web/App.tsx), no sidebar entry in [web/components/Sidebar/](../../web/components/Sidebar/), no create/edit/detail components.
+
+---
+
+## PGTW-13 — Manual selection of students and file upload
+
+**PGW behavior.** Two paths from [pg-specs.md §7.7 (Create)](../references/pg-specs.md) and [§7.4 (Add Students)](../references/pg-specs.md):
+
+- **Manual** — `+ Add Students` → "Add manually" → search/filter page (`/groups/customGroups/:id/edit/addStudents`) with Level / Form Class / CCA filters + paginated checkbox table. "Add N selected" returns to the edit page.
+- **Excel upload** — `+ Add Students` → "Upload via Excel" → file picker. **Disabled once group has students** ("Cannot be selected when the list has students"). Two-step protocol confirmed by BFF mock at [mock.go:273-274](../../server/internal/pg/mock.go#L273-L274): `POST /groups/custom/validateStudents` (upload + validate) → `POST /groups/custom/validateStudents/results` (confirm + create).
+
+Submit goes to `POST /api/web/2/staff/groups/custom` with `{ name, studentIds }` ([pg-api-contract.md:948-962](../references/pg-api-contract.md#L948-L962)). Title is required, max 120 chars; ≥1 student required.
+
+**Current state.** **No FE create flow.** Endpoints are mock-stubbed but unused. The recipient-selector consumes the list but cannot create. No Excel parser, no add-students subpage.
+
+**Gap.**
+
+- **Whole module missing:** `/groups` overview, `/groups/customGroups/new` create page, `/groups/customGroups/:id/edit/addStudents` subpage, "+ Add Students" dropdown.
+- **Excel upload pipeline missing:** UI (drag-drop or file input), client wiring to `validateStudents` → results, validation-error rendering (per PGW: "Cannot be selected when the list has students", malformed file, unknown students).
+- **Excel format / sheet schema unconfirmed.** PGW says "Excel" — `.xlsx` only? Headers required? One column or multiple? Flag as open question.
+- **Cross-app shortcut:** posts recipient picker has no "+ Create new group" affordance. A future follow-up — out of this audit's ticket scope but listed under cross-cutting.
+
+**Files to create/touch:** new `web/containers/GroupsView.tsx`, `web/containers/CreateCustomGroupView.tsx`, `web/containers/EditCustomGroupView.tsx`, `web/containers/AddStudentsView.tsx`, new `web/components/groups/*` for the file picker + table; routes in [web/App.tsx](../../web/App.tsx); nav entry in [web/components/Sidebar/SidebarContent.tsx](../../web/components/Sidebar/SidebarContent.tsx); types in [web/api/types.ts](../../web/api/types.ts) (detail shape, validateStudents request/response); client functions in [web/api/client.ts](../../web/api/client.ts).
+
+---
+
+## PGTW-14 — Share custom group with staff
+
+**PGW behavior.** Share modal launched from the detail page's "Share Group" action ([pg-specs.md §7.5](../references/pg-specs.md)). Search/autocomplete staff picker; bullet list of what the recipients gain ("View and send to the group", "Edit the group name", "Add or delete students", "Share the group with other staff"); "Share group" CTA disabled until ≥1 staff selected. Endpoints: `PUT /api/web/2/staff/groups/custom/:id/share` with `{ staffIds: number[] }` and `PUT /:id/removeAccess` for removal ([pg-api-contract.md:986-1000](../references/pg-api-contract.md#L986-L1000)). PGW shows the shared-with list on the detail page's Details tab ([pg-specs.md §7.2](../references/pg-specs.md)).
+
+**Current state.** **None.** Endpoints stubbed in BFF mock but no FE. The existing `staff-selector` component used by posts ([web/components/comms/staff-selector.tsx](../../web/components/comms/staff-selector.tsx)) is reusable for the modal's picker.
+
+**Gap.**
+
+- Share modal component (reuse `staff-selector` for the picker; render PGW's bullet list).
+- Detail-page integration: "Share Group" action card opens the modal; "Group shared with: [names]" rendered from detail payload.
+- Remove-access UX: PGW spec doesn't show the remove-staff UI explicitly — likely an "×" on each name in the shared-with list. Confirm with screenshots / PG team.
+- "Shared with you" tab on the overview list: when `isShared: true` and `createdBy` ≠ current staff, the group should show on the shared tab rather than (or in addition to) the owner tab. PGW [§7.1](../references/pg-specs.md) doesn't explicitly describe shared-tab UX on the overview — confirm.
+
+**Files:** new `web/components/groups/ShareGroupModal.tsx`, `web/containers/CustomGroupDetailView.tsx`; reuse [staff-selector.tsx](../../web/components/comms/staff-selector.tsx); client functions for share/removeAccess.
+
+---
+
+## PGTW-15 — School Cockpit (SC) custom group
+
+**Open question — flagged.** "SC" = School Cockpit (PG admin context). Unclear from current references whether this is:
+
+- (a) **A role-gated affordance on the same `/groups` module** — admins see additional powers (create on behalf of any teacher, view school-wide groups, override sharing). Single module, two views via role check.
+- (b) **A separate admin surface** — e.g. `/admin/groups` with a different list shape (school-wide), distinct endpoints. PGW's `/groups/custom?type=summary` returns the staff's own + shared; an admin endpoint may exist that returns all groups school-wide.
+- (c) **A different create flow only** — admin's create page lets them pick the owning teacher; everything else identical.
+
+**Action:** design the staff path (PGTW-13/14/20) fully now under a single `/groups` module; **revisit PGTW-15 once PG team confirms.** Specific asks for PG team:
+
+1. Does PGW expose an admin-scoped endpoint (e.g. `/api/web/2/admin/groups/custom` or a query param on the existing endpoint)?
+2. Is the admin's create page a different route, or the same `/groups/customGroups/new` with role-gated extra fields (e.g. owning teacher picker)?
+3. What does "School Cockpit" mean in tw-pg-experiment's IA — a separate top-level area, or the same `/groups` module with role checks?
+
+**Files:** TBD pending answers. Likely: a role check on existing module + extra fields on create page.
+
+---
+
+## PGTW-20 — Delete custom group (single and multi-select)
+
+**PGW behavior — single delete.** Per-row kebab on overview ([§7.1](../references/pg-specs.md): "Kebab: View, Edit, Delete") **and** "Delete this custom group" action card on the detail page ([§7.2](../references/pg-specs.md)) → Delete modal ([§7.6](../references/pg-specs.md)) with required acknowledgement checkbox ("I understand that this action cannot be undone…"); CTA disabled until checkbox ticked; no Cancel button (only X). Endpoint: `DELETE /api/web/2/staff/groups/custom/:id` ([pg-api-contract.md:980](../references/pg-api-contract.md#L980)).
+
+**PGW behavior — multi-select.** **Not documented in our spec.** [§7.1](../references/pg-specs.md) only describes the per-row kebab. Either PGW added it post-spec or this is a TW-specific addition baked into the ticket title.
+
+**Current state.** **No delete UI** anywhere. Endpoint stubbed in mock.
+
+**Gap.**
+
+- Single-delete modal with PGW's required-checkbox UX (mirror [§7.6](../references/pg-specs.md) verbatim).
+- Kebab on overview row + action card on detail page, both routing to the same modal.
+- **Multi-select delete is undocumented in PGW.** Two options:
+  - (a) **Treat as TW-only divergence**: add row checkboxes + a "Delete N selected" toolbar on the overview, with a batched delete dispatched as N parallel `DELETE` calls. Document as TW-only divergence; partial-failure UX (e.g. 3 of 5 deleted) needs a toast that names which failed.
+  - (b) **Defer pending PG-team confirmation**: ship single-delete in Phase 1; ask PG team if PGW has multi-select that's missing from the spec, and if so what endpoint shape. If yes, port; if no, reconsider whether multi-select is worth the divergence cost.
+  - **Recommend (b)** — minimum risk; multi-select is a marginal-utility feature that doesn't justify divergence until we've confirmed PGW's stance.
+- **Cascade behavior unknown.** What happens if a group is deleted while referenced by a draft / scheduled / posted announcement? PGW likely either (i) leaves the post intact with a "ghost group" reference, (ii) cascades and removes recipients, or (iii) refuses delete. Not in our docs. Open question.
+
+**Files:** new `web/components/groups/DeleteGroupModal.tsx`, kebab + toolbar in `GroupsView.tsx`, action card in `CustomGroupDetailView.tsx`.
+
+---
+
+## Cross-cutting gaps (not tied to one ticket)
+
+1. **Sidebar nav entry.** Posts is the only top-level nav today. Adding `/groups` requires a new `SidebarItem` in [SidebarContent.tsx](../../web/components/Sidebar/SidebarContent.tsx) — straightforward, but worth surfacing in the design.
+2. **Routing.** Add `/groups`, `/groups/customGroups/new`, `/groups/customGroups/:id`, `/groups/customGroups/:id/edit`, `/groups/customGroups/:id/edit/addStudents` to [App.tsx](../../web/App.tsx). Mirror PGW's URLs exactly (URLs are part of parity).
+3. **Detail-payload shape.** [pg-api-contract.md:905-930](../references/pg-api-contract.md#L905-L930) lists `{ customGroupId, name, createdBy, createdByName, isShared, sharedWith[], students[{studentId, studentName, className, indexNumber, ccas[]}], createdAt }` — `sharedWith[]` shape isn't fully documented (staff IDs? names? both?). Need to confirm and add to types.
+4. **Excel-upload pipeline.** Two-step protocol (`validateStudents` → `validateStudents/results`) needs full audit before implementation: file size limit, row limit, column schema, error response shape, what `valid: false` payload looks like. **Not in our current docs.** Open question for PG team.
+5. **Consuming-app shortcut from Posts recipient picker.** "+ Create new group" affordance on the Custom Groups tab → opens `/groups/customGroups/new` in a modal/new tab, then refreshes the recipient list. **Not in any of the four tickets covered here — called out as a future follow-up so it's not lost.**
+6. **Role gating for SC (PGTW-15).** Once SC scope is clarified, the `/groups` module may need a role-aware variant. Pre-build with a clear seam (e.g. `useStaffRole()` hook) so adding admin affordances is additive.
+7. **Onboarded-status column.** Detail page's Students tab shows an "Onboarded & Can Respond" ✓/✗ column ([§7.2](../references/pg-specs.md)). Detail-payload student shape from [pg-api-contract.md:919-927](../references/pg-api-contract.md#L919-L927) doesn't include this field. Either it's derived from another endpoint, or it's missing from the contract doc. Audit gap — flag.
+8. **Empty / error states.** Overview empty (no groups created), detail empty (no students), Excel upload error states — none designed yet.
+9. **PGW feature-flag plumbing.** Custom groups don't appear to be feature-flagged in PGW's known flag set, but worth confirming alongside the existing schedule/duplicate flag work.
+
+---
+
+## Suggested ordering
+
+Smallest unit that ships visible parity, then layer complexity:
+
+1. **PGTW-13a — Overview page + create-empty.** `/groups` overview reading from existing `/groups/custom?type=summary`; `+ Create custom group` button → `/groups/customGroups/new` with title input + empty students state + Save (disabled). Plus sidebar nav entry. **Lights up the route**, ~1 day.
+2. **PGTW-13b — Manual add-students subpage.** `/groups/customGroups/:id/edit/addStudents` with Level / Form Class / CCA filters + paginated checkbox table. Wire to existing students/classes endpoints. **The bulk of PGTW-13.**
+3. **PGTW-13c — Detail page + edit page.** Read detail; Students tab (grouped by class); Details tab with action cards; Edit page with title + add-students entrypoint.
+4. **PGTW-14 — Share modal + Details tab "shared with" list.** Reuse `staff-selector`. Wire to share/removeAccess endpoints.
+5. **PGTW-20a — Single-delete modal.** Kebab + action card → modal with required checkbox.
+6. **PGTW-13d — Excel upload.** Two-step `validateStudents` pipeline; only after PG team confirms format and error schema (open question).
+7. **PGTW-20b — Multi-select delete.** Only if PG team confirms PGW supports it; otherwise drop for Phase 1.
+8. **PGTW-15 — SC custom group.** Pending PG-team clarification on what SC means.
+
+Items 1-5 are straight ports; 6 is blocked on PG-team input; 7 is conditional; 8 is fully blocked.
+
+---
+
+## Open questions (need PG team / Grace input)
+
+All framed under the "PGW untouchable" constraint — they ask what PGW _already exposes_, not what PGW could add.
+
+1. **PGTW-15:** what is "SC custom group" on PGW? Separate admin endpoint, role-gated affordance, or different create flow? (See PGTW-15 section above.)
+2. **PGTW-20 multi-select:** does PGW's `/groups` overview support multi-select delete? If yes, what's the endpoint shape (one bulk delete, or N parallel)?
+3. **PGTW-13 Excel format:** `.xlsx` only or `.xls` / `.csv` accepted? Header row required? Single column (UIN/FIN) or multi-column? Max rows? Max file size?
+4. **PGTW-13 validateStudents protocol:** what does the request payload look like (multipart? raw bytes?), and what does `valid: false` look like (per-row errors? aggregate error code?)? Can we get a sample request/response from a PGW dev environment?
+5. **Cascade on delete:** if a custom group is referenced by a draft / scheduled / posted announcement, what does PGW do on delete — refuse, cascade, or orphan? Is the recipient resolved by ID at send-time, or snapshotted at post-creation?
+6. **Onboarded-status field:** the detail page shows ✓/✗ "Onboarded & Can Respond" per student — which endpoint sources that flag? It isn't in the documented detail payload.
+7. **Detail-payload `sharedWith[]` shape:** array of staff IDs, names, or `{ staffId, staffName }` objects?
+8. **Removing the only owner / sharing with self:** PGW likely guards both. Confirm.
+9. **Shared-with-you tab on `/groups` overview:** does PGW have a "Created by you" / "Shared with you" tab axis on this module like it does on `/announcements`? Spec [§7.1](../references/pg-specs.md) doesn't show it.
+
+---
+
+## Error handling & edge cases
+
+### Excel upload (PGTW-13)
+
+- **File too large** — 413 likely; need explicit size limit + clear error copy. PGW limit unknown.
+- **Wrong file type** (not Excel) — client-side mime check + server-side rejection.
+- **Malformed Excel** — corrupt file, encrypted, password-protected.
+- **Wrong schema** — wrong column headers, missing UIN column, blank file.
+- **Unknown student IDs** — PGW likely returns per-row errors; need per-row UI (not just a generic toast).
+- **Mixed valid + invalid rows** — does PGW accept the valid subset and return the rest as errors, or reject the whole file? Affects UX (can teacher fix-and-resume vs upload a corrected file).
+- **Duplicates within file** — silently dedupe vs error.
+- **Excel formulas / merged cells / multiple sheets** — which sheet? probably first; document.
+- **Browser-side parse vs server-side** — given the BFF stub already names `validateStudents`, server-side parse is implied. Client just uploads.
+- **Excel disabled when group has students** ([§7.3](../references/pg-specs.md)) — enforce this UI rule client-side, plus tooltip "Cannot be selected when the list has students".
+
+### Sharing (PGTW-14)
+
+- **Sharing with self** — PGW likely 400s. Suppress self from picker.
+- **Sharing with already-shared staff** — idempotent on PGW? confirm.
+- **Removing the only owner** — PGW likely refuses (would orphan the group). Need explicit error UI.
+- **Sharing a group that no longer exists** (deleted in another tab) — 404 → toast "This group has been deleted" + navigate back to overview.
+- **Race: share + delete from two tabs** — last write wins; need stale-data banner if `updatedAt` advances on a save.
+
+### Delete (PGTW-20)
+
+- **Cascade** (see open question 5) — UX depends on PGW behavior.
+- **Required-checkbox modal** ([§7.6](../references/pg-specs.md)) — ensure the checkbox state resets when modal reopens.
+- **Multi-select partial failure** (if implemented) — toast must name which IDs failed; rest succeed.
+- **Rapid-fire delete** (double-click the modal CTA) — disable button during in-flight call.
+
+### Add-students subpage (PGTW-13b)
+
+- **Empty filters** (no level / class) — show all students paginated; large schools may have thousands. Need virtualisation or aggressive pagination.
+- **Already-added** badge: PGW shows "N students already added" — must dedupe client-side; if a student is already in the group, the row is non-checkable.
+- **Search across thousands of students** — debounce + server-side search if needed; current client-side search in [student-recipient-selector.tsx](../../web/components/comms/student-recipient-selector.tsx) caps at 20 — may need server-side.
+- **Pagination + selection state** — selected rows must persist across pages; common bug.
+
+### Cross-cutting
+
+- **Stale-tab edits** — open the same group in two tabs, edit independently — last write wins. At minimum, show a "this group was edited elsewhere" banner if `updatedAt` advances.
+- **Network drop mid-Excel-upload** — retry behavior; client must surface "upload failed, try again" clearly.
+- **`-4031` redirect, CSRF token, session expiry** — already handled at the [client.ts](../../web/api/client.ts) layer; new endpoints inherit the existing routing automatically.
+- **Permissions guards** — every detail/edit/share/delete check must mirror PGW's check (which we don't fully know — open question 8).
+
+---
+
+## Verification — "how do we know parity is reached"
+
+Per ticket, parity is demonstrated by:
+
+- **UI walkthrough** against PGW [§7.1-§7.7](../references/pg-specs.md): every page, every modal, every dropdown.
+- **API payload diff** between BFF call and the PGW contract [§8-9](../references/pg-api-contract.md): every required field present, every enum value matches.
+- **Error handling** for every documented PGW error code per endpoint (TBC after open question 4 resolves Excel response shape).
+- **End-to-end against the local PGW** (per [PGW-tests-first memory](../../../.claude/projects/-Users-shin-Desktop-projects-tw-pg-experiment/memory/feedback-verify-before-done.md)): create → edit → share → delete a group through the UI, hitting real PGW endpoints in `TW_PG_MOCK=false` mode.
+
+For PGTW-13 specifically: Excel upload requires a real PGW environment to verify the two-step protocol — the mock stubs return only `{valid: true}` and don't model errors.
+
+---
+
+## Out of scope for this audit
+
+- **"+ Create new group" shortcut from the posts recipient picker** — useful follow-up; not in any of the four tickets covered here. Open as a separate ticket if pursued.
+- **Reports / Meetings / Login / Calendar** — separate audits per [pgtw-13-25-decomposition.md](pgtw-13-25-decomposition.md).
+- **Backend-side Excel parser implementation** — that's a BFF concern; this audit only cares about FE wiring + UX.
+
+Nothing in this doc requires code changes yet — the next step is to invoke `writing-plans` for PGTW-13a/b/c (the 1-3 unblocked items above) once the open questions are triaged.

--- a/docs/audits/pgtw-13-25-decomposition.md
+++ b/docs/audits/pgtw-13-25-decomposition.md
@@ -1,0 +1,91 @@
+# PGTW-13..25 Decomposition & Ordering
+
+## Context
+
+PGTW-1..12 ([scoped here](pgtw-1-12-parity-scope.md)) were one cohesive subsystem — announcements + forms. PGTW-13..25 spans **six independent subsystems** that share little code or data with each other or with posts. This doc decomposes them, names dependencies, and recommends an order so that each subsystem can be brainstormed → spec'd → planned → built independently, the same way PGTW-1..12 was.
+
+Each subsystem gets its **own** parity-scope audit (mirroring [pgtw-1-12-parity-scope.md](pgtw-1-12-parity-scope.md)) when it's pulled into a sprint. This file is the index, not the audit.
+
+---
+
+## Subsystems
+
+| Tickets        | Subsystem                                                     | Audit doc                                                                            | Status             |
+| -------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------------ |
+| 13, 14, 15, 20 | **Custom groups** (create, share, SC, delete)                 | [pgtw-13-20-custom-groups-parity-scope.md](pgtw-13-20-custom-groups-parity-scope.md) | Drafted 2026-04-30 |
+| 16, 17         | **Reports** (Travel Declaration, PG Onboarding)               | _to write_                                                                           | Pending            |
+| 18, 19         | **Access control** (90-day inactive logout, admin activation) | _to write_                                                                           | Pending            |
+| 21, 22, 23     | **Meetings** (create, dashboard, management)                  | _to write_                                                                           | Pending            |
+| 24             | **Login sync** (MIMS/Edupass between TW and PG)               | _to write_                                                                           | Pending            |
+| 25             | **Calendar** (Google Calendar create)                         | _to write_                                                                           | Pending            |
+
+---
+
+## Subsystem blurbs
+
+### Custom groups (PGTW-13/14/15/20)
+
+PGW already has a complete `/groups` module ([pg-specs.md §7](../references/pg-specs.md), [pg-api-contract.md §8-9](../references/pg-api-contract.md)). On our side, custom groups are **consumed read-only** as a recipient scope in the posts flow ([student-recipient-selector.tsx](../../web/components/comms/student-recipient-selector.tsx)). What's missing is the management UI (create, edit, share, delete) and the Excel-upload pipeline. **IA decision:** custom groups live at the **platform level** as a peer of `/posts`, mirroring PGW's IA — they're a shared primitive consumed by Posts (today) and likely Meetings/Reports (later). PGTW-15 (SC = School Cockpit) is flagged as an open question pending PG-team clarification.
+
+### Reports (PGTW-16/17)
+
+Two read-only report tables — Travel Declaration and PG Onboarding — both gated to FT/co-FT and Admin roles. PGW spec at [pg-specs.md §8](../references/pg-specs.md). Each has filters (level / class), an `.xlsx` export, and a drill-down. No write path. Likely the smallest subsystem; can be done in one sprint.
+
+### Access control (PGTW-18/19)
+
+Cross-cutting infra: 90-day inactive logout (18) and PG-admin activation of staff (19). Touches session lifecycle and role provisioning. Likely impacts every other subsystem — if PGW enforces 90-day server-side, our BFF must coordinate; if PGW exposes admin activation only via School Cockpit, we may not implement (19) at all and just document it. Worth scoping early to know what dependencies the others inherit.
+
+### Meetings (PGTW-21/22/23)
+
+PGW has a Parent-Teacher Meeting (PTM) module ([pg-specs.md §6](../references/pg-specs.md)) with create-meeting, timeslot grid, dashboard, and parent-side booking. **No FE parallel in tw-pg-experiment today.** Largest unknown; needs the deepest discovery. Recommend front-loading the audit even if implementation comes later, so we know the scope before quoting.
+
+### Login sync (PGTW-24)
+
+MIMS/Edupass session sync between TW and PG. Pure infra. Likely a BFF concern — possibly out of FE scope entirely. Audit needs to clarify what "in-sync" means: shared session cookie, token exchange, or just a redirect dance.
+
+### Calendar (PGTW-25)
+
+Google Calendar integration. Needs OAuth scope, calendar API client, and a write path. PGW reference unclear from current docs. Treat as greenfield until proven otherwise. Likely depends on Meetings (PGTW-21..23) — calendar events are probably created from meetings.
+
+---
+
+## Dependencies
+
+```
+Access control (18/19) ──► gates session behavior for all others
+Custom groups (13/14/15/20) ──► already a recipient scope in Posts; will likely feed Meetings recipient picker too
+Meetings (21/22/23) ──► likely creates Calendar events (25) → soft dep
+Login sync (24) ──► standalone, but blocks real-PGW e2e until resolved
+Reports (16/17) ──► standalone
+Calendar (25) ──► follows Meetings
+```
+
+Custom groups is the only subsystem with **upstream consumers already shipped** (the recipient selector relies on `customGroups`). Every day that custom groups is read-only, teachers can't create new audiences for posts. That's the highest-leverage parity gap on the board.
+
+---
+
+## Recommended order
+
+Biggest visible gap per unit of work, factoring in dependencies and PG-team cycle time on open questions:
+
+1. **Custom groups (13/14/15/20)** — highest leverage; unblocks recipient-selection flow on the existing posts feature; PGW spec is fully documented.
+2. **Access control (18/19)** — small, infra-y, but answers shape downstream subsystems. Audit it early even if implementation lands later.
+3. **Reports (16/17)** — small, self-contained, no FE prereq. Easy sprint filler.
+4. **Meetings (21/22/23)** — biggest unknown; audit early so estimates are honest, even if build slides.
+5. **Login sync (24)** — likely BFF-only; audit alongside meetings if timing allows.
+6. **Calendar (25)** — depends on meetings; defer.
+
+---
+
+## How to use this doc
+
+When starting a subsystem, copy the structure from [pgtw-1-12-parity-scope.md](pgtw-1-12-parity-scope.md):
+
+1. Per-ticket: **PGW behavior → Current state → Gap → Files**
+2. Cross-cutting gaps section
+3. Suggested ordering
+4. Open questions (frame under "PGW untouchable")
+5. Error / edge-case sweep
+6. Verification criteria
+
+Drop the audit at `docs/audits/pgtw-<range>-<subsystem>-parity-scope.md`, then update the **Status** column above.

--- a/docs/plans/2026-04-30-pgtw-13a-groups-module-shell-plan.md
+++ b/docs/plans/2026-04-30-pgtw-13a-groups-module-shell-plan.md
@@ -1,0 +1,1272 @@
+# PGTW-13a: Groups Module Shell — Overview + Create-Empty Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Light up the `/groups` module foundation — a top-level route showing the user's existing custom groups + assigned groups, a sidebar nav entry, and a `/groups/customGroups/new` create-page shell with the title input and empty states. Save remains disabled until PGTW-13b adds the manual student-selection subpage.
+
+**Architecture:** Mirror PGW's `/groups` IA exactly (URLs are part of parity — see [pg-specs.md §7](../references/pg-specs.md)). New top-level `/groups` and `/groups/customGroups/new` routes load via the existing `react-router` lazy + `Component` + `loader` pattern (same as PostsView). New container files under `web/containers/`, new presentational components under `web/components/groups/`. Reuse `loadCustomGroups()` and `loadGroupsAssigned()` from `web/api/client.ts` — both already wired and BFF-mock-stubbed. No new endpoints called in this plan; the create page's Save button stays disabled until 13b.
+
+**Tech Stack:** React 19, react-router 7, TypeScript 6, Tailwind 4, Vitest + React Testing Library + jsdom. UI primitives from `~/components/ui`; icons from `lucide-react` (matching the existing PostsView idiom).
+
+**Spec reference:** [docs/audits/pgtw-13-20-custom-groups-parity-scope.md](../audits/pgtw-13-20-custom-groups-parity-scope.md) — PGTW-13a sub-item under "Suggested ordering".
+
+---
+
+## File Structure
+
+| File                                                   | Responsibility                                                                                                                                       | Action |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `web/containers/GroupsView.tsx`                        | Route container for `/groups`. Loader fetches custom + assigned groups. Renders Assigned + Custom sections + Create CTA.                             | Create |
+| `web/containers/GroupsView.test.tsx`                   | Container integration tests for `GroupsView` (rendering, empty states, navigation).                                                                  | Create |
+| `web/containers/CreateCustomGroupView.tsx`             | Route container for `/groups/customGroups/new`. Renders title input, empty students state, disabled add-students dropdown, Cancel/Create Now footer. | Create |
+| `web/containers/CreateCustomGroupView.test.tsx`        | Container integration tests.                                                                                                                         | Create |
+| `web/components/groups/CustomGroupsTable.tsx`          | Presentational table of custom groups.                                                                                                               | Create |
+| `web/components/groups/CustomGroupsTable.test.tsx`     | Component tests.                                                                                                                                     | Create |
+| `web/components/groups/AssignedGroupsSection.tsx`      | Presentational card grid for assigned classes + CCAs.                                                                                                | Create |
+| `web/components/groups/AssignedGroupsSection.test.tsx` | Component tests.                                                                                                                                     | Create |
+| `web/App.tsx`                                          | Add `/groups` and `/groups/customGroups/new` lazy routes.                                                                                            | Modify |
+| `web/containers/RootLayout.tsx`                        | Add Groups sidebar item + extend `selected` switch.                                                                                                  | Modify |
+
+No changes to `web/api/client.ts`, `web/api/types.ts`, or BFF — all required types and endpoints exist already.
+
+---
+
+## Task 1: GroupsView container shell + `/groups` route
+
+**Files:**
+
+- Create: `web/containers/GroupsView.tsx`
+- Create: `web/containers/GroupsView.test.tsx`
+- Modify: `web/App.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/containers/GroupsView.test.tsx
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Component as GroupsView } from './GroupsView';
+
+function renderAt(path = '/groups') {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups',
+        Component: GroupsView,
+        loader: () => ({ customGroups: [], assigned: { classes: [], ccaGroups: [] } }),
+      },
+    ],
+    { initialEntries: [path] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('GroupsView', () => {
+  it('renders the page heading', async () => {
+    renderAt();
+    expect(await screen.findByRole('heading', { level: 1, name: /groups/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- GroupsView`
+Expected: FAIL — module `./GroupsView` not found.
+
+- [ ] **Step 3: Implement the minimal container**
+
+```tsx
+// web/containers/GroupsView.tsx
+import React from 'react';
+import { useLoaderData } from 'react-router';
+
+import { loadCustomGroups, loadGroupsAssigned } from '~/api/client';
+import type { PGApiCustomGroupSummary, PGApiGroupsAssigned } from '~/api/types';
+
+interface GroupsLoaderData {
+  customGroups: PGApiCustomGroupSummary[];
+  assigned: PGApiGroupsAssigned;
+}
+
+export async function loader(): Promise<GroupsLoaderData> {
+  const [customList, assigned] = await Promise.all([loadCustomGroups(), loadGroupsAssigned()]);
+  return { customGroups: customList.customGroups, assigned };
+}
+
+const GroupsView: React.FC = () => {
+  const data = useLoaderData() as GroupsLoaderData;
+  void data;
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <h1 className="text-2xl font-semibold">Groups</h1>
+    </div>
+  );
+};
+
+export { GroupsView as Component };
+```
+
+- [ ] **Step 4: Wire the lazy route**
+
+Edit `web/App.tsx`. After the `posts/:id/edit` entry and before `components`, add:
+
+```tsx
+{
+  path: 'groups',
+  lazy: () => import('./containers/GroupsView'),
+},
+```
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run: `pnpm test -- GroupsView`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/containers/GroupsView.tsx web/containers/GroupsView.test.tsx web/App.tsx
+git commit -m "feat(groups): PGTW-13a scaffold \`/groups\` route + \`GroupsView\` shell"
+```
+
+---
+
+## Task 2: Sidebar nav entry for Groups
+
+**Files:**
+
+- Modify: `web/containers/RootLayout.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `web/containers/GroupsView.test.tsx`:
+
+```tsx
+// inside describe('GroupsView', () => { ... })
+import RootLayout from './RootLayout';
+
+it('renders a Groups sidebar item that highlights at /groups', async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        Component: RootLayout,
+        children: [
+          {
+            path: 'groups',
+            Component: GroupsView,
+            loader: () => ({ customGroups: [], assigned: { classes: [], ccaGroups: [] } }),
+          },
+        ],
+      },
+    ],
+    { initialEntries: ['/groups'] },
+  );
+  render(<RouterProvider router={router} />);
+  const nav = await screen.findByRole('link', { name: /groups/i });
+  expect(nav).toHaveAttribute('href', '/groups');
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- GroupsView`
+Expected: FAIL — no link with name "Groups" found.
+
+- [ ] **Step 3: Add the sidebar entry**
+
+Edit `web/containers/RootLayout.tsx`.
+
+a) Extend the icon import:
+
+```tsx
+import { HelpCircle, Home, Mail, UsersRound, FolderKanban } from '@flow/icons';
+```
+
+(If `FolderKanban` isn't exported by `@flow/icons`, fall back to `Users` or `Folder` — confirm with `mcp__flow__list_icons` query "folder" or "group" before substituting.)
+
+b) Extend the `selected` switch:
+
+```tsx
+const selected = useMemo(() => {
+  switch (segment) {
+    case 'students':
+    case 'posts':
+    case 'groups':
+      return segment;
+    default:
+      return '/';
+  }
+}, [segment]);
+```
+
+c) Add the `SidebarItem` after the Posts item, inside `<SidebarContent>`:
+
+```tsx
+<SidebarItem
+  icon={FolderKanban}
+  label="Groups"
+  tooltip="Groups"
+  to="/groups"
+  selected={selected === 'groups'}
+/>
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- GroupsView`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/RootLayout.tsx web/containers/GroupsView.test.tsx
+git commit -m "feat(groups): PGTW-13a add Groups sidebar nav entry"
+```
+
+---
+
+## Task 3: `CustomGroupsTable` — empty state
+
+**Files:**
+
+- Create: `web/components/groups/CustomGroupsTable.tsx`
+- Create: `web/components/groups/CustomGroupsTable.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/components/groups/CustomGroupsTable.test.tsx
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { CustomGroupsTable } from './CustomGroupsTable';
+
+function renderTable(groups: Parameters<typeof CustomGroupsTable>[0]['groups']) {
+  return render(
+    <MemoryRouter>
+      <CustomGroupsTable groups={groups} />
+    </MemoryRouter>,
+  );
+}
+
+describe('CustomGroupsTable', () => {
+  it('renders empty state copy when there are no groups', () => {
+    renderTable([]);
+    expect(screen.getByText(/no custom groups yet/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- CustomGroupsTable`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the empty-state-only component**
+
+```tsx
+// web/components/groups/CustomGroupsTable.tsx
+import React from 'react';
+
+import type { PGApiCustomGroupSummary } from '~/api/types';
+
+interface CustomGroupsTableProps {
+  groups: PGApiCustomGroupSummary[];
+}
+
+export const CustomGroupsTable: React.FC<CustomGroupsTableProps> = ({ groups }) => {
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No custom groups yet.
+      </div>
+    );
+  }
+  return null;
+};
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- CustomGroupsTable`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/groups/CustomGroupsTable.tsx web/components/groups/CustomGroupsTable.test.tsx
+git commit -m "feat(groups): PGTW-13a \`CustomGroupsTable\` empty state"
+```
+
+---
+
+## Task 4: `CustomGroupsTable` — populated rows
+
+**Files:**
+
+- Modify: `web/components/groups/CustomGroupsTable.tsx`
+- Modify: `web/components/groups/CustomGroupsTable.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `CustomGroupsTable.test.tsx` inside the existing `describe`:
+
+```tsx
+import type { PGApiCustomGroupSummary } from '~/api/types';
+
+const olympiad: PGApiCustomGroupSummary = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  studentCount: 8,
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
+it('renders one row per group with name, student count, created on, and created by', () => {
+  renderTable([olympiad]);
+  expect(screen.getByText('Olympiad Study Group')).toBeInTheDocument();
+  expect(screen.getByText('8')).toBeInTheDocument();
+  expect(screen.getByText('TAN GUANG SHIN')).toBeInTheDocument();
+  expect(screen.getByText(/1 mar 2026/i)).toBeInTheDocument();
+});
+
+it('group name is a link to the detail page', () => {
+  renderTable([olympiad]);
+  const link = screen.getByRole('link', { name: 'Olympiad Study Group' });
+  expect(link).toHaveAttribute('href', '/groups/customGroups/5');
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `pnpm test -- CustomGroupsTable`
+Expected: 2 FAIL — rendered DOM is null.
+
+- [ ] **Step 3: Implement the populated table**
+
+```tsx
+// web/components/groups/CustomGroupsTable.tsx
+import { Users } from 'lucide-react';
+import React from 'react';
+import { Link } from 'react-router';
+
+import type { PGApiCustomGroupSummary } from '~/api/types';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui';
+import { formatDate } from '~/helpers/dateTime';
+
+interface CustomGroupsTableProps {
+  groups: PGApiCustomGroupSummary[];
+}
+
+export const CustomGroupsTable: React.FC<CustomGroupsTableProps> = ({ groups }) => {
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No custom groups yet.
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Group name</TableHead>
+          <TableHead className="text-right">No. of students</TableHead>
+          <TableHead>Created on</TableHead>
+          <TableHead>Created by</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {groups.map((g) => (
+          <TableRow key={g.customGroupId}>
+            <TableCell>
+              <Link
+                to={`/groups/customGroups/${g.customGroupId}`}
+                className="font-medium text-foreground hover:underline"
+              >
+                {g.name}
+              </Link>
+            </TableCell>
+            <TableCell className="text-right">
+              <span className="inline-flex items-center gap-1">
+                <Users className="size-4 text-muted-foreground" aria-hidden />
+                {g.studentCount}
+              </span>
+            </TableCell>
+            <TableCell>{formatDate(g.createdAt)}</TableCell>
+            <TableCell>{g.createdByName}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+```
+
+Note: if `formatDate(g.createdAt)` doesn't render as `1 Mar 2026` (the helper might use a different format), tweak the test's regex to match the actual output — DO NOT change the helper. Existing PostsView already calls `formatDate` so its output format is canonical.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test -- CustomGroupsTable`
+Expected: 3 PASS (empty state + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/groups/CustomGroupsTable.tsx web/components/groups/CustomGroupsTable.test.tsx
+git commit -m "feat(groups): PGTW-13a \`CustomGroupsTable\` populated rows"
+```
+
+---
+
+## Task 5: Wire `CustomGroupsTable` into `GroupsView`
+
+**Files:**
+
+- Modify: `web/containers/GroupsView.tsx`
+- Modify: `web/containers/GroupsView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe('GroupsView', …)` block:
+
+```tsx
+it('renders the custom-groups table populated from the loader', async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups',
+        Component: GroupsView,
+        loader: () => ({
+          customGroups: [
+            {
+              customGroupId: 5,
+              name: 'Olympiad Study Group',
+              studentCount: 8,
+              createdBy: 1013,
+              createdByName: 'TAN GUANG SHIN',
+              isShared: false,
+              createdAt: '2026-03-01T08:00:00.000Z',
+            },
+          ],
+          assigned: { classes: [], ccaGroups: [] },
+        }),
+      },
+    ],
+    { initialEntries: ['/groups'] },
+  );
+  render(<RouterProvider router={router} />);
+  expect(await screen.findByText('Olympiad Study Group')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- GroupsView`
+Expected: FAIL — "Olympiad Study Group" not in document.
+
+- [ ] **Step 3: Wire the table into `GroupsView`**
+
+Edit `web/containers/GroupsView.tsx`. Add the import and replace the body:
+
+```tsx
+import { CustomGroupsTable } from '~/components/groups/CustomGroupsTable';
+```
+
+Replace the `<div>` body with:
+
+```tsx
+return (
+  <div className="px-4 py-6 md:px-6">
+    <h1 className="text-2xl font-semibold">Groups</h1>
+    <section className="mt-8">
+      <h2 className="text-lg font-semibold">
+        Custom Groups{' '}
+        <span className="text-sm font-normal text-muted-foreground">
+          ({data.customGroups.length} created)
+        </span>
+      </h2>
+      <div className="mt-3">
+        <CustomGroupsTable groups={data.customGroups} />
+      </div>
+    </section>
+  </div>
+);
+```
+
+Remove the `void data;` line.
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- GroupsView`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/GroupsView.tsx web/containers/GroupsView.test.tsx
+git commit -m "feat(groups): PGTW-13a render \`CustomGroupsTable\` inside \`GroupsView\`"
+```
+
+---
+
+## Task 6: `AssignedGroupsSection` component
+
+**Files:**
+
+- Create: `web/components/groups/AssignedGroupsSection.tsx`
+- Create: `web/components/groups/AssignedGroupsSection.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// web/components/groups/AssignedGroupsSection.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiGroupsAssigned } from '~/api/types';
+
+import { AssignedGroupsSection } from './AssignedGroupsSection';
+
+const empty: PGApiGroupsAssigned = { classes: [], ccaGroups: [] };
+
+describe('AssignedGroupsSection', () => {
+  it('renders empty-state copy when no classes or CCAs are assigned', () => {
+    render(<AssignedGroupsSection assigned={empty} />);
+    expect(screen.getByText(/no assigned groups/i)).toBeInTheDocument();
+  });
+
+  it('renders one card per class with the class name and a "Form Class" label', () => {
+    render(
+      <AssignedGroupsSection
+        assigned={{
+          classes: [
+            {
+              classId: 1005,
+              className: 'P1 KINDNESS',
+              level: 'P1',
+              year: 2026,
+              role: 'FT',
+              studentCount: 30,
+            },
+          ],
+          ccaGroups: [],
+        }}
+      />,
+    );
+    expect(screen.getByText('P1 KINDNESS')).toBeInTheDocument();
+    expect(screen.getByText(/form class/i)).toBeInTheDocument();
+  });
+
+  it('renders one card per CCA with the CCA description and a "CCA" label', () => {
+    render(
+      <AssignedGroupsSection
+        assigned={{
+          classes: [],
+          ccaGroups: [{ ccaId: 1001, ccaDescription: 'AIR RIFLE / SHOOTING', studentCount: 12 }],
+        }}
+      />,
+    );
+    expect(screen.getByText('AIR RIFLE / SHOOTING')).toBeInTheDocument();
+    expect(screen.getByText(/^cca$/i)).toBeInTheDocument();
+  });
+});
+```
+
+Type shapes verified against [web/api/types.ts:388-401](../../web/api/types.ts#L388-L401): `PGApiGroupsAssignedClass = { classId, className, level, year, role, studentCount }`; `PGApiGroupsAssignedCcaGroup = { ccaId, ccaDescription, studentCount }`. Do NOT modify the types — if these change before implementation, update the fixtures, not the type.
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `pnpm test -- AssignedGroupsSection`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the section**
+
+```tsx
+// web/components/groups/AssignedGroupsSection.tsx
+import React from 'react';
+
+import type { PGApiGroupsAssigned } from '~/api/types';
+
+interface AssignedGroupsSectionProps {
+  assigned: PGApiGroupsAssigned;
+}
+
+export const AssignedGroupsSection: React.FC<AssignedGroupsSectionProps> = ({ assigned }) => {
+  const isEmpty = assigned.classes.length === 0 && assigned.ccaGroups.length === 0;
+
+  if (isEmpty) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No assigned groups.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {assigned.classes.map((c) => (
+        <article key={`class-${c.classId}`} className="rounded-md border border-border bg-card p-4">
+          <h3 className="font-medium">{c.className}</h3>
+          <p className="text-xs text-muted-foreground">Form Class</p>
+        </article>
+      ))}
+      {assigned.ccaGroups.map((g) => (
+        <article key={`cca-${g.ccaId}`} className="rounded-md border border-border bg-card p-4">
+          <h3 className="font-medium">{g.ccaDescription || 'Untitled CCA'}</h3>
+          <p className="text-xs text-muted-foreground">CCA</p>
+        </article>
+      ))}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test -- AssignedGroupsSection`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/groups/AssignedGroupsSection.tsx web/components/groups/AssignedGroupsSection.test.tsx
+git commit -m "feat(groups): PGTW-13a \`AssignedGroupsSection\` card grid"
+```
+
+---
+
+## Task 7: Wire `AssignedGroupsSection` into `GroupsView`
+
+**Files:**
+
+- Modify: `web/containers/GroupsView.tsx`
+- Modify: `web/containers/GroupsView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe('GroupsView', …)` block:
+
+```tsx
+it('renders the assigned-groups section above the custom-groups section', async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups',
+        Component: GroupsView,
+        loader: () => ({
+          customGroups: [],
+          assigned: {
+            classes: [
+              {
+                classId: 1005,
+                className: 'P1 KINDNESS',
+                level: 'P1',
+                year: 2026,
+                role: 'FT',
+                studentCount: 30,
+              },
+            ],
+            ccaGroups: [],
+          },
+        }),
+      },
+    ],
+    { initialEntries: ['/groups'] },
+  );
+  render(<RouterProvider router={router} />);
+  expect(await screen.findByText('P1 KINDNESS')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- GroupsView`
+Expected: FAIL — "P1 KINDNESS" not in document.
+
+- [ ] **Step 3: Wire the section**
+
+Edit `web/containers/GroupsView.tsx`. Add the import:
+
+```tsx
+import { AssignedGroupsSection } from '~/components/groups/AssignedGroupsSection';
+```
+
+Insert this section ABOVE the existing Custom Groups section in the JSX:
+
+```tsx
+<section className="mt-6">
+  <h2 className="text-lg font-semibold">Assigned Groups</h2>
+  <div className="mt-3">
+    <AssignedGroupsSection assigned={data.assigned} />
+  </div>
+</section>
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- GroupsView`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/GroupsView.tsx web/containers/GroupsView.test.tsx
+git commit -m "feat(groups): PGTW-13a render \`AssignedGroupsSection\` inside \`GroupsView\`"
+```
+
+---
+
+## Task 8: "+ Create custom group" CTA on overview
+
+**Files:**
+
+- Modify: `web/containers/GroupsView.tsx`
+- Modify: `web/containers/GroupsView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe('GroupsView', …)` block:
+
+```tsx
+it('shows a "Create custom group" CTA that links to /groups/customGroups/new', async () => {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups',
+        Component: GroupsView,
+        loader: () => ({ customGroups: [], assigned: { classes: [], ccaGroups: [] } }),
+      },
+    ],
+    { initialEntries: ['/groups'] },
+  );
+  render(<RouterProvider router={router} />);
+  const cta = await screen.findByRole('link', { name: /create custom group/i });
+  expect(cta).toHaveAttribute('href', '/groups/customGroups/new');
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- GroupsView`
+Expected: FAIL — link not found.
+
+- [ ] **Step 3: Add the CTA**
+
+Edit `web/containers/GroupsView.tsx`. Add imports:
+
+```tsx
+import { Plus } from 'lucide-react';
+import { Link } from 'react-router';
+import { Button } from '~/components/ui';
+```
+
+Wrap the heading in a flex row so the CTA sits on the right:
+
+```tsx
+<div className="flex items-center justify-between">
+  <h1 className="text-2xl font-semibold">Groups</h1>
+  <Button asChild>
+    <Link to="/groups/customGroups/new">
+      <Plus className="size-4" aria-hidden />
+      Create custom group
+    </Link>
+  </Button>
+</div>
+```
+
+If the local `Button` primitive doesn't expose `asChild`, fall back to `<Link>` with a button-like className — check `web/components/ui/button.tsx` first; mirror whichever pattern PostsView uses for the "+ New post" CTA.
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- GroupsView`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/GroupsView.tsx web/containers/GroupsView.test.tsx
+git commit -m "feat(groups): PGTW-13a \`+ Create custom group\` CTA on overview"
+```
+
+---
+
+## Task 9: `CreateCustomGroupView` shell + `/groups/customGroups/new` route
+
+**Files:**
+
+- Create: `web/containers/CreateCustomGroupView.tsx`
+- Create: `web/containers/CreateCustomGroupView.test.tsx`
+- Modify: `web/App.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/containers/CreateCustomGroupView.test.tsx
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Component as CreateCustomGroupView } from './CreateCustomGroupView';
+
+function renderView() {
+  const router = createMemoryRouter(
+    [{ path: '/groups/customGroups/new', Component: CreateCustomGroupView }],
+    { initialEntries: ['/groups/customGroups/new'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('CreateCustomGroupView', () => {
+  it('renders the page heading "Create new group"', async () => {
+    renderView();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /create new group/i }),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the shell + register the route**
+
+```tsx
+// web/containers/CreateCustomGroupView.tsx
+import React from 'react';
+
+const CreateCustomGroupView: React.FC = () => {
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <h1 className="text-2xl font-semibold">Create new group</h1>
+    </div>
+  );
+};
+
+export { CreateCustomGroupView as Component };
+```
+
+Edit `web/App.tsx`. After the `groups` entry, add:
+
+```tsx
+{
+  path: 'groups/customGroups/new',
+  lazy: () => import('./containers/CreateCustomGroupView'),
+},
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx web/App.tsx
+git commit -m "feat(groups): PGTW-13a scaffold \`/groups/customGroups/new\` + \`CreateCustomGroupView\` shell"
+```
+
+---
+
+## Task 10: Title input with 120-char limit + counter
+
+**Files:**
+
+- Modify: `web/containers/CreateCustomGroupView.tsx`
+- Modify: `web/containers/CreateCustomGroupView.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `describe`:
+
+```tsx
+import { fireEvent } from '@testing-library/react';
+
+it('allows typing into the title input and shows the remaining-character counter', () => {
+  renderView();
+  const input = screen.getByLabelText(/title/i) as HTMLInputElement;
+  fireEvent.change(input, { target: { value: 'Olympiad Squad' } });
+  expect(input.value).toBe('Olympiad Squad');
+  expect(screen.getByText(/106 characters left/i)).toBeInTheDocument();
+});
+
+it('does not allow typing past 120 characters', () => {
+  renderView();
+  const input = screen.getByLabelText(/title/i) as HTMLInputElement;
+  fireEvent.change(input, { target: { value: 'a'.repeat(150) } });
+  expect(input.value.length).toBe(120);
+  expect(screen.getByText(/0 characters left/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: 2 FAIL — input not found.
+
+- [ ] **Step 3: Implement the controlled input + counter**
+
+Replace the body of `CreateCustomGroupView.tsx` with:
+
+```tsx
+import React, { useState } from 'react';
+
+import { Input } from '~/components/ui';
+
+const TITLE_MAX = 120;
+
+const CreateCustomGroupView: React.FC = () => {
+  const [title, setTitle] = useState('');
+
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <h1 className="text-2xl font-semibold">Create new group</h1>
+      <div className="mt-6 max-w-2xl">
+        <label htmlFor="group-title" className="text-sm font-medium">
+          Title<span className="text-destructive">*</span>
+        </label>
+        <Input
+          id="group-title"
+          value={title}
+          maxLength={TITLE_MAX}
+          onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+          placeholder="What would you like to call your group?"
+          className="mt-1"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          {TITLE_MAX - title.length} characters left
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export { CreateCustomGroupView as Component };
+```
+
+If the local `Input` primitive's API differs (e.g. accepts `onValueChange` instead of `onChange`), match its signature — read `web/components/ui/input.tsx` and mirror PostsView's title input.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: 3 PASS (heading + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx
+git commit -m "feat(groups): PGTW-13a title input with 120-char counter on create page"
+```
+
+---
+
+## Task 11: Empty students state
+
+**Files:**
+
+- Modify: `web/containers/CreateCustomGroupView.tsx`
+- Modify: `web/containers/CreateCustomGroupView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe`:
+
+```tsx
+it('shows the empty students state with a "0 students added" counter and "No students added yet." copy', () => {
+  renderView();
+  expect(screen.getByText(/0 students added/i)).toBeInTheDocument();
+  expect(screen.getByText(/no students added yet/i)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the empty students section**
+
+In `CreateCustomGroupView.tsx`, append below the title block (still inside the `max-w-2xl` div):
+
+```tsx
+<div className="mt-6">
+  <p className="text-sm font-medium">0 students added.</p>
+  <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+    No students added yet.
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx
+git commit -m "feat(groups): PGTW-13a empty students state on create page"
+```
+
+---
+
+## Task 12: "+ Add Students" dropdown with disabled items
+
+**Files:**
+
+- Modify: `web/containers/CreateCustomGroupView.tsx`
+- Modify: `web/containers/CreateCustomGroupView.test.tsx`
+
+PGW shows two items in this dropdown ("Add manually", "Upload via Excel"). Both are wired in PGTW-13b/13d; in 13a the button renders but both items are `disabled` so clicking has no navigation effect.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe`:
+
+```tsx
+it('shows an "+ Add Students" dropdown with two disabled items', async () => {
+  renderView();
+  const trigger = screen.getByRole('button', { name: /add students/i });
+  fireEvent.click(trigger);
+  const manual = await screen.findByRole('menuitem', { name: /add manually/i });
+  const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
+  expect(manual).toHaveAttribute('aria-disabled', 'true');
+  expect(excel).toHaveAttribute('aria-disabled', 'true');
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: FAIL — button not found.
+
+- [ ] **Step 3: Add the dropdown**
+
+Edit `CreateCustomGroupView.tsx`. Add imports:
+
+```tsx
+import { Plus } from 'lucide-react';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '~/components/ui';
+```
+
+Replace the empty-students block from Task 11 with:
+
+```tsx
+<div className="mt-6">
+  <div className="flex items-center justify-between">
+    <p className="text-sm font-medium">0 students added.</p>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">
+          <Plus className="size-4" aria-hidden />
+          Add Students
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem disabled>Add manually</DropdownMenuItem>
+        <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+  <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+    No students added yet.
+  </div>
+</div>
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: ALL PASS.
+
+If `DropdownMenuItem` renders `aria-disabled="true"` on `disabled` automatically, the test passes as written. If not, the local primitive may need an explicit `aria-disabled={true}` prop — check the existing PostsView dropdown usage and mirror it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx
+git commit -m "feat(groups): PGTW-13a disabled \`+ Add Students\` dropdown on create page"
+```
+
+---
+
+## Task 13: Cancel + Create Now footer (Cancel works, Create disabled)
+
+**Files:**
+
+- Modify: `web/containers/CreateCustomGroupView.tsx`
+- Modify: `web/containers/CreateCustomGroupView.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing `describe`:
+
+```tsx
+it('shows a Cancel link that navigates back to /groups', async () => {
+  renderView();
+  const cancel = await screen.findByRole('link', { name: /cancel/i });
+  expect(cancel).toHaveAttribute('href', '/groups');
+});
+
+it('disables the Create Now button when there are no students or no title', async () => {
+  renderView();
+  const create = screen.getByRole('button', { name: /create now/i });
+  expect(create).toBeDisabled();
+
+  // Even with a title, no students → still disabled.
+  const input = screen.getByLabelText(/title/i) as HTMLInputElement;
+  fireEvent.change(input, { target: { value: 'Some title' } });
+  expect(create).toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: 2 FAIL — buttons not found.
+
+- [ ] **Step 3: Add the footer**
+
+Edit `CreateCustomGroupView.tsx`. Add imports:
+
+```tsx
+import { Link } from 'react-router';
+```
+
+Append to the bottom of the `max-w-2xl` div:
+
+```tsx
+<div className="mt-8 flex items-center justify-end gap-3">
+  <Link to="/groups" className="text-sm font-medium text-muted-foreground hover:underline">
+    Cancel
+  </Link>
+  <Button disabled title="Add at least one student to create the group">
+    Create Now
+  </Button>
+</div>
+```
+
+The `disabled` attribute is hard-coded in 13a — there is no way to add students yet. PGTW-13b will replace this with a `disabled={title.length === 0 || students.length === 0}` expression once selected students are wired into state.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run: `pnpm test -- CreateCustomGroupView`
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx
+git commit -m "feat(groups): PGTW-13a Cancel + (disabled) Create Now footer on create page"
+```
+
+---
+
+## Task 14: Manual smoke test in mock mode
+
+The unit tests above lock in component behavior; this task confirms the route boots end-to-end against the BFF mock per [memory: port pgw-web tests first; otherwise curl+click before marking done](../../../.claude/projects/-Users-shin-Desktop-projects-tw-pg-experiment/memory/feedback-verify-before-done.md).
+
+- [ ] **Step 1: Start both servers**
+
+In two shells from the repo root (with `TW_PG_MOCK=true` in your `.env`):
+
+```bash
+go run ./server/cmd/tw    # shell 1 — BFF on :3000
+pnpm dev                  # shell 2 — Vite on :5173
+```
+
+- [ ] **Step 2: Open http://localhost:5173/groups in a browser**
+
+Confirm:
+
+- Sidebar highlights "Groups".
+- Page heading reads "Groups".
+- Assigned Groups section renders cards from `groups_assigned.json`.
+- Custom Groups table shows the "Olympiad Study Group" row from `groups_custom.json`.
+- Clicking the row's group name navigates to `/groups/customGroups/5` (404 expected — no detail route in 13a).
+- "+ Create custom group" CTA is visible top-right.
+
+- [ ] **Step 3: Click "+ Create custom group"**
+
+Confirm:
+
+- URL is `/groups/customGroups/new`.
+- Heading reads "Create new group".
+- Title input accepts up to 120 characters; counter updates as you type.
+- Empty students state shows "0 students added." and "No students added yet."
+- "+ Add Students" dropdown opens; both items appear visually disabled.
+- "Cancel" link navigates back to `/groups`.
+- "Create Now" button is disabled.
+
+- [ ] **Step 4: Run the full unit-test suite**
+
+```bash
+pnpm test
+```
+
+Expected: full suite PASSES, including the new GroupsView, CreateCustomGroupView, CustomGroupsTable, AssignedGroupsSection tests.
+
+- [ ] **Step 5: Run lint + typecheck**
+
+```bash
+pnpm lint
+pnpm format
+go test ./...        # confirm no BFF regressions
+golangci-lint run    # if installed
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Final sanity commit (if anything was tweaked during smoke testing)**
+
+If steps 1-5 surfaced minor fixes, commit them:
+
+```bash
+git add -p          # review and stage interactively
+git commit -m "fix(groups): PGTW-13a address smoke-test findings"
+```
+
+If no fixes were needed, skip this step.
+
+---
+
+## Out of scope (deferred to later PGTW-13/14/15/20 sub-plans)
+
+- Manual student-selection subpage `/groups/customGroups/:id/edit/addStudents` (PGTW-13b).
+- Group detail page + edit page (PGTW-13c).
+- Share modal + "Shared with you" tab (PGTW-14).
+- Single + multi-select delete (PGTW-20a, b).
+- Excel upload pipeline (PGTW-13d — blocked on PG-team confirmation; see open questions in [docs/audits/pgtw-13-20-custom-groups-parity-scope.md](../audits/pgtw-13-20-custom-groups-parity-scope.md)).
+- SC custom group (PGTW-15 — blocked).
+- "+ Create new group" shortcut from the posts recipient picker (cross-cutting follow-up).
+- Wiring the kebab menu (View / Edit / Delete) on each table row — depends on detail/edit/delete pages above.
+
+---
+
+## Self-review checklist (run after implementation)
+
+- [ ] Every task's tests pass in isolation (`pnpm test -- <file>`) and as a suite (`pnpm test`).
+- [ ] `/groups` route renders against the mock fixtures with no console errors.
+- [ ] Sidebar highlights "Groups" when on `/groups` and on `/groups/customGroups/new`.
+- [ ] Title-counter copy matches PGW spec ("N characters left") — check [pg-specs.md §7.7](../references/pg-specs.md).
+- [ ] No new endpoints called; no changes to `web/api/client.ts`, `types.ts`, or BFF mock.
+- [ ] No backwards-compat shims, no TODO comments, no dead code.

--- a/docs/plans/2026-05-04-pgtw-13b-add-students-subpage-plan.md
+++ b/docs/plans/2026-05-04-pgtw-13b-add-students-subpage-plan.md
@@ -1,0 +1,1207 @@
+# PGTW-13b: Manual Add-Students Subpage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the manual student-selection subpage that PGW exposes at `/groups/customGroups/:id/edit/addStudents` ([pg-specs.md §7.4](../references/pg-specs.md)) — a searchable + filterable + paginated checkbox table that returns the selected students to the parent (create or edit) page. In PGTW-13b we wire it to the **create flow only** (`/groups/customGroups/new/addStudents`); the edit-flow URL lands with PGTW-13c when the edit page exists.
+
+**Architecture:** New route renders `AddStudentsView` which loads `/school/students` + `/school/groups` (classes) via the route loader. Selection state (a `Set<studentId>`) lives in the view and persists across pagination. Submitting "Add N selected" navigates back to `/groups/customGroups/new` with the selected `studentId[]` in `useNavigate`'s `state` option. `CreateCustomGroupView` reads `useLocation().state` on mount and seeds its student counter. Already-added students passed _into_ the subpage via the same `state` channel are pre-checked and excluded from the "available" count.
+
+**Tech Stack:** React 19, react-router 7 (`useLoaderData`, `useNavigate`, `useLocation`), TypeScript 6, Tailwind 4, Vitest + React Testing Library + jsdom. Existing `~/components/ui` primitives (Checkbox, Input, Select, Table, Button). No new dependencies.
+
+**Spec reference:** [docs/audits/pgtw-13-20-custom-groups-parity-scope.md](../audits/pgtw-13-20-custom-groups-parity-scope.md) — PGTW-13b sub-item, plus [pg-specs.md §7.4](../references/pg-specs.md).
+
+**Phase-1 scope cuts (deferred):**
+
+- "All Students | CCA" radio at the top — defer; render All Students only. PGW spec describes the radio but the CCA mode is closer to PGTW-14 sharing logic. File as follow-up.
+- Edit-flow URL `/groups/customGroups/:id/edit/addStudents` — lands with PGTW-13c.
+- "N students already added" header copy — Phase 1 wires the counter only when the parent passes `alreadyAdded` IDs in. Defer the visual delta until 13c.
+
+---
+
+## File Structure
+
+| File                                                 | Responsibility                                                                                                                                                                                  | Action |
+| ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `web/containers/AddStudentsView.tsx`                 | Route container for `/groups/customGroups/new/addStudents`. Loader fetches students + classes. Renders header, filter bar, paginated table, footer. Owns selection + filter + pagination state. | Create |
+| `web/containers/AddStudentsView.test.tsx`            | Container integration tests (rendering, selection toggle, select-all, pagination, filters, submit).                                                                                             | Create |
+| `web/components/groups/StudentResultsTable.tsx`      | Presentational paginated checkbox table with select-all in the header.                                                                                                                          | Create |
+| `web/components/groups/StudentResultsTable.test.tsx` | Component tests.                                                                                                                                                                                | Create |
+| `web/components/groups/StudentFilterBar.tsx`         | Presentational Level dropdown + Form Class dropdown + search input. Emits filter changes via callbacks.                                                                                         | Create |
+| `web/components/groups/StudentFilterBar.test.tsx`    | Component tests.                                                                                                                                                                                | Create |
+| `web/containers/CreateCustomGroupView.tsx`           | Wire "Add manually" → navigate to subpage; receive back selected students via `useLocation().state`; render dynamic counter ("N students added") and the simple list of names.                  | Modify |
+| `web/containers/CreateCustomGroupView.test.tsx`      | Add tests for navigation + state hand-off.                                                                                                                                                      | Modify |
+| `web/App.tsx`                                        | Add lazy route `/groups/customGroups/new/addStudents`.                                                                                                                                          | Modify |
+
+No changes to `web/api/client.ts`, `web/api/types.ts`, or BFF — all required types (`PGApiSchoolStudent`, `PGApiSchoolClass`) and endpoints (`fetchSchoolStudents`, `fetchSchoolClasses`) exist.
+
+---
+
+## Task 1: Route + `AddStudentsView` shell
+
+**Files:**
+
+- Create: `web/containers/AddStudentsView.tsx`
+- Create: `web/containers/AddStudentsView.test.tsx`
+- Modify: `web/App.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/containers/AddStudentsView.test.tsx
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Component as AddStudentsView } from './AddStudentsView';
+
+const stubLoader = () => ({ students: [], classes: [] });
+
+function renderAt(path = '/groups/customGroups/new/addStudents') {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/new/addStudents',
+        Component: AddStudentsView,
+        loader: stubLoader,
+      },
+    ],
+    { initialEntries: [path] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('AddStudentsView', () => {
+  it('renders the page heading "Add students"', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /add students/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a close link back to /groups/customGroups/new', async () => {
+    renderAt();
+    const close = await screen.findByRole('link', { name: /close|cancel/i });
+    expect(close).toHaveAttribute('href', '/groups/customGroups/new');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a
+pnpm test -- AddStudentsView
+```
+
+Expected: FAIL — module `./AddStudentsView` not found.
+
+- [ ] **Step 3: Implement the shell**
+
+```tsx
+// web/containers/AddStudentsView.tsx
+import { X } from 'lucide-react';
+import React from 'react';
+import { Link, useLoaderData } from 'react-router';
+
+import { fetchSchoolClasses, fetchSchoolStudents } from '~/api/client';
+import type { PGApiSchoolClass, PGApiSchoolStudent } from '~/api/types';
+
+interface AddStudentsLoaderData {
+  students: PGApiSchoolStudent[];
+  classes: PGApiSchoolClass[];
+}
+
+export async function loader(): Promise<AddStudentsLoaderData> {
+  const [students, classes] = await Promise.all([fetchSchoolStudents(), fetchSchoolClasses()]);
+  return { students, classes };
+}
+
+const AddStudentsView: React.FC = () => {
+  const data = useLoaderData() as AddStudentsLoaderData;
+  void data;
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-4xl">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Add students</h1>
+          <Link
+            to="/groups/customGroups/new"
+            aria-label="Close"
+            className="rounded-md p-2 text-muted-foreground hover:bg-muted"
+          >
+            <X className="size-5" aria-hidden />
+          </Link>
+        </header>
+      </div>
+    </div>
+  );
+};
+
+export { AddStudentsView as Component };
+```
+
+`fetchSchoolClasses` returns the unwrapped class list per `web/api/client.ts:753-756`. If you read that and find it actually returns `{ class: PGApiSchoolClass[] }` instead of a bare array, adjust the destructure in the loader: `const { class: classes } = await fetchSchoolClasses();`. The unit test passes either way because it uses a stub loader.
+
+- [ ] **Step 4: Wire the lazy route**
+
+Edit `web/App.tsx`. After the `groups/customGroups/new` entry, add:
+
+```tsx
+{
+  path: 'groups/customGroups/new/addStudents',
+  lazy: () => import('./containers/AddStudentsView'),
+},
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+```bash
+pnpm test -- AddStudentsView
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/containers/AddStudentsView.tsx web/containers/AddStudentsView.test.tsx web/App.tsx
+git commit -m "feat(groups): PGTW-13b scaffold \`/groups/customGroups/new/addStudents\` route"
+```
+
+---
+
+## Task 2: `StudentResultsTable` — empty state + populated rows
+
+**Files:**
+
+- Create: `web/components/groups/StudentResultsTable.tsx`
+- Create: `web/components/groups/StudentResultsTable.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// web/components/groups/StudentResultsTable.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PGApiSchoolStudent } from '~/api/types';
+
+import { StudentResultsTable } from './StudentResultsTable';
+
+const aldddin: PGApiSchoolStudent = {
+  studentId: 1025,
+  studentName: 'ALDDIN ANG MO KIO',
+  uinFinNo: 'S9000003A',
+  classSerialNo: '15',
+  classCode: 'H6-05',
+  className: 'H6 KINDNESS',
+  levelCode: 'H6',
+  levelDescription: 'HIGHER 6',
+  cca: [],
+};
+
+describe('StudentResultsTable', () => {
+  it('renders empty state copy when there are no rows', () => {
+    render(
+      <StudentResultsTable
+        rows={[]}
+        selectedIds={new Set()}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no students match/i)).toBeInTheDocument();
+  });
+
+  it('renders one row per student with name, UIN, class', () => {
+    render(
+      <StudentResultsTable
+        rows={[aldddin]}
+        selectedIds={new Set()}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('ALDDIN ANG MO KIO')).toBeInTheDocument();
+    expect(screen.getByText(/S9000003A/i)).toBeInTheDocument();
+    expect(screen.getByText(/H6 KINDNESS/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+pnpm test -- StudentResultsTable
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the table**
+
+```tsx
+// web/components/groups/StudentResultsTable.tsx
+import React from 'react';
+
+import type { PGApiSchoolStudent } from '~/api/types';
+import {
+  Checkbox,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui';
+
+interface StudentResultsTableProps {
+  rows: PGApiSchoolStudent[];
+  selectedIds: Set<number>;
+  onToggle: (studentId: number) => void;
+  onToggleAll: (rowIds: number[]) => void;
+}
+
+export const StudentResultsTable: React.FC<StudentResultsTableProps> = ({
+  rows,
+  selectedIds,
+  onToggle,
+  onToggleAll,
+}) => {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No students match.
+      </div>
+    );
+  }
+
+  const allSelected = rows.every((r) => selectedIds.has(r.studentId));
+  const rowIds = rows.map((r) => r.studentId);
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <Checkbox
+              aria-label="Select all on this page"
+              checked={allSelected}
+              onCheckedChange={() => onToggleAll(rowIds)}
+            />
+          </TableHead>
+          <TableHead>Name</TableHead>
+          <TableHead>Class / Index</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((s) => (
+          <TableRow key={s.studentId}>
+            <TableCell>
+              <Checkbox
+                aria-label={`Select ${s.studentName}`}
+                checked={selectedIds.has(s.studentId)}
+                onCheckedChange={() => onToggle(s.studentId)}
+              />
+            </TableCell>
+            <TableCell>
+              <div className="font-medium">{s.studentName}</div>
+              <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
+            </TableCell>
+            <TableCell>
+              <div>{s.className}</div>
+              <div className="text-xs text-muted-foreground">#{s.classSerialNo}</div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+```
+
+If `Checkbox` from `~/components/ui` doesn't accept `onCheckedChange` (e.g. it accepts `onChange` on the underlying input), adapt to whatever signature the existing Checkbox primitive uses — read `web/components/ui/checkbox.tsx` and mirror PostsView's usage if there is one.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+pnpm test -- StudentResultsTable
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/groups/StudentResultsTable.tsx web/components/groups/StudentResultsTable.test.tsx
+git commit -m "feat(groups): PGTW-13b \`StudentResultsTable\` empty + populated states"
+```
+
+---
+
+## Task 3: `StudentResultsTable` — selection toggle + select-all
+
+**Files:**
+
+- Modify: `web/components/groups/StudentResultsTable.test.tsx`
+
+The component already accepts `onToggle` / `onToggleAll`. This task adds tests proving callbacks fire correctly with the right IDs, and checks visual selection state.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe`:
+
+```tsx
+import { fireEvent } from '@testing-library/react';
+
+it('calls onToggle with the studentId when a row checkbox is clicked', () => {
+  const onToggle = vi.fn();
+  render(
+    <StudentResultsTable
+      rows={[aldddin]}
+      selectedIds={new Set()}
+      onToggle={onToggle}
+      onToggleAll={vi.fn()}
+    />,
+  );
+  fireEvent.click(screen.getByRole('checkbox', { name: /select aldddin/i }));
+  expect(onToggle).toHaveBeenCalledWith(1025);
+});
+
+it('shows the row checkbox as checked when its id is in selectedIds', () => {
+  render(
+    <StudentResultsTable
+      rows={[aldddin]}
+      selectedIds={new Set([1025])}
+      onToggle={vi.fn()}
+      onToggleAll={vi.fn()}
+    />,
+  );
+  expect(screen.getByRole('checkbox', { name: /select aldddin/i })).toBeChecked();
+});
+
+it('calls onToggleAll with the visible row ids when select-all is clicked', () => {
+  const onToggleAll = vi.fn();
+  render(
+    <StudentResultsTable
+      rows={[aldddin]}
+      selectedIds={new Set()}
+      onToggle={vi.fn()}
+      onToggleAll={onToggleAll}
+    />,
+  );
+  fireEvent.click(screen.getByRole('checkbox', { name: /select all on this page/i }));
+  expect(onToggleAll).toHaveBeenCalledWith([1025]);
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they pass without further code changes**
+
+```bash
+pnpm test -- StudentResultsTable
+```
+
+Expected: 5 PASS (the impl already supports these contracts; this task locks them in).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/components/groups/StudentResultsTable.test.tsx
+git commit -m "test(groups): PGTW-13b lock in \`StudentResultsTable\` selection contract"
+```
+
+---
+
+## Task 4: `StudentFilterBar` — Level + Form Class dropdowns + search input
+
+**Files:**
+
+- Create: `web/components/groups/StudentFilterBar.tsx`
+- Create: `web/components/groups/StudentFilterBar.test.tsx`
+
+PGW spec §7.4: "Search student name or class name" text input, "All levels" dropdown, "All classes" dropdown. Levels are derived from the loaded students' `levelDescription`; classes come from `/school/groups`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// web/components/groups/StudentFilterBar.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { StudentFilterBar } from './StudentFilterBar';
+
+const baseProps = {
+  query: '',
+  onQueryChange: vi.fn(),
+  levelOptions: ['HIGHER 6', 'PRIMARY 1'],
+  level: '',
+  onLevelChange: vi.fn(),
+  classOptions: [
+    { label: 'P1 KINDNESS (2026)', value: 1005 },
+    { label: 'H6 KINDNESS (2026)', value: 1018 },
+  ],
+  classId: '',
+  onClassChange: vi.fn(),
+};
+
+describe('StudentFilterBar', () => {
+  it('renders the search input with the spec placeholder', () => {
+    render(<StudentFilterBar {...baseProps} />);
+    expect(screen.getByPlaceholderText(/search student name or class name/i)).toBeInTheDocument();
+  });
+
+  it('emits onQueryChange when the user types', () => {
+    const onQueryChange = vi.fn();
+    render(<StudentFilterBar {...baseProps} onQueryChange={onQueryChange} />);
+    fireEvent.change(screen.getByPlaceholderText(/search student/i), {
+      target: { value: 'al' },
+    });
+    expect(onQueryChange).toHaveBeenCalledWith('al');
+  });
+
+  it('renders one Level option per provided level + an "All levels" sentinel', () => {
+    render(<StudentFilterBar {...baseProps} />);
+    const select = screen.getByLabelText(/level/i) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.label);
+    expect(options).toEqual(['All levels', 'HIGHER 6', 'PRIMARY 1']);
+  });
+
+  it('renders one Form Class option per provided class + an "All classes" sentinel', () => {
+    render(<StudentFilterBar {...baseProps} />);
+    const select = screen.getByLabelText(/form class/i) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.label);
+    expect(options).toEqual(['All classes', 'P1 KINDNESS (2026)', 'H6 KINDNESS (2026)']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+pnpm test -- StudentFilterBar
+```
+
+Expected: 4 FAIL — module not found.
+
+- [ ] **Step 3: Implement the filter bar with native `<select>` elements**
+
+Native `<select>` is used so the test can introspect options without driving Radix popovers. The look is plain; if a designer wants the styled `~/components/ui/Select` later, swap in a follow-up.
+
+```tsx
+// web/components/groups/StudentFilterBar.tsx
+import React from 'react';
+
+import { Input } from '~/components/ui';
+
+interface ClassOption {
+  label: string;
+  value: number;
+}
+
+interface StudentFilterBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  levelOptions: string[];
+  level: string;
+  onLevelChange: (level: string) => void;
+  classOptions: ClassOption[];
+  classId: string;
+  onClassChange: (classId: string) => void;
+}
+
+export const StudentFilterBar: React.FC<StudentFilterBarProps> = ({
+  query,
+  onQueryChange,
+  levelOptions,
+  level,
+  onLevelChange,
+  classOptions,
+  classId,
+  onClassChange,
+}) => {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <Input
+        placeholder="Search student name or class name"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        className="sm:col-span-3"
+      />
+      <label className="flex flex-col gap-1 text-xs font-medium">
+        Level
+        <select
+          aria-label="Level"
+          value={level}
+          onChange={(e) => onLevelChange(e.target.value)}
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+        >
+          <option value="">All levels</option>
+          {levelOptions.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-xs font-medium">
+        Form Class
+        <select
+          aria-label="Form Class"
+          value={classId}
+          onChange={(e) => onClassChange(e.target.value)}
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+        >
+          <option value="">All classes</option>
+          {classOptions.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+pnpm test -- StudentFilterBar
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/groups/StudentFilterBar.tsx web/components/groups/StudentFilterBar.test.tsx
+git commit -m "feat(groups): PGTW-13b \`StudentFilterBar\` with search + Level + Form Class filters"
+```
+
+---
+
+## Task 5: `AddStudentsView` — selection state + filter wiring + paginated table
+
+This is the meatiest task. We add a `useReducer` for selection + filter + pagination state, derive filtered+paginated rows, and render the filter bar + table.
+
+**Files:**
+
+- Modify: `web/containers/AddStudentsView.tsx`
+- Modify: `web/containers/AddStudentsView.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe`:
+
+```tsx
+import { fireEvent } from '@testing-library/react';
+
+const studentRoster = [
+  {
+    studentId: 1,
+    studentName: 'ALDDIN ANG',
+    uinFinNo: 'S9000003A',
+    classSerialNo: '15',
+    classCode: 'H6-05',
+    className: 'H6 KINDNESS',
+    levelCode: 'H6',
+    levelDescription: 'HIGHER 6',
+    cca: [],
+  },
+  {
+    studentId: 2,
+    studentName: 'BERNICE LIM',
+    uinFinNo: 'S9000004B',
+    classSerialNo: '02',
+    classCode: 'P1-01',
+    className: 'P1 KINDNESS',
+    levelCode: 'P1',
+    levelDescription: 'PRIMARY 1',
+    cca: [],
+  },
+];
+
+const classRoster = [
+  {
+    type: 'class' as const,
+    label: 'P1 KINDNESS (2026)',
+    labelDescription: 'P1 KINDNESS',
+    value: 1001,
+    acadYear: '2026',
+    schoolId: 1,
+  },
+];
+
+function renderWithData(
+  studentsList = studentRoster,
+  classes = classRoster,
+  initialState: unknown = undefined,
+) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/new/addStudents',
+        Component: AddStudentsView,
+        loader: () => ({ students: studentsList, classes }),
+      },
+      { path: '/groups/customGroups/new', element: <div>create page</div> },
+    ],
+    {
+      initialEntries: [{ pathname: '/groups/customGroups/new/addStudents', state: initialState }],
+    },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+it('renders the full roster initially', async () => {
+  renderWithData();
+  expect(await screen.findByText('ALDDIN ANG')).toBeInTheDocument();
+  expect(screen.getByText('BERNICE LIM')).toBeInTheDocument();
+});
+
+it('toggling a row checkbox updates the "Add N selected" button', async () => {
+  renderWithData();
+  fireEvent.click(await screen.findByRole('checkbox', { name: /select aldddin ang/i }));
+  expect(screen.getByRole('button', { name: /add 1 selected/i })).toBeEnabled();
+});
+
+it('search filters rows by name', async () => {
+  renderWithData();
+  fireEvent.change(await screen.findByPlaceholderText(/search student/i), {
+    target: { value: 'bernice' },
+  });
+  expect(screen.queryByText('ALDDIN ANG')).not.toBeInTheDocument();
+  expect(screen.getByText('BERNICE LIM')).toBeInTheDocument();
+});
+
+it('Level filter narrows by levelDescription', async () => {
+  renderWithData();
+  fireEvent.change(await screen.findByLabelText(/level/i), {
+    target: { value: 'PRIMARY 1' },
+  });
+  expect(screen.queryByText('ALDDIN ANG')).not.toBeInTheDocument();
+  expect(screen.getByText('BERNICE LIM')).toBeInTheDocument();
+});
+
+it('Add N selected button is disabled when nothing is selected', async () => {
+  renderWithData();
+  expect(await screen.findByRole('button', { name: /add 0 selected/i })).toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+pnpm test -- AddStudentsView
+```
+
+Expected: FAIL — checkbox role queries find nothing because the table isn't rendered yet.
+
+- [ ] **Step 3: Implement the full view**
+
+```tsx
+// web/containers/AddStudentsView.tsx
+import { X } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import { Link, useLoaderData, useNavigate, useLocation } from 'react-router';
+
+import { fetchSchoolClasses, fetchSchoolStudents } from '~/api/client';
+import type { PGApiSchoolClass, PGApiSchoolStudent } from '~/api/types';
+import { StudentFilterBar } from '~/components/groups/StudentFilterBar';
+import { StudentResultsTable } from '~/components/groups/StudentResultsTable';
+import { Button } from '~/components/ui';
+
+interface AddStudentsLoaderData {
+  students: PGApiSchoolStudent[];
+  classes: PGApiSchoolClass[];
+}
+
+interface IncomingNavState {
+  alreadyAdded?: number[];
+}
+
+interface OutgoingNavState {
+  addedStudents: PGApiSchoolStudent[];
+}
+
+const PAGE_SIZE = 20;
+
+export async function loader(): Promise<AddStudentsLoaderData> {
+  const [students, classes] = await Promise.all([fetchSchoolStudents(), fetchSchoolClasses()]);
+  return { students, classes };
+}
+
+const AddStudentsView: React.FC = () => {
+  const data = useLoaderData() as AddStudentsLoaderData;
+  const navigate = useNavigate();
+  const location = useLocation();
+  const incoming = (location.state as IncomingNavState | null) ?? {};
+  const alreadyAdded = useMemo(() => new Set(incoming.alreadyAdded ?? []), [incoming.alreadyAdded]);
+
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [query, setQuery] = useState('');
+  const [level, setLevel] = useState('');
+  const [classId, setClassId] = useState('');
+  // Pagination is intentionally Phase-1-deferred (see Task 6); render the
+  // first 200 rows so the UI behaves under realistic data volumes.
+
+  const levelOptions = useMemo(() => {
+    const set = new Set(data.students.map((s) => s.levelDescription));
+    return Array.from(set).sort();
+  }, [data.students]);
+
+  const classOptions = useMemo(
+    () =>
+      data.classes.map((c) => ({
+        label: c.label,
+        value: c.value,
+      })),
+    [data.classes],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    return data.students.filter((s) => {
+      if (alreadyAdded.has(s.studentId)) return false;
+      if (level && s.levelDescription !== level) return false;
+      if (
+        classId &&
+        s.classCode !== data.classes.find((c) => c.value.toString() === classId)?.labelDescription
+      ) {
+        return false;
+      }
+      if (q) {
+        const hay = `${s.studentName} ${s.className}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [data.students, data.classes, alreadyAdded, level, classId, query]);
+
+  const visibleRows = filtered.slice(0, PAGE_SIZE * 10); // up to 200 rows in Phase 1
+
+  function toggle(studentId: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(studentId)) next.delete(studentId);
+      else next.add(studentId);
+      return next;
+    });
+  }
+
+  function toggleAll(rowIds: number[]) {
+    setSelectedIds((prev) => {
+      const allSelected = rowIds.every((id) => prev.has(id));
+      const next = new Set(prev);
+      for (const id of rowIds) {
+        if (allSelected) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function submit() {
+    const addedStudents = data.students.filter((s) => selectedIds.has(s.studentId));
+    const state: OutgoingNavState = { addedStudents };
+    navigate('/groups/customGroups/new', { state });
+  }
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-4xl space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Add students</h1>
+          <Link
+            to="/groups/customGroups/new"
+            aria-label="Close"
+            className="rounded-md p-2 text-muted-foreground hover:bg-muted"
+          >
+            <X className="size-5" aria-hidden />
+          </Link>
+        </header>
+
+        <StudentFilterBar
+          query={query}
+          onQueryChange={setQuery}
+          levelOptions={levelOptions}
+          level={level}
+          onLevelChange={setLevel}
+          classOptions={classOptions}
+          classId={classId}
+          onClassChange={setClassId}
+        />
+
+        <p className="text-sm text-muted-foreground">
+          Showing {visibleRows.length} of {filtered.length} matching students.
+        </p>
+
+        <StudentResultsTable
+          rows={visibleRows}
+          selectedIds={selectedIds}
+          onToggle={toggle}
+          onToggleAll={toggleAll}
+        />
+
+        <footer className="flex items-center justify-end gap-3">
+          <Link
+            to="/groups/customGroups/new"
+            className="text-sm font-medium text-muted-foreground hover:underline"
+          >
+            Cancel
+          </Link>
+          <Button disabled={selectedIds.size === 0} onClick={submit}>
+            Add {selectedIds.size} selected
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export { AddStudentsView as Component };
+```
+
+There is one subtlety in the class filter: PGW's `school/students.classCode` (e.g. `P1-01`) doesn't directly match `school/groups.label` (e.g. `P1 KINDNESS (2026)`) — they share neither the year suffix nor the punctuation. The filter above maps via `labelDescription` (the year-stripped label, e.g. `P1 KINDNESS`) which is what `student-recipient-selector.tsx:31-33` already uses. If it doesn't match in your run, read the live data via the browser's network tab and adjust the comparison.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+pnpm test -- AddStudentsView
+```
+
+Expected: 7 PASS (2 from Task 1 + 5 added here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/AddStudentsView.tsx web/containers/AddStudentsView.test.tsx
+git commit -m "feat(groups): PGTW-13b \`AddStudentsView\` filter + selection + submit"
+```
+
+---
+
+## Task 6: Wire the create page to the subpage round-trip
+
+PGTW-13a's `CreateCustomGroupView` had the "+ Add Students" dropdown items disabled. Now we enable "Add manually", make it navigate to the subpage, and have the create page consume the returned `addedStudents` from `useLocation().state`.
+
+**Files:**
+
+- Modify: `web/containers/CreateCustomGroupView.tsx`
+- Modify: `web/containers/CreateCustomGroupView.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe`:
+
+```tsx
+import { Component as AddStudentsViewComp } from './AddStudentsView';
+
+it('"Add manually" navigates to /groups/customGroups/new/addStudents', async () => {
+  const router = createMemoryRouter(
+    [
+      { path: '/groups/customGroups/new', Component: CreateCustomGroupView },
+      {
+        path: '/groups/customGroups/new/addStudents',
+        Component: AddStudentsViewComp,
+        loader: () => ({ students: [], classes: [] }),
+      },
+    ],
+    { initialEntries: ['/groups/customGroups/new'] },
+  );
+  render(<RouterProvider router={router} />);
+  const triggers = screen.getAllByRole('button', { name: /add students/i });
+  fireEvent.click(triggers[0]);
+  fireEvent.click(await screen.findByRole('menuitem', { name: /add manually/i }));
+  expect(
+    await screen.findByRole('heading', { level: 1, name: /add students/i }),
+  ).toBeInTheDocument();
+});
+
+it('reads addedStudents from router state and shows the new counter + names', async () => {
+  const router = createMemoryRouter(
+    [{ path: '/groups/customGroups/new', Component: CreateCustomGroupView }],
+    {
+      initialEntries: [
+        {
+          pathname: '/groups/customGroups/new',
+          state: {
+            addedStudents: [
+              {
+                studentId: 1,
+                studentName: 'ALDDIN ANG',
+                uinFinNo: 'S9000003A',
+                classSerialNo: '15',
+                classCode: 'H6-05',
+                className: 'H6 KINDNESS',
+                levelCode: 'H6',
+                levelDescription: 'HIGHER 6',
+                cca: [],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  );
+  render(<RouterProvider router={router} />);
+  expect(await screen.findByText(/1 student added/i)).toBeInTheDocument();
+  expect(screen.getByText('ALDDIN ANG')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+pnpm test -- CreateCustomGroupView
+```
+
+Expected: FAIL — "Add manually" item is disabled (PGTW-13a's stub) and the create page ignores router state.
+
+- [ ] **Step 3: Update `CreateCustomGroupView.tsx`**
+
+Replace the file contents with:
+
+```tsx
+// web/containers/CreateCustomGroupView.tsx
+import { Plus } from 'lucide-react';
+import React, { useState } from 'react';
+import { Link, useLocation } from 'react-router';
+
+import type { PGApiSchoolStudent } from '~/api/types';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+} from '~/components/ui';
+
+const TITLE_MAX = 120;
+
+interface IncomingNavState {
+  addedStudents?: PGApiSchoolStudent[];
+}
+
+const CreateCustomGroupView: React.FC = () => {
+  const [title, setTitle] = useState('');
+  const location = useLocation();
+  const navState = (location.state as IncomingNavState | null) ?? {};
+  const [students, setStudents] = useState<PGApiSchoolStudent[]>(navState.addedStudents ?? []);
+
+  const studentCount = students.length;
+  const canSave = title.trim().length > 0 && studentCount > 0;
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-2xl">
+        <h1 className="text-2xl font-semibold">Create new group</h1>
+        <div className="mt-6">
+          <label htmlFor="group-title" className="text-sm font-medium">
+            Title<span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="group-title"
+            value={title}
+            maxLength={TITLE_MAX}
+            onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+            placeholder="What would you like to call your group?"
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {TITLE_MAX - title.length} characters left
+          </p>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium">
+                {studentCount} student{studentCount === 1 ? '' : 's'} added.
+              </p>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline">
+                    <Plus className="size-4" aria-hidden />
+                    Add Students
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/groups/customGroups/new/addStudents"
+                      state={{ alreadyAdded: students.map((s) => s.studentId) }}
+                    >
+                      Add manually
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            {studentCount === 0 ? (
+              <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+                No students added yet.
+              </div>
+            ) : (
+              <ul className="mt-2 divide-y rounded-md border">
+                {students.map((s) => (
+                  <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
+                    <span>{s.studentName}</span>
+                    <span className="text-xs text-muted-foreground">{s.className}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="mt-8 flex items-center justify-end gap-3">
+            <Link
+              to="/groups"
+              className="text-sm font-medium text-muted-foreground hover:underline"
+            >
+              Cancel
+            </Link>
+            <Button
+              disabled={!canSave}
+              title={canSave ? undefined : 'Add at least one student to create the group'}
+            >
+              Create Now
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export { CreateCustomGroupView as Component };
+```
+
+This intentionally still has Save as a no-op (no API call yet) — actual Save lands when 13c arrives with the create endpoint wiring. The button enables once title + students are present, but clicking it does nothing until POST `/api/web/2/staff/groups/custom` is wired.
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+pnpm test -- CreateCustomGroupView
+```
+
+Expected: All previous tests still PASS plus the 2 new ones.
+
+A handful of pre-existing tests in this file may need re-targeting:
+
+- The "+ Add Students dropdown with two disabled items" test from PGTW-13a will now FAIL (Add manually is no longer disabled). Update that test to check ONLY that "Upload via Excel" is `aria-disabled="true"`, and that "Add manually" is now a link to the subpage.
+- The "Create Now button disabled when title set but no students" test still passes — `canSave` requires both.
+
+Specifically, replace this previously-passing test:
+
+```tsx
+it('shows an "+ Add Students" dropdown with two disabled items', async () => {
+```
+
+with:
+
+```tsx
+it('shows an "+ Add Students" dropdown with "Add manually" enabled and "Upload via Excel" disabled', async () => {
+  renderView();
+  const triggers = screen.getAllByRole('button', { name: /add students/i });
+  fireEvent.click(triggers[0]);
+  const manual = await screen.findByRole('menuitem', { name: /add manually/i });
+  const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
+  expect(manual).not.toHaveAttribute('aria-disabled', 'true');
+  expect(excel).toHaveAttribute('aria-disabled', 'true');
+});
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx
+git commit -m "feat(groups): PGTW-13b wire create page \`Add manually\` to subpage round-trip"
+```
+
+---
+
+## Task 7: Manual smoke test in proxy mode
+
+The mapper (PGTW-13a-final commit f5c64f4) routes raw PGW shape through `fetchCustomGroups`. `fetchSchoolStudents` and `fetchSchoolClasses` are existing endpoints already exercised by PostsView, so they should work in proxy mode without further mapper work — BUT verify on the live data.
+
+- [ ] **Step 1: Make sure the stack is up**
+
+If shells are still running from PGTW-13a, just refresh the browser. If not, use the new slash command from session:
+
+```
+/tw-up
+```
+
+Or manually:
+
+```bash
+docker info >/dev/null 2>&1 || open -a Docker
+cd /Users/shin/Desktop/projects/tw-pg-experiment
+MYSQL_PASSWORD=iloveida MYSQL_PASSWORD_READ=iloveidaread MYSQL_ROOT_PASSWORD=root docker compose up -d
+go run ./server/cmd/tw &        # BFF on :3000 (picks up .env: TW_PG_MOCK=false)
+cd .worktrees/pgtw-13a && pnpm dev &     # Vite on :5173
+open "http://localhost:3001/api/web/2/staff/identity/login/BypassMIMS?loginId=PGU00032@hq.moe.gov.sg&type=mims"
+```
+
+- [ ] **Step 2: Walk through the create flow**
+
+1. Navigate to http://localhost:5173/groups
+2. Click "+ Create custom group"
+3. Type a title
+4. Click "+ Add Students" → "Add manually"
+5. URL → `/groups/customGroups/new/addStudents`. Heading "Add students" visible. Roster of real PGW students is rendered.
+6. Type into search → roster filters live.
+7. Pick a Level → roster narrows.
+8. Pick a Form Class → roster narrows further (verify the `classCode`/`labelDescription` mapping holds — if not, file as gap).
+9. Tick a few rows. "Add N selected" button updates and enables.
+10. Click "Add N selected" → returns to `/groups/customGroups/new`. Counter shows "N students added.". Names render in the list. Title input retains its value (it doesn't — see follow-up below).
+11. Click "+ Add Students" → "Add manually" again. Already-added students should be excluded from the visible roster.
+
+- [ ] **Step 3: Run the unit-test suite**
+
+```bash
+cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a
+pnpm test
+```
+
+Expected: previously 159 - 2 = 157 PGTW-13a tests still pass. PGTW-13b adds: 2 (Task 1) + 2 + 3 (Task 2 + 3) + 4 (Task 4) + 5 (Task 5) + 2 (Task 6) - 1 (replaced PGTW-13a test) = 17 new passing tests, for a new total of 174. (The 2 pre-existing PGTW-11 failures remain.)
+
+- [ ] **Step 4: Lint**
+
+```bash
+pnpm lint
+```
+
+Expected: 0 warnings, 0 errors.
+
+- [ ] **Step 5: Commit any smoke-test fixups**
+
+If steps 1-4 surfaced minor issues (e.g. the class-code mapping needs adjustment), commit them:
+
+```bash
+git add -p
+git commit -m "fix(groups): PGTW-13b address smoke-test findings"
+```
+
+If no fixes were needed, skip this step.
+
+---
+
+## Known Phase-1 limitations (file as follow-ups, not blockers)
+
+1. **Title input does not persist across the round-trip.** When the user navigates to the subpage and back, the title field resets to empty. PGW retains it. Fix in 13c when the create-page state moves from local `useState` to a parent loader/context, or pass the title in `state` alongside `alreadyAdded`.
+2. **Pagination is render-capped at 200 rows, not paged.** Real schools have ≤ 1500 students; 200 covers most filter results but a user with no filters could miss tail rows. Add real pagination in a follow-up; not critical for parity.
+3. **"All Students | CCA" radio not implemented.** §7.4 of the spec describes it; deferred per the audit.
+4. **Class-code → class-label mapping fragility.** `classCode` (e.g. `P1-01`) and `labelDescription` (e.g. `P1 KINDNESS`) come from different endpoints and aren't structurally linked. If PGW renames or re-formats either side, the Form Class filter silently shows nothing. Worth a TODO comment in the filter and an integration test against fixtures from a known school.
+5. **Save-on-create is still a no-op.** `Create Now` enables but doesn't POST. Wired in 13c.
+
+---
+
+## Out of scope (revisit after 13b lands)
+
+- **Edit-flow URL** `/groups/customGroups/:id/edit/addStudents` — same component, different parent. Wires when 13c builds the edit page.
+- **Excel upload** — PGTW-13d, blocked on PG-team confirmation of `validateStudents` request/response shape.
+- **Detail page** — PGTW-13c.
+- **Share modal** — PGTW-14.
+- **Delete** — PGTW-20.

--- a/docs/plans/2026-05-04-pgtw-13c-detail-edit-save-plan.md
+++ b/docs/plans/2026-05-04-pgtw-13c-detail-edit-save-plan.md
@@ -1,0 +1,1145 @@
+# PGTW-13c: Detail page + Edit page + Save wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the create → detail → edit → save loop for custom groups. Wire `Create Now` to `POST /groups/custom`, build the `/groups/customGroups/:id` detail page (Students tab + Details tab + action cards), and the `/groups/customGroups/:id/edit` edit page (reuses the same form shape as create + `PUT /groups/custom/:id`).
+
+**Architecture:** Three new client functions in `web/api/client.ts` (`createCustomGroup`, `fetchCustomGroupDetail`, `updateCustomGroup`) — the detail fetch applies a mapper to align real PGW's wire shape (`id`, `groupName`, `studentsList`, etc.) with our internal type. New container `CustomGroupDetailView`; new container `EditCustomGroupView` that reuses the same JSX skeleton as `CreateCustomGroupView`. The existing `AddStudentsView` route gets a parallel edit-flow path (`/groups/customGroups/:id/edit/addStudents`) wired so the same view serves both create and edit flows.
+
+**Tech Stack:** React 19, react-router 7, TypeScript 6, Tailwind 4, Vitest + RTL + jsdom.
+
+**Spec reference:** [docs/audits/pgtw-13-20-custom-groups-parity-scope.md](../audits/pgtw-13-20-custom-groups-parity-scope.md), PGW [pg-specs.md §7.2 / §7.3](../references/pg-specs.md), [pg-api-contract.md §8-9](../references/pg-api-contract.md).
+
+**Phase-1 scope cuts (deferred):**
+
+- Detail-page **Edit / Share / Delete** action cards render but link nowhere. "Edit Group" links to `/groups/customGroups/:id/edit` (the page this plan adds). "Share Group" and "Delete Forever" are non-functional buttons (PGTW-14 / PGTW-20a).
+- "Onboarded & Can Respond" ✓/✗ column on the Students tab — flagged as open question (#6 in audit). Render placeholder `—` until PG team confirms which endpoint sources it.
+- `sharedWith` shape — confirmed via real-PGW response shape during implementation.
+- Real-PGW **detail** endpoint shape — applies same mapper pattern as the list (PGTW-13a's f5c64f4 commit). If proxy-mode response differs from the contract doc, adjust the mapper and update the mock fixture, like we did for `groups_custom.json`.
+
+---
+
+## File Structure
+
+| File                                                   | Responsibility                                                                                                                          | Action |
+| ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `web/api/client.ts`                                    | Add `createCustomGroup`, `fetchCustomGroupDetail` (with mapper), `updateCustomGroup`.                                                   | Modify |
+| `web/api/types.ts`                                     | Add `PGApiCustomGroupDetail` (internal shape after mapper).                                                                             | Modify |
+| `web/containers/CreateCustomGroupView.tsx`             | Wire `Create Now` to call `createCustomGroup` then navigate to `/groups/customGroups/:newId`.                                           | Modify |
+| `web/containers/CustomGroupDetailView.tsx`             | Route container for `/groups/customGroups/:id`. Loader fetches detail. Renders header, tabs (Students / Details), action cards.         | Create |
+| `web/containers/CustomGroupDetailView.test.tsx`        | Container integration tests.                                                                                                            | Create |
+| `web/containers/EditCustomGroupView.tsx`               | Route container for `/groups/customGroups/:id/edit`. Loader fetches detail. Same form layout as create; Save calls `updateCustomGroup`. | Create |
+| `web/containers/EditCustomGroupView.test.tsx`          | Container integration tests.                                                                                                            | Create |
+| `web/components/groups/StudentsByClassList.tsx`        | Presentational: groups detail-page students by `className` and renders sections.                                                        | Create |
+| `web/components/groups/StudentsByClassList.test.tsx`   | Component tests.                                                                                                                        | Create |
+| `web/App.tsx`                                          | Add three lazy routes: `/groups/customGroups/:id`, `/groups/customGroups/:id/edit`, `/groups/customGroups/:id/edit/addStudents`.        | Modify |
+| `server/internal/pg/fixtures/group_custom_detail.json` | Update to match real PGW raw shape.                                                                                                     | Modify |
+
+---
+
+## Task 1: Add client write functions + detail mapper
+
+**Files:**
+
+- Modify: `web/api/client.ts`
+- Modify: `web/api/types.ts`
+
+- [ ] **Step 1: Add `PGApiCustomGroupDetail` type**
+
+In `web/api/types.ts`, after `PGApiCustomGroupSummary`:
+
+```ts
+export interface PGApiCustomGroupDetailStudent {
+  studentId: number;
+  studentName: string;
+  className: string;
+  indexNumber?: number;
+  uinFinNo?: string;
+  ccas?: string[];
+}
+
+export interface PGApiCustomGroupSharedStaff {
+  staffId: number;
+  staffName: string;
+}
+
+export interface PGApiCustomGroupDetail {
+  customGroupId: number;
+  name: string;
+  createdBy: number;
+  createdByName: string;
+  isShared: boolean;
+  sharedWith: PGApiCustomGroupSharedStaff[];
+  students: PGApiCustomGroupDetailStudent[];
+  createdAt: string;
+}
+
+export interface PGApiCreateCustomGroupResponse {
+  customGroupId: number;
+}
+```
+
+- [ ] **Step 2: Add `createCustomGroup` + `fetchCustomGroupDetail` + `updateCustomGroup`**
+
+In `web/api/client.ts`, after the `fetchCustomGroups` block (around line 770):
+
+```ts
+interface PgwRawCustomGroupDetail {
+  id: number;
+  groupName: string;
+  createdBy: string;
+  createdAt: string;
+  owners?: { staffId: number; staffName: string }[];
+  studentsList?: {
+    studentId: number;
+    studentName: string;
+    className: string;
+    indexNumber?: number;
+    uinFinNo?: string;
+    ccas?: string[];
+  }[];
+}
+
+function mapPgwCustomGroupDetail(raw: PgwRawCustomGroupDetail): PGApiCustomGroupDetail {
+  const owners = raw.owners ?? [];
+  const creator = owners[0];
+  return {
+    customGroupId: raw.id,
+    name: raw.groupName,
+    createdBy: creator?.staffId ?? 0,
+    createdByName: raw.createdBy,
+    isShared: owners.length > 1,
+    sharedWith: owners.slice(1),
+    students: (raw.studentsList ?? []).map((s) => ({
+      studentId: s.studentId,
+      studentName: s.studentName,
+      className: s.className,
+      indexNumber: s.indexNumber,
+      uinFinNo: s.uinFinNo,
+      ccas: s.ccas,
+    })),
+    createdAt: raw.createdAt,
+  };
+}
+
+export async function fetchCustomGroupDetail(id: number): Promise<PGApiCustomGroupDetail> {
+  const raw = await fetchApi<PgwRawCustomGroupDetail>(`/groups/custom/${id}`);
+  return mapPgwCustomGroupDetail(raw);
+}
+
+export async function createCustomGroup(payload: {
+  name: string;
+  studentIds: number[];
+}): Promise<PGApiCreateCustomGroupResponse> {
+  return mutateApi<PGApiCreateCustomGroupResponse>('POST', '/groups/custom', payload);
+}
+
+export async function updateCustomGroup(
+  id: number,
+  payload: { name: string; studentIds: number[] },
+): Promise<void> {
+  await mutateApi<void>('PUT', `/groups/custom/${id}`, payload);
+}
+```
+
+Existing `mutateApi` signature (line 253): `(method, path, body, options?)` — handles CSRF retry, timeout, error mapping. Don't write a new helper.
+
+- [ ] **Step 3: Update `web/api/types.ts` exports**
+
+Add `PGApiCustomGroupDetail`, `PGApiCustomGroupDetailStudent`, `PGApiCustomGroupSharedStaff`, `PGApiCreateCustomGroupResponse` to whatever the file's barrel-export is.
+
+- [ ] **Step 4: Update mock fixture**
+
+Replace `server/internal/pg/fixtures/group_custom_detail.json` with the real PGW raw shape:
+
+```json
+{
+  "id": 5,
+  "groupName": "Olympiad Study Group",
+  "createdBy": "TAN GUANG SHIN",
+  "createdAt": "2026-03-01T08:00:00.000Z",
+  "owners": [{ "staffId": 1013, "staffName": "TAN GUANG SHIN" }],
+  "studentsList": [
+    {
+      "studentId": 1,
+      "studentName": "TAN XIAO MING",
+      "className": "H6 KINDNESS",
+      "indexNumber": 15,
+      "uinFinNo": "S9000001A",
+      "ccas": ["BOXING"]
+    }
+  ]
+}
+```
+
+- [ ] **Step 5: Run the existing test suite to confirm no regression**
+
+```bash
+cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a
+pnpm test
+```
+
+Expected: prior 173 passes hold (the 2 PGTW-11 failures persist).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/api/client.ts web/api/types.ts server/internal/pg/fixtures/group_custom_detail.json
+git commit -m "feat(api): PGTW-13c add \`createCustomGroup\`, \`fetchCustomGroupDetail\`, \`updateCustomGroup\` + detail mapper"
+```
+
+---
+
+## Task 2: Wire `Create Now` on the create page
+
+**Files:**
+
+- Modify: `web/containers/CreateCustomGroupView.tsx`
+- Modify: `web/containers/CreateCustomGroupView.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```tsx
+import { vi } from 'vitest';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createCustomGroup: vi.fn().mockResolvedValue({ customGroupId: 42 }),
+  };
+});
+
+it('clicking "Create Now" with a title and students POSTs and navigates to /groups/customGroups/:id', async () => {
+  const { createCustomGroup } = await import('~/api/client');
+  const router = createMemoryRouter(
+    [
+      { path: '/groups/customGroups/new', Component: CreateCustomGroupView },
+      { path: '/groups/customGroups/:id', element: <div>detail page</div> },
+    ],
+    {
+      initialEntries: [
+        {
+          pathname: '/groups/customGroups/new',
+          state: {
+            addedStudents: [
+              {
+                studentId: 1,
+                studentName: 'ALDDIN',
+                uinFinNo: 'S9000003A',
+                classSerialNo: '15',
+                classCode: 'H6-05',
+                className: 'H6 KINDNESS',
+                levelCode: 'H6',
+                levelDescription: 'HIGHER 6',
+                cca: [],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  );
+  render(<RouterProvider router={router} />);
+
+  fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Olympiad' } });
+  fireEvent.click(screen.getByRole('button', { name: /create now/i }));
+
+  await screen.findByText('detail page');
+  expect(createCustomGroup).toHaveBeenCalledWith({ name: 'Olympiad', studentIds: [1] });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm test -- CreateCustomGroupView
+```
+
+Expected: FAIL — `createCustomGroup` never called; navigation didn't happen.
+
+- [ ] **Step 3: Wire the Save handler**
+
+Edit `web/containers/CreateCustomGroupView.tsx`. Add `useNavigate` import and a submit handler:
+
+```tsx
+import { useLocation, useNavigate } from 'react-router';
+import { createCustomGroup } from '~/api/client';
+import { notify } from '~/lib/notify';
+```
+
+Inside the component, before `return`:
+
+```tsx
+const navigate = useNavigate();
+const [submitting, setSubmitting] = useState(false);
+
+async function handleSave() {
+  if (!canSave) return;
+  setSubmitting(true);
+  try {
+    const { customGroupId } = await createCustomGroup({
+      name: title.trim(),
+      studentIds: students.map((s) => s.studentId),
+    });
+    navigate(`/groups/customGroups/${customGroupId}`);
+  } catch (err) {
+    setSubmitting(false);
+    if (!(err instanceof Error)) throw err;
+    // PGError subclasses already toast through `handleErrorResponse`. Generic
+    // errors fall through here.
+    notify.error('Could not create the group. Please try again.');
+  }
+}
+```
+
+Update the Create Now button:
+
+```tsx
+<Button
+  disabled={!canSave || submitting}
+  title={canSave ? undefined : 'Add at least one student to create the group'}
+  onClick={handleSave}
+>
+  {submitting ? 'Creating…' : 'Create Now'}
+</Button>
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm test -- CreateCustomGroupView
+```
+
+Expected: 8 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CreateCustomGroupView.tsx web/containers/CreateCustomGroupView.test.tsx
+git commit -m "feat(groups): PGTW-13c wire \`Create Now\` to POST + navigate to detail"
+```
+
+---
+
+## Task 3: Detail-page route + shell + tabs
+
+**Files:**
+
+- Create: `web/containers/CustomGroupDetailView.tsx`
+- Create: `web/containers/CustomGroupDetailView.test.tsx`
+- Modify: `web/App.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// web/containers/CustomGroupDetailView.test.tsx
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiCustomGroupDetail } from '~/api/types';
+
+import { Component as CustomGroupDetailView } from './CustomGroupDetailView';
+
+const detail: PGApiCustomGroupDetail = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  sharedWith: [],
+  students: [
+    {
+      studentId: 1,
+      studentName: 'TAN XIAO MING',
+      className: 'H6 KINDNESS',
+      indexNumber: 15,
+      uinFinNo: 'S9000001A',
+      ccas: ['BOXING'],
+    },
+  ],
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
+function renderAt(loaderData: PGApiCustomGroupDetail = detail) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/:id',
+        Component: CustomGroupDetailView,
+        loader: () => loaderData,
+      },
+    ],
+    { initialEntries: ['/groups/customGroups/5'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('CustomGroupDetailView', () => {
+  it('renders the group name as the page heading', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Olympiad Study Group' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders both tab triggers', async () => {
+    renderAt();
+    expect(await screen.findByRole('tab', { name: /students/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /details/i })).toBeInTheDocument();
+  });
+
+  it('renders the student count in the Students tab label', async () => {
+    renderAt();
+    expect(await screen.findByRole('tab', { name: /students \(1\)/i })).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+pnpm test -- CustomGroupDetailView
+```
+
+Expected: 3 FAIL — module not found.
+
+- [ ] **Step 3: Implement the shell**
+
+```tsx
+// web/containers/CustomGroupDetailView.tsx
+import React from 'react';
+import { useLoaderData, useParams } from 'react-router';
+
+import { fetchCustomGroupDetail } from '~/api/client';
+import type { PGApiCustomGroupDetail } from '~/api/types';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '~/components/ui';
+
+export async function loader({
+  params,
+}: {
+  params: { id?: string };
+}): Promise<PGApiCustomGroupDetail> {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) throw new Response('Invalid group id', { status: 400 });
+  return fetchCustomGroupDetail(id);
+}
+
+const CustomGroupDetailView: React.FC = () => {
+  const data = useLoaderData() as PGApiCustomGroupDetail;
+  const params = useParams();
+  void params;
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-4xl">
+        <header>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Custom Group</p>
+          <h1 className="mt-1 text-2xl font-semibold">{data.name}</h1>
+        </header>
+
+        <Tabs defaultValue="students" className="mt-6">
+          <TabsList>
+            <TabsTrigger value="students">Students ({data.students.length})</TabsTrigger>
+            <TabsTrigger value="details">Details</TabsTrigger>
+          </TabsList>
+          <TabsContent value="students">{/* Task 4 */}</TabsContent>
+          <TabsContent value="details">{/* Task 5 */}</TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+export { CustomGroupDetailView as Component };
+```
+
+- [ ] **Step 4: Wire the lazy route**
+
+Edit `web/App.tsx`. After the `groups/customGroups/new/addStudents` entry, add:
+
+```tsx
+{
+  path: 'groups/customGroups/:id',
+  lazy: () => import('./containers/CustomGroupDetailView'),
+},
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+pnpm test -- CustomGroupDetailView
+```
+
+Expected: 3 PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/containers/CustomGroupDetailView.tsx web/containers/CustomGroupDetailView.test.tsx web/App.tsx
+git commit -m "feat(groups): PGTW-13c scaffold detail page with Students + Details tabs"
+```
+
+---
+
+## Task 4: `StudentsByClassList` + Students tab body
+
+**Files:**
+
+- Create: `web/components/groups/StudentsByClassList.tsx`
+- Create: `web/components/groups/StudentsByClassList.test.tsx`
+- Modify: `web/containers/CustomGroupDetailView.tsx`
+- Modify: `web/containers/CustomGroupDetailView.test.tsx`
+
+- [ ] **Step 1: Write `StudentsByClassList` tests**
+
+```tsx
+// web/components/groups/StudentsByClassList.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiCustomGroupDetailStudent } from '~/api/types';
+
+import { StudentsByClassList } from './StudentsByClassList';
+
+const xiaoming: PGApiCustomGroupDetailStudent = {
+  studentId: 1,
+  studentName: 'TAN XIAO MING',
+  className: 'H6 KINDNESS',
+  indexNumber: 15,
+  uinFinNo: 'S9000001A',
+  ccas: ['BOXING'],
+};
+const ahkow: PGApiCustomGroupDetailStudent = {
+  studentId: 2,
+  studentName: 'LIM AH KOW',
+  className: 'P1 KINDNESS',
+  indexNumber: 2,
+  uinFinNo: 'S9000002B',
+  ccas: [],
+};
+
+describe('StudentsByClassList', () => {
+  it('groups students by className and shows count per group', () => {
+    render(<StudentsByClassList students={[xiaoming, ahkow]} />);
+    expect(screen.getByText(/H6 KINDNESS \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/P1 KINDNESS \(1\)/)).toBeInTheDocument();
+  });
+
+  it('renders student name + UIN under each class', () => {
+    render(<StudentsByClassList students={[xiaoming]} />);
+    expect(screen.getByText('TAN XIAO MING')).toBeInTheDocument();
+    expect(screen.getByText('S9000001A')).toBeInTheDocument();
+  });
+
+  it('renders empty-state copy when there are no students', () => {
+    render(<StudentsByClassList students={[]} />);
+    expect(screen.getByText(/no students in this group/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+pnpm test -- StudentsByClassList
+```
+
+Expected: 3 FAIL.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// web/components/groups/StudentsByClassList.tsx
+import React, { useMemo } from 'react';
+
+import type { PGApiCustomGroupDetailStudent } from '~/api/types';
+
+interface StudentsByClassListProps {
+  students: PGApiCustomGroupDetailStudent[];
+}
+
+export const StudentsByClassList: React.FC<StudentsByClassListProps> = ({ students }) => {
+  const groups = useMemo(() => {
+    const map = new Map<string, PGApiCustomGroupDetailStudent[]>();
+    for (const s of students) {
+      const list = map.get(s.className) ?? [];
+      list.push(s);
+      map.set(s.className, list);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [students]);
+
+  if (students.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No students in this group.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map(([className, rows]) => (
+        <section key={className} className="rounded-md border bg-card">
+          <header className="border-b px-4 py-2 text-sm font-semibold">
+            {className} ({rows.length})
+          </header>
+          <ul className="divide-y">
+            {rows.map((s) => (
+              <li key={s.studentId} className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <div className="font-medium">{s.studentName}</div>
+                  {s.uinFinNo ? (
+                    <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
+                  ) : null}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {/* PGTW-13c-deferred: Onboarded & Can Respond ✓/✗ */}—
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+};
+```
+
+- [ ] **Step 4: Wire into the Students tab**
+
+Edit `CustomGroupDetailView.tsx`:
+
+```tsx
+import { StudentsByClassList } from '~/components/groups/StudentsByClassList';
+```
+
+Replace the `<TabsContent value="students" />` placeholder:
+
+```tsx
+<TabsContent value="students" className="mt-4">
+  <StudentsByClassList students={data.students} />
+</TabsContent>
+```
+
+- [ ] **Step 5: Add a wire-up test on the detail view**
+
+Append to `CustomGroupDetailView.test.tsx`:
+
+```tsx
+it('renders the student list on the Students tab by default', async () => {
+  renderAt();
+  expect(await screen.findByText('TAN XIAO MING')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 6: Run, see pass**
+
+```bash
+pnpm test -- StudentsByClassList CustomGroupDetailView
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/components/groups/StudentsByClassList.tsx web/components/groups/StudentsByClassList.test.tsx web/containers/CustomGroupDetailView.tsx web/containers/CustomGroupDetailView.test.tsx
+git commit -m "feat(groups): PGTW-13c \`StudentsByClassList\` wired into detail page"
+```
+
+---
+
+## Task 5: Details tab + action cards
+
+**Files:**
+
+- Modify: `web/containers/CustomGroupDetailView.tsx`
+- Modify: `web/containers/CustomGroupDetailView.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+import { fireEvent } from '@testing-library/react';
+
+it('Details tab shows creator metadata + the three action cards', async () => {
+  renderAt();
+  fireEvent.click(screen.getByRole('tab', { name: /details/i }));
+  expect(await screen.findByText(/created/i)).toBeInTheDocument();
+  expect(screen.getByText('TAN GUANG SHIN')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /edit group/i })).toHaveAttribute(
+    'href',
+    '/groups/customGroups/5/edit',
+  );
+  expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
+  expect(screen.getByRole('button', { name: /delete forever/i })).toBeDisabled();
+});
+```
+
+The Share / Delete buttons are intentionally disabled in 13c; PGTW-14 / PGTW-20a wire them up.
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+pnpm test -- CustomGroupDetailView
+```
+
+- [ ] **Step 3: Render the Details tab body**
+
+In `CustomGroupDetailView.tsx`, add imports:
+
+```tsx
+import { Link } from 'react-router';
+import { Button } from '~/components/ui';
+import { formatDate } from '~/helpers/dateTime';
+```
+
+Replace `<TabsContent value="details" />` with:
+
+```tsx
+<TabsContent value="details" className="mt-4 space-y-6">
+  <p className="text-sm text-muted-foreground">
+    Created on {formatDate(data.createdAt)} by {data.createdByName}.
+  </p>
+  {data.sharedWith.length > 0 ? (
+    <div className="text-sm">
+      <span className="font-medium">Group shared with:</span>{' '}
+      {data.sharedWith.map((s) => s.staffName).join(', ')}
+    </div>
+  ) : null}
+
+  <div className="grid gap-3 sm:grid-cols-3">
+    <article className="rounded-md border p-4">
+      <h3 className="font-semibold">Edit this custom group</h3>
+      <Button asChild variant="outline" className="mt-3">
+        <Link to={`/groups/customGroups/${data.customGroupId}/edit`}>Edit Group</Link>
+      </Button>
+    </article>
+    <article className="rounded-md border p-4">
+      <h3 className="font-semibold">Share this custom group</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        You will be granting access to edit this group. Please be certain.
+      </p>
+      <Button variant="outline" className="mt-3" disabled>
+        Share Group
+      </Button>
+    </article>
+    <article className="rounded-md border p-4">
+      <h3 className="font-semibold">Delete this custom group</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Once you delete this custom group, you can never get it back again.
+      </p>
+      <Button variant="outline" className="mt-3" disabled>
+        Delete Forever
+      </Button>
+    </article>
+  </div>
+</TabsContent>
+```
+
+- [ ] **Step 4: Run, see pass**
+
+```bash
+pnpm test -- CustomGroupDetailView
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/containers/CustomGroupDetailView.tsx web/containers/CustomGroupDetailView.test.tsx
+git commit -m "feat(groups): PGTW-13c detail-page Details tab + action cards"
+```
+
+---
+
+## Task 6: Edit page route + shell + Save (PUT)
+
+**Files:**
+
+- Create: `web/containers/EditCustomGroupView.tsx`
+- Create: `web/containers/EditCustomGroupView.test.tsx`
+- Modify: `web/App.tsx`
+
+`EditCustomGroupView` reuses the same JSX skeleton as `CreateCustomGroupView` but seeds initial state from the loader's detail and Save calls `updateCustomGroup` instead of `createCustomGroup`. Reuses `CreateCustomGroupView`'s patterns; if a refactor opportunity emerges (extract a shared `<GroupForm>`), do it inline here as a clean-up under the same task — but only if it keeps both views simpler.
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// web/containers/EditCustomGroupView.test.tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PGApiCustomGroupDetail } from '~/api/types';
+
+import { Component as EditCustomGroupView } from './EditCustomGroupView';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    updateCustomGroup: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const detail: PGApiCustomGroupDetail = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  sharedWith: [],
+  students: [
+    {
+      studentId: 1,
+      studentName: 'TAN XIAO MING',
+      className: 'H6 KINDNESS',
+      indexNumber: 15,
+      uinFinNo: 'S9000001A',
+      ccas: ['BOXING'],
+    },
+  ],
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
+function renderAt() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/:id/edit',
+        Component: EditCustomGroupView,
+        loader: () => detail,
+      },
+      { path: '/groups/customGroups/:id', element: <div>detail page</div> },
+    ],
+    { initialEntries: ['/groups/customGroups/5/edit'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('EditCustomGroupView', () => {
+  it('renders the page heading "Edit group"', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /edit group/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('seeds the title input from the loaded detail', async () => {
+    renderAt();
+    const input = (await screen.findByLabelText(/title/i)) as HTMLInputElement;
+    expect(input.value).toBe('Olympiad Study Group');
+  });
+
+  it('shows the existing students count and names', async () => {
+    renderAt();
+    expect(await screen.findByText(/1 student added/i)).toBeInTheDocument();
+    expect(screen.getByText('TAN XIAO MING')).toBeInTheDocument();
+  });
+
+  it('clicking Save calls updateCustomGroup and navigates to the detail page', async () => {
+    const { updateCustomGroup } = await import('~/api/client');
+    renderAt();
+    fireEvent.change(await screen.findByLabelText(/title/i), {
+      target: { value: 'Olympiad Squad' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await screen.findByText('detail page');
+    expect(updateCustomGroup).toHaveBeenCalledWith(5, {
+      name: 'Olympiad Squad',
+      studentIds: [1],
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run, see fail**
+
+```bash
+pnpm test -- EditCustomGroupView
+```
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// web/containers/EditCustomGroupView.tsx
+import { Plus } from 'lucide-react';
+import React, { useState } from 'react';
+import { Link, useLoaderData, useLocation, useNavigate, useParams } from 'react-router';
+
+import { fetchCustomGroupDetail, updateCustomGroup } from '~/api/client';
+import type { PGApiCustomGroupDetail, PGApiSchoolStudent } from '~/api/types';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+} from '~/components/ui';
+import { notify } from '~/lib/notify';
+
+const TITLE_MAX = 120;
+
+export async function loader({
+  params,
+}: {
+  params: { id?: string };
+}): Promise<PGApiCustomGroupDetail> {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) throw new Response('Invalid group id', { status: 400 });
+  return fetchCustomGroupDetail(id);
+}
+
+interface IncomingNavState {
+  addedStudents?: PGApiSchoolStudent[];
+}
+
+const EditCustomGroupView: React.FC = () => {
+  const detail = useLoaderData() as PGApiCustomGroupDetail;
+  const params = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const groupId = Number(params.id);
+
+  const navState = (location.state as IncomingNavState | null) ?? {};
+  // The edit-flow add-students subpage will return PGApiSchoolStudent[]; the
+  // initial detail contains PGApiCustomGroupDetailStudent[]. Normalise to the
+  // shape we need for display + submit (just `studentId` + display fields).
+  const initialStudents = navState.addedStudents
+    ? navState.addedStudents.map((s) => ({
+        studentId: s.studentId,
+        studentName: s.studentName,
+        className: s.className,
+      }))
+    : detail.students.map((s) => ({
+        studentId: s.studentId,
+        studentName: s.studentName,
+        className: s.className,
+      }));
+
+  const [title, setTitle] = useState(detail.name);
+  const [students] = useState(initialStudents);
+  const [submitting, setSubmitting] = useState(false);
+
+  const studentCount = students.length;
+  const dirty = title.trim() !== detail.name || navState.addedStudents !== undefined;
+  const canSave = title.trim().length > 0 && studentCount > 0 && dirty;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    try {
+      await updateCustomGroup(groupId, {
+        name: title.trim(),
+        studentIds: students.map((s) => s.studentId),
+      });
+      navigate(`/groups/customGroups/${groupId}`);
+    } catch (err) {
+      setSubmitting(false);
+      if (!(err instanceof Error)) throw err;
+      notify.error('Could not save the group. Please try again.');
+    }
+  }
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-2xl">
+        <h1 className="text-2xl font-semibold">Edit group</h1>
+        <div className="mt-6">
+          <label htmlFor="group-title" className="text-sm font-medium">
+            Title<span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="group-title"
+            value={title}
+            maxLength={TITLE_MAX}
+            onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {TITLE_MAX - title.length} characters left
+          </p>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium">
+                {studentCount} student{studentCount === 1 ? '' : 's'} added.
+              </p>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline">
+                    <Plus className="size-4" aria-hidden />
+                    Add Students
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to={`/groups/customGroups/${groupId}/edit/addStudents`}
+                      state={{ alreadyAdded: students.map((s) => s.studentId) }}
+                    >
+                      Add manually
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <ul className="mt-2 divide-y rounded-md border">
+              {students.map((s) => (
+                <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
+                  <span>{s.studentName}</span>
+                  <span className="text-xs text-muted-foreground">{s.className}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="mt-8 flex items-center justify-end gap-3">
+            <Link
+              to={`/groups/customGroups/${groupId}`}
+              className="text-sm font-medium text-muted-foreground hover:underline"
+            >
+              Cancel
+            </Link>
+            <Button disabled={!canSave || submitting} onClick={handleSave}>
+              {submitting ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export { EditCustomGroupView as Component };
+```
+
+- [ ] **Step 4: Wire the lazy routes**
+
+Edit `web/App.tsx`. After the `groups/customGroups/:id` entry, add:
+
+```tsx
+{
+  path: 'groups/customGroups/:id/edit',
+  lazy: () => import('./containers/EditCustomGroupView'),
+},
+{
+  path: 'groups/customGroups/:id/edit/addStudents',
+  lazy: () => import('./containers/AddStudentsView'),
+},
+```
+
+The third route reuses `AddStudentsView` — but the existing component's submit always navigates to `/groups/customGroups/new`. The same component must instead navigate back to whichever parent path it was reached from.
+
+- [ ] **Step 5: Generalise `AddStudentsView` submit destination**
+
+In `web/containers/AddStudentsView.tsx`, replace the hardcoded navigate:
+
+```tsx
+function submit() {
+  const addedStudents = data.students.filter((s) => selectedIds.has(s.studentId));
+  const state: OutgoingNavState = { addedStudents };
+  // Strip the trailing /addStudents to return to the parent (create or edit).
+  const parent = location.pathname.replace(/\/addStudents$/, '');
+  navigate(parent, { state });
+}
+```
+
+Also update the close link + cancel link:
+
+```tsx
+const parentPath = location.pathname.replace(/\/addStudents$/, '');
+// …
+<Link to={parentPath} aria-label="Close" …>
+// …
+<Link to={parentPath} className="…">Cancel</Link>
+```
+
+Update existing AddStudentsView tests to assert on the dynamic parent path:
+
+```tsx
+it('renders a close link back to the parent route', async () => {
+  renderWithData([], []);
+  const close = await screen.findByRole('link', { name: /close/i });
+  expect(close).toHaveAttribute('href', '/groups/customGroups/new');
+});
+```
+
+- [ ] **Step 6: Run, see pass**
+
+```bash
+pnpm test -- EditCustomGroupView AddStudentsView
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/containers/EditCustomGroupView.tsx web/containers/EditCustomGroupView.test.tsx web/containers/AddStudentsView.tsx web/containers/AddStudentsView.test.tsx web/App.tsx
+git commit -m "feat(groups): PGTW-13c edit page + reuse \`AddStudentsView\` for edit flow"
+```
+
+---
+
+## Task 7: Manual smoke test
+
+- [ ] **Step 1: Make sure the stack is up**
+
+```
+/tw-up
+```
+
+- [ ] **Step 2: Walk through the full create → detail → edit loop**
+
+1. Navigate to http://localhost:5173/groups
+2. Click "+ Create custom group" → land on `/groups/customGroups/new`
+3. Type a title; Add manually; pick students; Add N selected
+4. Click **Create Now** → POST fires; URL becomes `/groups/customGroups/<newId>`
+5. Detail page renders: heading is the group name; "Custom Group" subtitle; Students tab shows students grouped by className with count; Details tab shows "Created on … by …", action cards, Edit link works, Share + Delete are disabled
+6. Click **Edit Group** → URL becomes `/groups/customGroups/<id>/edit`. Title pre-filled; students list pre-populated; Save is initially disabled (no changes); editing the title enables Save
+7. Click **+ Add Students → Add manually** → URL becomes `/groups/customGroups/<id>/edit/addStudents`. Pick more students. Add N selected → returns to edit page with both old + new students
+8. Click **Save** → PUT fires; URL returns to `/groups/customGroups/<id>` detail page; new title + students reflected
+9. Refresh the detail page → loader re-fetches; data persists in MySQL
+
+- [ ] **Step 3: Run unit tests + lint**
+
+```bash
+cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a
+pnpm test
+pnpm lint
+```
+
+- [ ] **Step 4: Commit any smoke-test fixups**
+
+```bash
+git add -p
+git commit -m "fix(groups): PGTW-13c address smoke-test findings"
+```
+
+---
+
+## Known Phase-1 limitations
+
+1. **Onboarded & Can Respond ✓/✗** — placeholder `—` rendered. Open question #6 in the audit.
+2. **Edit page state hand-off only carries the latest add-students return** — the `dirty` flag treats new added-students as always-dirty even if they overlap with existing. Acceptable for Phase 1; refine in 13c follow-up if needed.
+3. **No "remove student" UX on edit page** — PGW spec §7.3 has a × icon per row. Defer; file as follow-up. Without it, the edit page can only ADD students, not remove.
+4. **Stale-tab edits** — last write wins. PGTW-13a audit cross-cutting #5.
+5. **Share + Delete buttons are visually disabled** — PGTW-14 / PGTW-20a.
+
+---
+
+## Out of scope
+
+- **PGTW-13d Excel upload** — blocked on PG-team confirmation of `validateStudents` shape.
+- **PGTW-14 share modal** — wires the disabled Share Group button.
+- **PGTW-20 delete** — wires the disabled Delete Forever button.
+- **PGTW-15 SC custom group** — open question.

--- a/docs/superpowers/plans/2026-05-04-pgtw-14-share-custom-group-plan.md
+++ b/docs/superpowers/plans/2026-05-04-pgtw-14-share-custom-group-plan.md
@@ -1,0 +1,560 @@
+# PGTW-14: Share Custom Group with Staff — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a share modal to the custom group detail page that lets the group owner share access with other staff members, matching PGW's existing behavior.
+
+**Architecture:** A `ShareGroupModal` dialog component reuses the existing `StaffSelector`. The modal opens from the detail page's "Share Group" action card. On submit it calls `shareCustomGroup()` → `PUT /groups/custom/:id/share`. After success, the detail page refetches to update the shared-with list.
+
+**Tech Stack:** React 19, react-router 7, Vitest + React Testing Library, `@base-ui/react` Dialog, existing `StaffSelector` / `EntitySelector` components, `mutateApi` for CSRF-aware writes, `sonner` toast for errors.
+
+---
+
+## File Structure
+
+| Action | Path                                             | Responsibility                                                  |
+| ------ | ------------------------------------------------ | --------------------------------------------------------------- |
+| Create | `web/components/groups/ShareGroupModal.tsx`      | Dialog with staff picker + permissions info + submit            |
+| Create | `web/components/groups/ShareGroupModal.test.tsx` | Unit tests for modal rendering, submit, disabled states         |
+| Modify | `web/api/client.ts:879`                          | Add `shareCustomGroup()` function                               |
+| Modify | `web/containers/CustomGroupDetailView.tsx`       | Enable Share button → open modal, pass data, refetch on success |
+| Modify | `web/containers/CustomGroupDetailView.test.tsx`  | Update test: Share button enabled, opens modal                  |
+
+---
+
+### Task 1: Add `shareCustomGroup` API client function
+
+**Files:**
+
+- Modify: `web/api/client.ts:879` (after `updateCustomGroup`)
+
+- [ ] **Step 1: Add the `shareCustomGroup` function**
+
+Insert after the `updateCustomGroup` function (line 879):
+
+```typescript
+export async function shareCustomGroup(id: number, staffIds: number[]): Promise<void> {
+  await mutateApi<void>('PUT', `/groups/custom/${id}/share`, {
+    selectedStaff: staffIds,
+  });
+}
+```
+
+- [ ] **Step 2: Verify the build compiles**
+
+Run: `cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a && pnpm exec tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/api/client.ts
+git commit -m "feat(api): PGTW-14 add \`shareCustomGroup\` client function"
+```
+
+---
+
+### Task 2: Create `ShareGroupModal` component with tests
+
+**Files:**
+
+- Create: `web/components/groups/ShareGroupModal.tsx`
+- Create: `web/components/groups/ShareGroupModal.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `web/components/groups/ShareGroupModal.test.tsx`:
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PGApiSchoolStaff } from '~/api/types';
+
+import { ShareGroupModal } from './ShareGroupModal';
+
+const schoolStaff: PGApiSchoolStaff[] = [
+  { staffId: 1001, name: 'ALICE TAN', email: 'alice@school.edu.sg', className: 'P3 BEST' },
+  { staffId: 1002, name: 'BOB LIM', email: 'bob@school.edu.sg', className: null },
+  { staffId: 1003, name: 'CHARLIE NG', email: 'charlie@school.edu.sg', className: 'P1 KINDNESS' },
+];
+
+const excludeStaffIds = [1001];
+
+function renderModal(onShare = vi.fn().mockResolvedValue(undefined)) {
+  const onClose = vi.fn();
+  render(
+    <ShareGroupModal
+      open={true}
+      onClose={onClose}
+      staff={schoolStaff}
+      excludeStaffIds={excludeStaffIds}
+      onShare={onShare}
+    />,
+  );
+  return { onShare, onClose };
+}
+
+describe('ShareGroupModal', () => {
+  it('renders the dialog title "Share group"', () => {
+    renderModal();
+    expect(screen.getByText('Share group')).toBeInTheDocument();
+  });
+
+  it('renders the permissions bullet list', () => {
+    renderModal();
+    expect(screen.getByText(/view and send to the group/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit the group name/i)).toBeInTheDocument();
+    expect(screen.getByText(/add or delete students/i)).toBeInTheDocument();
+    expect(screen.getByText(/share the group with other staff/i)).toBeInTheDocument();
+  });
+
+  it('renders the "Share group" button disabled when no staff selected', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a && pnpm vitest run web/components/groups/ShareGroupModal.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the `ShareGroupModal` component**
+
+Create `web/components/groups/ShareGroupModal.tsx`:
+
+```tsx
+import React, { useMemo, useState } from 'react';
+
+import type { PGApiSchoolStaff } from '~/api/types';
+import { StaffSelector } from '~/components/comms/staff-selector';
+import type { SelectedStaff } from '~/components/comms/staff-selector';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui';
+import { notify } from '~/lib/notify';
+
+interface ShareGroupModalProps {
+  open: boolean;
+  onClose: () => void;
+  staff: PGApiSchoolStaff[];
+  excludeStaffIds: number[];
+  onShare: (staffIds: number[]) => Promise<void>;
+}
+
+export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
+  open,
+  onClose,
+  staff,
+  excludeStaffIds,
+  onShare,
+}) => {
+  const [selected, setSelected] = useState<SelectedStaff[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const excludeSet = useMemo(() => new Set(excludeStaffIds), [excludeStaffIds]);
+  const filteredStaff = useMemo(
+    () => staff.filter((s) => !excludeSet.has(s.staffId)),
+    [staff, excludeSet],
+  );
+
+  async function handleShare() {
+    if (selected.length === 0) return;
+    setSubmitting(true);
+    try {
+      const staffIds = selected.map((s) => Number(s.id));
+      await onShare(staffIds);
+      onClose();
+    } catch {
+      notify.error('Could not share the group. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Share group</DialogTitle>
+          <DialogDescription>
+            By sharing this group, other staff members will have access to:
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="list-disc space-y-1 pl-5 text-sm">
+          <li>View and send to the group</li>
+          <li>Edit the group name</li>
+          <li>Add or delete students</li>
+          <li>Share the group with other staff</li>
+        </ul>
+
+        <div>
+          <StaffSelector value={selected} onChange={setSelected} staff={filteredStaff} />
+        </div>
+
+        <DialogFooter>
+          <Button disabled={selected.length === 0 || submitting} onClick={handleShare}>
+            {submitting ? 'Sharing…' : 'Share group'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a && pnpm vitest run web/components/groups/ShareGroupModal.test.tsx`
+Expected: 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/components/groups/ShareGroupModal.tsx web/components/groups/ShareGroupModal.test.tsx
+git commit -m "feat(groups): PGTW-14 \`ShareGroupModal\` with staff picker + permissions list"
+```
+
+---
+
+### Task 3: Wire Share button on the detail page
+
+**Files:**
+
+- Modify: `web/containers/CustomGroupDetailView.tsx`
+- Modify: `web/containers/CustomGroupDetailView.test.tsx`
+
+- [ ] **Step 1: Update the existing test — Share button should be enabled**
+
+In `web/containers/CustomGroupDetailView.test.tsx`, update the `'Details tab shows creator metadata + the three action cards'` test. Change the Share button assertion from `toBeDisabled()` to `toBeEnabled()`:
+
+```tsx
+it('Details tab shows creator metadata + the three action cards', async () => {
+  const { fireEvent } = await import('@testing-library/react');
+  renderAt();
+  const detailsTab = await screen.findByRole('tab', { name: /details/i });
+  fireEvent.click(detailsTab);
+  expect(await screen.findByText(/created on/i)).toBeInTheDocument();
+  expect(screen.getByText(/TAN GUANG SHIN/)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /edit group/i })).toHaveAttribute(
+    'href',
+    '/groups/customGroups/5/edit',
+  );
+  expect(screen.getByRole('button', { name: /share group/i })).toBeEnabled();
+  expect(screen.getByRole('button', { name: /delete forever/i })).toBeDisabled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a && pnpm vitest run web/containers/CustomGroupDetailView.test.tsx`
+Expected: FAIL — button is disabled
+
+- [ ] **Step 3: Wire the detail page to open ShareGroupModal**
+
+Replace the full contents of `web/containers/CustomGroupDetailView.tsx`:
+
+```tsx
+import React, { useState } from 'react';
+import { Link, useLoaderData, useRevalidator } from 'react-router';
+
+import { fetchCustomGroupDetail, fetchSchoolStaff, shareCustomGroup } from '~/api/client';
+import type { PGApiCustomGroupDetail, PGApiSchoolStaff } from '~/api/types';
+import { ShareGroupModal } from '~/components/groups/ShareGroupModal';
+import { StudentsByClassList } from '~/components/groups/StudentsByClassList';
+import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
+import { formatDate } from '~/helpers/dateTime';
+
+interface LoaderData {
+  detail: PGApiCustomGroupDetail;
+  staff: PGApiSchoolStaff[];
+}
+
+export async function loader({ params }: { params: { id?: string } }): Promise<LoaderData> {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) throw new Response('Invalid group id', { status: 400 });
+  const [detail, staff] = await Promise.all([fetchCustomGroupDetail(id), fetchSchoolStaff()]);
+  return { detail, staff };
+}
+
+const CustomGroupDetailView: React.FC = () => {
+  const { detail: data, staff } = useLoaderData() as LoaderData;
+  const revalidator = useRevalidator();
+  const [shareOpen, setShareOpen] = useState(false);
+
+  const excludeStaffIds = [data.createdBy, ...data.sharedWith.map((s) => s.staffId)];
+
+  async function handleShare(staffIds: number[]) {
+    await shareCustomGroup(data.customGroupId, staffIds);
+    revalidator.revalidate();
+  }
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-4xl">
+        <header>
+          <p className="text-xs tracking-wide text-muted-foreground uppercase">Custom Group</p>
+          <h1 className="mt-1 text-2xl font-semibold">{data.name}</h1>
+        </header>
+
+        <Tabs defaultValue="students" className="mt-6">
+          <TabsList>
+            <TabsTrigger value="students">Students ({data.students.length})</TabsTrigger>
+            <TabsTrigger value="details">Details</TabsTrigger>
+          </TabsList>
+          <TabsContent value="students" className="mt-4">
+            <StudentsByClassList students={data.students} />
+          </TabsContent>
+          <TabsContent value="details" className="mt-4 space-y-6">
+            <p className="text-sm text-muted-foreground">
+              Created on {formatDate(data.createdAt)} by {data.createdByName}.
+            </p>
+            {data.sharedWith.length > 0 ? (
+              <div className="text-sm">
+                <span className="font-medium">Group shared with:</span>{' '}
+                {data.sharedWith.map((s) => s.staffName).join(', ')}
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <article className="rounded-md border p-4">
+                <h3 className="font-semibold">Edit this custom group</h3>
+                <Button asChild variant="outline" className="mt-3">
+                  <Link to={`/groups/customGroups/${data.customGroupId}/edit`}>Edit Group</Link>
+                </Button>
+              </article>
+              <article className="rounded-md border p-4">
+                <h3 className="font-semibold">Share this custom group</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  You will be granting access to edit this group. Please be certain.
+                </p>
+                <Button variant="outline" className="mt-3" onClick={() => setShareOpen(true)}>
+                  Share Group
+                </Button>
+              </article>
+              <article className="rounded-md border p-4">
+                <h3 className="font-semibold">Delete this custom group</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Once you delete this custom group, you can never get it back again.
+                </p>
+                <Button variant="outline" className="mt-3" disabled>
+                  Delete Forever
+                </Button>
+              </article>
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        <ShareGroupModal
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+          staff={staff}
+          excludeStaffIds={excludeStaffIds}
+          onShare={handleShare}
+        />
+      </div>
+    </div>
+  );
+};
+
+export { CustomGroupDetailView as Component };
+```
+
+Key changes from the previous version:
+
+- Loader now returns `{ detail, staff }` (parallel-fetches `fetchCustomGroupDetail` + `fetchSchoolStaff`)
+- `useState` for `shareOpen` dialog state
+- `useRevalidator` to refetch after share success
+- Share button is no longer `disabled` — it calls `setShareOpen(true)`
+- `ShareGroupModal` rendered with `excludeStaffIds` (creator + already-shared)
+- `handleShare` calls `shareCustomGroup` then triggers revalidation
+
+- [ ] **Step 4: Update the test to account for the new loader shape**
+
+Replace the full contents of `web/containers/CustomGroupDetailView.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PGApiCustomGroupDetail, PGApiSchoolStaff } from '~/api/types';
+
+import { Component as CustomGroupDetailView } from './CustomGroupDetailView';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    shareCustomGroup: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const detail: PGApiCustomGroupDetail = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  sharedWith: [],
+  students: [
+    {
+      studentId: 1,
+      studentName: 'TAN XIAO MING',
+      className: 'H6 KINDNESS',
+      indexNumber: 15,
+      uinFinNo: 'S9000001A',
+      ccas: ['BOXING'],
+    },
+  ],
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
+const staff: PGApiSchoolStaff[] = [
+  { staffId: 1013, name: 'TAN GUANG SHIN', email: 'gs@school.edu.sg', className: null },
+  { staffId: 1014, name: 'ALICE TAN', email: 'alice@school.edu.sg', className: 'P3 BEST' },
+];
+
+function renderAt(loaderDetail: PGApiCustomGroupDetail = detail) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/:id',
+        Component: CustomGroupDetailView,
+        loader: () => ({ detail: loaderDetail, staff }),
+      },
+    ],
+    { initialEntries: ['/groups/customGroups/5'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('CustomGroupDetailView', () => {
+  it('renders the group name as the page heading', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Olympiad Study Group' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders both tab triggers', async () => {
+    renderAt();
+    expect(await screen.findByRole('tab', { name: /students/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /details/i })).toBeInTheDocument();
+  });
+
+  it('renders the student count in the Students tab label', async () => {
+    renderAt();
+    expect(await screen.findByRole('tab', { name: /students \(1\)/i })).toBeInTheDocument();
+  });
+
+  it('renders the student list on the Students tab by default', async () => {
+    renderAt();
+    expect(await screen.findByText('TAN XIAO MING')).toBeInTheDocument();
+  });
+
+  it('Details tab shows creator metadata + action cards with Share enabled', async () => {
+    const { fireEvent } = await import('@testing-library/react');
+    renderAt();
+    const detailsTab = await screen.findByRole('tab', { name: /details/i });
+    fireEvent.click(detailsTab);
+    expect(await screen.findByText(/created on/i)).toBeInTheDocument();
+    expect(screen.getByText(/TAN GUANG SHIN/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /edit group/i })).toHaveAttribute(
+      'href',
+      '/groups/customGroups/5/edit',
+    );
+    expect(screen.getByRole('button', { name: /share group/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /delete forever/i })).toBeDisabled();
+  });
+
+  it('renders shared-with names when group is shared', async () => {
+    const { fireEvent } = await import('@testing-library/react');
+    const shared: PGApiCustomGroupDetail = {
+      ...detail,
+      isShared: true,
+      sharedWith: [{ staffId: 1014, staffName: 'ALICE TAN' }],
+    };
+    renderAt(shared);
+    const detailsTab = await screen.findByRole('tab', { name: /details/i });
+    fireEvent.click(detailsTab);
+    expect(await screen.findByText(/group shared with/i)).toBeInTheDocument();
+    expect(screen.getByText(/ALICE TAN/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a && pnpm vitest run web/containers/CustomGroupDetailView.test.tsx`
+Expected: 6 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/containers/CustomGroupDetailView.tsx web/containers/CustomGroupDetailView.test.tsx
+git commit -m "feat(groups): PGTW-14 wire Share button on detail page to \`ShareGroupModal\`"
+```
+
+---
+
+### Task 4: Run full test suite + manual smoke test
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd /Users/shin/Desktop/projects/tw-pg-experiment/.worktrees/pgtw-13a && pnpm vitest run`
+Expected: All groups-related test files pass. Pre-existing `CreatePostView.validation.test.tsx` failures (2 tests) are unrelated to this branch.
+
+- [ ] **Step 2: Manual smoke test in mock mode**
+
+1. Navigate to `/groups` → click a custom group → detail page loads
+2. Click the "Details" tab → "Share Group" button should be **enabled**
+3. Click "Share Group" → modal opens with staff picker + permissions bullet list
+4. Select a staff member → "Share group" button becomes **enabled**
+5. Click "Share group" → modal closes, page re-renders (mock returns `{}`, shared-with list won't visually update because the mock fixture is static)
+
+- [ ] **Step 3: Manual smoke test in proxy mode (real PGW)**
+
+1. Same steps as above, but with `TW_PG_MOCK=false`
+2. After sharing, the detail page should refetch and the "Group shared with:" line should show the newly shared staff member's name
+3. Open the PGW web UI and verify the group shows the shared staff member
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+
+- ✅ `shareCustomGroup` API function — Task 1
+- ✅ `ShareGroupModal` with staff picker + permissions list — Task 2
+- ✅ Enable Share button on detail page — Task 3
+- ✅ Exclude creator + already-shared staff from picker — Task 2 (`excludeStaffIds` prop, filtered in component)
+- ✅ Refetch detail after share — Task 3 (`useRevalidator`)
+- ✅ Error toast on failure — Task 2 (`notify.error`)
+- ✅ Button disabled states (empty selection, submitting) — Task 2
+- ✅ Tests — Tasks 2 + 3
+
+**Placeholder scan:** None found.
+
+**Type consistency:**
+
+- `shareCustomGroup(id: number, staffIds: number[])` — same signature in Task 1 (client) and Task 3 (detail page call)
+- `ShareGroupModalProps.onShare: (staffIds: number[]) => Promise<void>` — matches Task 2 component and Task 3 `handleShare`
+- `ShareGroupModalProps.excludeStaffIds: number[]` — consumed in Task 2, constructed in Task 3 from `[data.createdBy, ...data.sharedWith.map(s => s.staffId)]`
+- `LoaderData.staff: PGApiSchoolStaff[]` — matches `fetchSchoolStaff()` return type (`PGApiSchoolStaffList` = `PGApiSchoolStaff[]`)

--- a/docs/superpowers/specs/2026-05-04-pgtw-14-share-custom-group-design.md
+++ b/docs/superpowers/specs/2026-05-04-pgtw-14-share-custom-group-design.md
@@ -1,0 +1,82 @@
+# PGTW-14: Share Custom Group with Staff — Design Spec
+
+## Goal
+
+Add a share modal to the custom group detail page that lets the group owner share access with other staff members, matching PGW's existing behavior.
+
+## Architecture
+
+A `ShareGroupModal` dialog component reuses the existing `StaffSelector` (which wraps `EntitySelector`). The modal opens from the detail page's "Share Group" action card. On submit, it calls `shareCustomGroup()` which POSTs to the BFF. After success, the detail page refetches to update the shared-with list.
+
+## Components
+
+### ShareGroupModal
+
+- **Trigger**: "Share Group" button on the detail page's Details tab (currently disabled — enable it)
+- **Content**:
+  - `StaffSelector` pre-loaded with `fetchSchoolStaff()` data, filtered to exclude:
+    - The group creator (`data.createdBy`)
+    - Already-shared staff (`data.sharedWith[].staffId`)
+  - Permissions info (matching PGW verbatim):
+    > By sharing this group, other staff members will have access to:
+    >
+    > - View and send to the group
+    > - Edit the group name
+    > - Add or delete students
+    > - Share the group with other staff
+  - "Share group" button — disabled when no staff selected or while submitting
+  - "Sharing..." loading state during submission
+
+### API
+
+- `shareCustomGroup(id: number, staffIds: number[]): Promise<void>` — `PUT /groups/custom/:id/share` with body `{ selectedStaff: staffIds }` (real PGW field name, not contract-doc `staffIds`)
+- Uses existing `mutateApi` for CSRF + timeout handling
+
+### Detail Page Updates
+
+- Enable "Share Group" button → opens `ShareGroupModal` via dialog state
+- Pass `data.createdBy` + `data.sharedWith` to the modal for filtering
+- After successful share: call `router.revalidate()` or `navigate(0)` to refetch loader data so shared-with list updates
+- Shared-with display already renders from `data.sharedWith` — no changes needed
+
+### What's NOT in scope
+
+- `removeAccess` / "Leave group" — that's PGTW-20 (tied to delete flow; PGW shows it conditionally based on owner count)
+- Conditional action card logic (delete vs leave) — PGTW-20
+- Share from overview kebab menu — PGW doesn't have this; share is detail-page only
+
+## Data Flow
+
+```
+[Detail Page] --click "Share Group"--> [ShareGroupModal opens]
+  |                                        |
+  |-- passes: groupId, createdBy,          |-- loads: fetchSchoolStaff()
+  |   sharedWith (for filtering)           |-- user picks staff
+  |                                        |-- click "Share group"
+  |                                        |-- calls shareCustomGroup(id, staffIds)
+  |                                        |-- on success: close modal + refetch detail
+  |<-- detail loader re-runs, sharedWith updates
+```
+
+## Error Handling
+
+- Network error on share → toast "Could not share the group. Please try again." (same pattern as edit page)
+- Button disabled during in-flight request (prevent double-submit)
+- Empty staff selection → button disabled
+
+## Testing
+
+- `ShareGroupModal.test.tsx` — renders permissions list, staff picker, submit calls API, button disabled states
+- `CustomGroupDetailView.test.tsx` — Share button opens modal, shared-with list renders names
+- Manual smoke test against real PGW in proxy mode
+
+## Wire Format (real PGW)
+
+```
+PUT /api/web/2/staff/groups/custom/:customGroupId/share
+Content-Type: application/json
+
+{ "selectedStaff": [1014, 1015] }
+```
+
+Response: `200 OK` with empty body.

--- a/server/internal/pg/fixtures/group_custom_detail.json
+++ b/server/internal/pg/fixtures/group_custom_detail.json
@@ -1,16 +1,16 @@
 {
-  "customGroupId": 5,
-  "name": "Olympiad Study Group",
-  "createdBy": 1013,
-  "createdByName": "TAN GUANG SHIN",
-  "isShared": false,
-  "sharedWith": [],
-  "students": [
+  "id": 5,
+  "groupName": "Olympiad Study Group",
+  "createdBy": "TAN GUANG SHIN",
+  "createdAt": "2026-03-01T08:00:00.000Z",
+  "owners": [{ "staffId": 1013, "staffName": "TAN GUANG SHIN" }],
+  "studentsList": [
     {
       "studentId": 1,
       "studentName": "TAN XIAO MING",
       "className": "4A",
       "indexNumber": 15,
+      "uinFinNo": "S9000001A",
       "ccas": ["BOXING"]
     },
     {
@@ -18,6 +18,7 @@
       "studentName": "LEE WEI LIANG",
       "className": "4A",
       "indexNumber": 8,
+      "uinFinNo": "S9000002B",
       "ccas": []
     },
     {
@@ -25,8 +26,8 @@
       "studentName": "CAROL CHEN HUI",
       "className": "4A",
       "indexNumber": 3,
+      "uinFinNo": "S9000003C",
       "ccas": ["CHOIR"]
     }
-  ],
-  "createdAt": "2026-03-01T08:00:00.000Z"
+  ]
 }

--- a/server/internal/pg/fixtures/groups_custom.json
+++ b/server/internal/pg/fixtures/groups_custom.json
@@ -1,13 +1,19 @@
-{
-  "customGroups": [
-    {
-      "customGroupId": 5,
-      "name": "Olympiad Study Group",
-      "studentCount": 8,
-      "createdBy": 1013,
-      "createdByName": "TAN GUANG SHIN",
-      "isShared": false,
-      "createdAt": "2026-03-01T08:00:00.000Z"
-    }
-  ]
-}
+[
+  {
+    "id": 5,
+    "groupName": "Olympiad Study Group",
+    "createdBy": "TAN GUANG SHIN",
+    "createdAt": "2026-03-01T08:00:00.000Z",
+    "owners": [{ "staffId": 1013, "staffName": "TAN GUANG SHIN" }],
+    "studentsList": [
+      { "studentId": 1, "studentName": "Student 1" },
+      { "studentId": 2, "studentName": "Student 2" },
+      { "studentId": 3, "studentName": "Student 3" },
+      { "studentId": 4, "studentName": "Student 4" },
+      { "studentId": 5, "studentName": "Student 5" },
+      { "studentId": 6, "studentName": "Student 6" },
+      { "studentId": 7, "studentName": "Student 7" },
+      { "studentId": 8, "studentName": "Student 8" }
+    ]
+  }
+]

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -43,6 +43,10 @@ const router = createBrowserRouter([
         lazy: () => import('./containers/CreateCustomGroupView'),
       },
       {
+        path: 'groups/customGroups/new/addStudents',
+        lazy: () => import('./containers/AddStudentsView'),
+      },
+      {
         path: 'components',
         lazy: () => import('./containers/ComponentsView'),
       },

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -47,6 +47,10 @@ const router = createBrowserRouter([
         lazy: () => import('./containers/AddStudentsView'),
       },
       {
+        path: 'groups/customGroups/:id',
+        lazy: () => import('./containers/CustomGroupDetailView'),
+      },
+      {
         path: 'components',
         lazy: () => import('./containers/ComponentsView'),
       },

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -51,6 +51,14 @@ const router = createBrowserRouter([
         lazy: () => import('./containers/CustomGroupDetailView'),
       },
       {
+        path: 'groups/customGroups/:id/edit',
+        lazy: () => import('./containers/EditCustomGroupView'),
+      },
+      {
+        path: 'groups/customGroups/:id/edit/addStudents',
+        lazy: () => import('./containers/AddStudentsView'),
+      },
+      {
         path: 'components',
         lazy: () => import('./containers/ComponentsView'),
       },

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -39,6 +39,10 @@ const router = createBrowserRouter([
         lazy: () => import('./containers/GroupsView'),
       },
       {
+        path: 'groups/customGroups/new',
+        lazy: () => import('./containers/CreateCustomGroupView'),
+      },
+      {
         path: 'components',
         lazy: () => import('./containers/ComponentsView'),
       },

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -35,6 +35,10 @@ const router = createBrowserRouter([
         lazy: () => import('./containers/CreatePostView'),
       },
       {
+        path: 'groups',
+        lazy: () => import('./containers/GroupsView'),
+      },
+      {
         path: 'components',
         lazy: () => import('./containers/ComponentsView'),
       },

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -41,8 +41,11 @@ import type {
   PGApiCreateAnnouncementPayload,
   PGApiCreateConsentFormDraftPayload,
   PGApiCreateConsentFormPayload,
+  PGApiCreateCustomGroupResponse,
   PGApiCreateDraftPayload,
+  PGApiCustomGroupDetail,
   PGApiCustomGroupsList,
+  PGApiCustomGroupSummary,
   PGApiDuplicateAnnouncementResponse,
   PGApiDuplicateConsentFormResponse,
   PGApiGroupsAssigned,
@@ -797,6 +800,63 @@ function mapPgwCustomGroup(raw: PgwRawCustomGroup): PGApiCustomGroupSummary {
 export async function fetchCustomGroups(): Promise<PGApiCustomGroupsList> {
   const raw = await fetchApi<PgwRawCustomGroup[]>('/groups/custom');
   return { customGroups: raw.map(mapPgwCustomGroup) };
+}
+
+interface PgwRawCustomGroupDetail {
+  id: number;
+  groupName: string;
+  createdBy: string;
+  createdAt: string;
+  owners?: { staffId: number; staffName: string }[];
+  studentsList?: {
+    studentId: number;
+    studentName: string;
+    className: string;
+    indexNumber?: number;
+    uinFinNo?: string;
+    ccas?: string[];
+  }[];
+}
+
+function mapPgwCustomGroupDetail(raw: PgwRawCustomGroupDetail): PGApiCustomGroupDetail {
+  const owners = raw.owners ?? [];
+  const creator = owners[0];
+  return {
+    customGroupId: raw.id,
+    name: raw.groupName,
+    createdBy: creator?.staffId ?? 0,
+    createdByName: raw.createdBy,
+    isShared: owners.length > 1,
+    sharedWith: owners.slice(1),
+    students: (raw.studentsList ?? []).map((s) => ({
+      studentId: s.studentId,
+      studentName: s.studentName,
+      className: s.className,
+      indexNumber: s.indexNumber,
+      uinFinNo: s.uinFinNo,
+      ccas: s.ccas,
+    })),
+    createdAt: raw.createdAt,
+  };
+}
+
+export async function fetchCustomGroupDetail(id: number): Promise<PGApiCustomGroupDetail> {
+  const raw = await fetchApi<PgwRawCustomGroupDetail>(`/groups/custom/${id}`);
+  return mapPgwCustomGroupDetail(raw);
+}
+
+export async function createCustomGroup(payload: {
+  name: string;
+  studentIds: number[];
+}): Promise<PGApiCreateCustomGroupResponse> {
+  return mutateApi<PGApiCreateCustomGroupResponse>('POST', '/groups/custom', payload);
+}
+
+export async function updateCustomGroup(
+  id: number,
+  payload: { name: string; studentIds: number[] },
+): Promise<void> {
+  await mutateApi<void>('PUT', `/groups/custom/${id}`, payload);
 }
 
 export function fetchClassDetail(classId: number) {

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -849,12 +849,12 @@ export async function createCustomGroup(payload: {
   name: string;
   studentIds: number[];
 }): Promise<PGApiCreateCustomGroupResponse> {
-  // Real PGW expects `groupName`, not `name` (matches the read shape — see
-  // `mapPgwCustomGroup`). The contract doc says `name`; PGW responded with
-  // `-400 "groupName" is required` so we use the wire field here.
+  // Real PGW field names diverge from the contract doc:
+  //   `groupName` (not `name`), `selectedSchoolStudents` (not `studentIds`).
+  // Confirmed via -400 responses during PGTW-13c smoke test.
   return mutateApi<PGApiCreateCustomGroupResponse>('POST', '/groups/custom', {
     groupName: payload.name,
-    studentIds: payload.studentIds,
+    selectedSchoolStudents: payload.studentIds,
   });
 }
 
@@ -864,7 +864,7 @@ export async function updateCustomGroup(
 ): Promise<void> {
   await mutateApi<void>('PUT', `/groups/custom/${id}`, {
     groupName: payload.name,
-    studentIds: payload.studentIds,
+    selectedSchoolStudents: payload.studentIds,
   });
 }
 

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -763,8 +763,40 @@ export function fetchGroupsAssigned() {
   return fetchApi<PGApiGroupsAssigned>('/groups/assigned');
 }
 
-export function fetchCustomGroups() {
-  return fetchApi<PGApiCustomGroupsList>('/groups/custom');
+/**
+ * Real PGW returns `body` as a bare array of groups in a different field
+ * vocabulary than our internal type (`id` not `customGroupId`, `groupName`
+ * not `name`, no `studentCount` — derived from `studentsList`, `createdBy`
+ * is a staff name string, etc.). The BFF mock fixture mirrors this raw
+ * shape so both proxy and mock modes flow through the same mapper.
+ */
+interface PgwRawCustomGroup {
+  id: number;
+  groupName: string;
+  createdBy: string;
+  createdAt: string;
+  owners?: { staffId: number; staffName: string }[];
+  studentsList?: unknown[];
+}
+
+function mapPgwCustomGroup(raw: PgwRawCustomGroup): PGApiCustomGroupSummary {
+  return {
+    customGroupId: raw.id,
+    name: raw.groupName,
+    studentCount: raw.studentsList?.length ?? 0,
+    // Real PGW returns only the creator's display name in this list
+    // payload — no numeric staffId. Surface 0 as a sentinel so callers
+    // can detect "unknown" if they need ownership checks.
+    createdBy: raw.owners?.[0]?.staffId ?? 0,
+    createdByName: raw.createdBy,
+    isShared: (raw.owners?.length ?? 0) > 1,
+    createdAt: raw.createdAt,
+  };
+}
+
+export async function fetchCustomGroups(): Promise<PGApiCustomGroupsList> {
+  const raw = await fetchApi<PgwRawCustomGroup[]>('/groups/custom');
+  return { customGroups: raw.map(mapPgwCustomGroup) };
 }
 
 export function fetchClassDetail(classId: number) {

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -878,6 +878,12 @@ export async function updateCustomGroup(
   });
 }
 
+export async function shareCustomGroup(id: number, staffIds: number[]): Promise<void> {
+  await mutateApi<void>('PUT', `/groups/custom/${id}/share`, {
+    selectedStaff: staffIds,
+  });
+}
+
 export function fetchClassDetail(classId: number) {
   return fetchApi<PGApiClassDetail>(`/groups/classes/${classId}`);
 }

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -841,8 +841,16 @@ function mapPgwCustomGroupDetail(raw: PgwRawCustomGroupDetail): PGApiCustomGroup
 }
 
 export async function fetchCustomGroupDetail(id: number): Promise<PGApiCustomGroupDetail> {
-  const raw = await fetchApi<PgwRawCustomGroupDetail>(`/groups/custom/${id}`);
-  return mapPgwCustomGroupDetail(raw);
+  // Real PGW returns `body` as a single-element array even for detail
+  // endpoints (matches the list shape). The mock fixture mirrors this.
+  const raw = await fetchApi<PgwRawCustomGroupDetail | PgwRawCustomGroupDetail[]>(
+    `/groups/custom/${id}`,
+  );
+  const item = Array.isArray(raw) ? raw[0] : raw;
+  if (!item) {
+    throw new Response('Group not found', { status: 404 });
+  }
+  return mapPgwCustomGroupDetail(item);
 }
 
 export async function createCustomGroup(payload: {

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -849,14 +849,23 @@ export async function createCustomGroup(payload: {
   name: string;
   studentIds: number[];
 }): Promise<PGApiCreateCustomGroupResponse> {
-  return mutateApi<PGApiCreateCustomGroupResponse>('POST', '/groups/custom', payload);
+  // Real PGW expects `groupName`, not `name` (matches the read shape — see
+  // `mapPgwCustomGroup`). The contract doc says `name`; PGW responded with
+  // `-400 "groupName" is required` so we use the wire field here.
+  return mutateApi<PGApiCreateCustomGroupResponse>('POST', '/groups/custom', {
+    groupName: payload.name,
+    studentIds: payload.studentIds,
+  });
 }
 
 export async function updateCustomGroup(
   id: number,
   payload: { name: string; studentIds: number[] },
 ): Promise<void> {
-  await mutateApi<void>('PUT', `/groups/custom/${id}`, payload);
+  await mutateApi<void>('PUT', `/groups/custom/${id}`, {
+    groupName: payload.name,
+    studentIds: payload.studentIds,
+  });
 }
 
 export function fetchClassDetail(classId: number) {

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -850,12 +850,14 @@ export async function createCustomGroup(payload: {
   studentIds: number[];
 }): Promise<PGApiCreateCustomGroupResponse> {
   // Real PGW field names diverge from the contract doc:
-  //   `groupName` (not `name`), `selectedSchoolStudents` (not `studentIds`).
-  // Confirmed via -400 responses during PGTW-13c smoke test.
-  return mutateApi<PGApiCreateCustomGroupResponse>('POST', '/groups/custom', {
+  //   - request: `groupName` (not `name`), `selectedSchoolStudents` (not `studentIds`)
+  //   - response: `id` (not `customGroupId`)
+  // Confirmed via -400 responses + smoke testing during PGTW-13c.
+  const raw = await mutateApi<{ id: number; customGroupId?: number }>('POST', '/groups/custom', {
     groupName: payload.name,
     selectedSchoolStudents: payload.studentIds,
   });
+  return { customGroupId: raw.customGroupId ?? raw.id };
 }
 
 export async function updateCustomGroup(

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -391,13 +391,15 @@ export interface PGApiGroupsAssignedClass {
   level: string;
   year: number;
   role: string;
-  studentCount: number;
+  /** Real PGW omits this; only the mock fixture currently populates it. */
+  studentCount?: number;
 }
 
 export interface PGApiGroupsAssignedCcaGroup {
   ccaId: number;
   ccaDescription: string;
-  studentCount: number;
+  /** Real PGW omits this; only the mock fixture currently populates it. */
+  studentCount?: number;
 }
 
 export interface PGApiGroupsAssigned {

--- a/web/api/types.ts
+++ b/web/api/types.ts
@@ -421,6 +421,35 @@ export interface PGApiCustomGroupsList {
   customGroups: PGApiCustomGroupSummary[];
 }
 
+export interface PGApiCustomGroupDetailStudent {
+  studentId: number;
+  studentName: string;
+  className: string;
+  indexNumber?: number;
+  uinFinNo?: string;
+  ccas?: string[];
+}
+
+export interface PGApiCustomGroupSharedStaff {
+  staffId: number;
+  staffName: string;
+}
+
+export interface PGApiCustomGroupDetail {
+  customGroupId: number;
+  name: string;
+  createdBy: number;
+  createdByName: string;
+  isShared: boolean;
+  sharedWith: PGApiCustomGroupSharedStaff[];
+  students: PGApiCustomGroupDetailStudent[];
+  createdAt: string;
+}
+
+export interface PGApiCreateCustomGroupResponse {
+  customGroupId: number;
+}
+
 export interface PGApiClassDetail {
   classId: number;
   className: string;

--- a/web/components/groups/AssignedGroupsSection.test.tsx
+++ b/web/components/groups/AssignedGroupsSection.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiGroupsAssigned } from '~/api/types';
+
+import { AssignedGroupsSection } from './AssignedGroupsSection';
+
+const empty: PGApiGroupsAssigned = { classes: [], ccaGroups: [] };
+
+describe('AssignedGroupsSection', () => {
+  it('renders empty-state copy when no classes or CCAs are assigned', () => {
+    render(<AssignedGroupsSection assigned={empty} />);
+    expect(screen.getByText(/no assigned groups/i)).toBeInTheDocument();
+  });
+
+  it('renders one card per class with the class name and a "Form Class" label', () => {
+    render(
+      <AssignedGroupsSection
+        assigned={{
+          classes: [
+            {
+              classId: 1005,
+              className: 'P1 KINDNESS',
+              level: 'P1',
+              year: 2026,
+              role: 'FT',
+              studentCount: 30,
+            },
+          ],
+          ccaGroups: [],
+        }}
+      />,
+    );
+    expect(screen.getByText('P1 KINDNESS')).toBeInTheDocument();
+    expect(screen.getByText(/form class/i)).toBeInTheDocument();
+  });
+
+  it('renders one card per CCA with the description and a "CCA" label', () => {
+    render(
+      <AssignedGroupsSection
+        assigned={{
+          classes: [],
+          ccaGroups: [{ ccaId: 1001, ccaDescription: 'AIR RIFLE / SHOOTING', studentCount: 12 }],
+        }}
+      />,
+    );
+    expect(screen.getByText('AIR RIFLE / SHOOTING')).toBeInTheDocument();
+    expect(screen.getByText(/^cca$/i)).toBeInTheDocument();
+  });
+});

--- a/web/components/groups/AssignedGroupsSection.tsx
+++ b/web/components/groups/AssignedGroupsSection.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import type { PGApiGroupsAssigned } from '~/api/types';
+
+interface AssignedGroupsSectionProps {
+  assigned: PGApiGroupsAssigned;
+}
+
+export const AssignedGroupsSection: React.FC<AssignedGroupsSectionProps> = ({ assigned }) => {
+  const isEmpty = assigned.classes.length === 0 && assigned.ccaGroups.length === 0;
+
+  if (isEmpty) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No assigned groups.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      {assigned.classes.map((c) => (
+        <article key={`class-${c.classId}`} className="rounded-md border border-border bg-card p-4">
+          <h3 className="font-medium">{c.className}</h3>
+          <p className="text-xs text-muted-foreground">Form Class</p>
+        </article>
+      ))}
+      {assigned.ccaGroups.map((g) => (
+        <article key={`cca-${g.ccaId}`} className="rounded-md border border-border bg-card p-4">
+          <h3 className="font-medium">{g.ccaDescription || 'Untitled CCA'}</h3>
+          <p className="text-xs text-muted-foreground">CCA</p>
+        </article>
+      ))}
+    </div>
+  );
+};

--- a/web/components/groups/CustomGroupsTable.test.tsx
+++ b/web/components/groups/CustomGroupsTable.test.tsx
@@ -14,9 +14,38 @@ function renderTable(groups: PGApiCustomGroupSummary[]) {
   );
 }
 
+const olympiad: PGApiCustomGroupSummary = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  studentCount: 8,
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
 describe('CustomGroupsTable', () => {
   it('renders empty state copy when there are no groups', () => {
     renderTable([]);
     expect(screen.getByText(/no custom groups yet/i)).toBeInTheDocument();
+  });
+
+  it('renders one row per group with name, student count, and creator', () => {
+    renderTable([olympiad]);
+    expect(screen.getByText('Olympiad Study Group')).toBeInTheDocument();
+    expect(screen.getByText('8')).toBeInTheDocument();
+    expect(screen.getByText('TAN GUANG SHIN')).toBeInTheDocument();
+  });
+
+  it('renders the created-on date in en-SG short format', () => {
+    renderTable([olympiad]);
+    // Intl.DateTimeFormat('en-SG', { day, month: short, year }) → "1 Mar 2026"
+    expect(screen.getByText('1 Mar 2026')).toBeInTheDocument();
+  });
+
+  it('group name is a link to the detail page', () => {
+    renderTable([olympiad]);
+    const link = screen.getByRole('link', { name: 'Olympiad Study Group' });
+    expect(link).toHaveAttribute('href', '/groups/customGroups/5');
   });
 });

--- a/web/components/groups/CustomGroupsTable.test.tsx
+++ b/web/components/groups/CustomGroupsTable.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiCustomGroupSummary } from '~/api/types';
+
+import { CustomGroupsTable } from './CustomGroupsTable';
+
+function renderTable(groups: PGApiCustomGroupSummary[]) {
+  return render(
+    <MemoryRouter>
+      <CustomGroupsTable groups={groups} />
+    </MemoryRouter>,
+  );
+}
+
+describe('CustomGroupsTable', () => {
+  it('renders empty state copy when there are no groups', () => {
+    renderTable([]);
+    expect(screen.getByText(/no custom groups yet/i)).toBeInTheDocument();
+  });
+});

--- a/web/components/groups/CustomGroupsTable.tsx
+++ b/web/components/groups/CustomGroupsTable.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import type { PGApiCustomGroupSummary } from '~/api/types';
+
+interface CustomGroupsTableProps {
+  groups: PGApiCustomGroupSummary[];
+}
+
+export const CustomGroupsTable: React.FC<CustomGroupsTableProps> = ({ groups }) => {
+  if (groups.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No custom groups yet.
+      </div>
+    );
+  }
+  return null;
+};

--- a/web/components/groups/CustomGroupsTable.tsx
+++ b/web/components/groups/CustomGroupsTable.tsx
@@ -1,6 +1,10 @@
+import { Users } from 'lucide-react';
 import React from 'react';
+import { Link } from 'react-router';
 
 import type { PGApiCustomGroupSummary } from '~/api/types';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/ui';
+import { formatDate } from '~/helpers/dateTime';
 
 interface CustomGroupsTableProps {
   groups: PGApiCustomGroupSummary[];
@@ -14,5 +18,39 @@ export const CustomGroupsTable: React.FC<CustomGroupsTableProps> = ({ groups }) 
       </div>
     );
   }
-  return null;
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Group name</TableHead>
+          <TableHead className="text-right">No. of students</TableHead>
+          <TableHead>Created on</TableHead>
+          <TableHead>Created by</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {groups.map((g) => (
+          <TableRow key={g.customGroupId}>
+            <TableCell>
+              <Link
+                to={`/groups/customGroups/${g.customGroupId}`}
+                className="font-medium text-foreground hover:underline"
+              >
+                {g.name}
+              </Link>
+            </TableCell>
+            <TableCell className="text-right">
+              <span className="inline-flex items-center gap-1">
+                <Users className="size-4 text-muted-foreground" aria-hidden />
+                {g.studentCount}
+              </span>
+            </TableCell>
+            <TableCell>{formatDate(g.createdAt)}</TableCell>
+            <TableCell>{g.createdByName}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
 };

--- a/web/components/groups/ShareGroupModal.test.tsx
+++ b/web/components/groups/ShareGroupModal.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { PGApiSchoolStaff } from '~/api/types';
+
+import { ShareGroupModal } from './ShareGroupModal';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+const schoolStaff: PGApiSchoolStaff[] = [
+  { staffId: 1001, name: 'ALICE TAN', email: 'alice@school.edu.sg', className: 'P3 BEST' },
+  { staffId: 1002, name: 'BOB LIM', email: 'bob@school.edu.sg', className: null },
+  { staffId: 1003, name: 'CHARLIE NG', email: 'charlie@school.edu.sg', className: 'P1 KINDNESS' },
+];
+
+const excludeStaffIds = [1001];
+
+function renderModal(onShare = vi.fn().mockResolvedValue(undefined)) {
+  const onClose = vi.fn();
+  render(
+    <ShareGroupModal
+      open={true}
+      onClose={onClose}
+      staff={schoolStaff}
+      excludeStaffIds={excludeStaffIds}
+      onShare={onShare}
+    />,
+  );
+  return { onShare, onClose };
+}
+
+describe('ShareGroupModal', () => {
+  it('renders the dialog title "Share group"', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Share group' })).toBeInTheDocument();
+  });
+
+  it('renders the permissions bullet list', () => {
+    renderModal();
+    expect(screen.getByText(/view and send to the group/i)).toBeInTheDocument();
+    expect(screen.getByText(/edit the group name/i)).toBeInTheDocument();
+    expect(screen.getByText(/add or delete students/i)).toBeInTheDocument();
+    expect(screen.getByText(/share the group with other staff/i)).toBeInTheDocument();
+  });
+
+  it('renders the "Share group" button disabled when no staff selected', () => {
+    renderModal();
+    expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
+  });
+});

--- a/web/components/groups/ShareGroupModal.test.tsx
+++ b/web/components/groups/ShareGroupModal.test.tsx
@@ -27,16 +27,18 @@ const schoolStaff: PGApiSchoolStaff[] = [
   { staffId: 1003, name: 'CHARLIE NG', email: 'charlie@school.edu.sg', className: 'P1 KINDNESS' },
 ];
 
-const excludeStaffIds = [1001];
-
-function renderModal(onShare = vi.fn().mockResolvedValue(undefined)) {
+function renderModal(
+  onShare = vi.fn().mockResolvedValue(undefined),
+  alreadySharedStaffIds: number[] = [],
+) {
   const onClose = vi.fn();
   render(
     <ShareGroupModal
       open={true}
       onClose={onClose}
       staff={schoolStaff}
-      excludeStaffIds={excludeStaffIds}
+      creatorStaffId={1001}
+      alreadySharedStaffIds={alreadySharedStaffIds}
       onShare={onShare}
     />,
   );

--- a/web/components/groups/ShareGroupModal.tsx
+++ b/web/components/groups/ShareGroupModal.tsx
@@ -29,6 +29,31 @@ export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
   excludeStaffIds,
   onShare,
 }) => {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      {open && (
+        <ShareGroupModalContent
+          staff={staff}
+          excludeStaffIds={excludeStaffIds}
+          onShare={onShare}
+          onClose={onClose}
+        />
+      )}
+    </Dialog>
+  );
+};
+
+const ShareGroupModalContent: React.FC<{
+  staff: PGApiSchoolStaff[];
+  excludeStaffIds: number[];
+  onShare: (staffIds: number[]) => Promise<void>;
+  onClose: () => void;
+}> = ({ staff, excludeStaffIds, onShare, onClose }) => {
   const [selected, setSelected] = useState<SelectedStaff[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
@@ -53,37 +78,30 @@ export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(nextOpen) => {
-        if (!nextOpen) onClose();
-      }}
-    >
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Share group</DialogTitle>
-          <DialogDescription>
-            By sharing this group, other staff members will have access to:
-          </DialogDescription>
-        </DialogHeader>
+    <DialogContent className="sm:max-w-lg">
+      <DialogHeader>
+        <DialogTitle>Share group</DialogTitle>
+        <DialogDescription>
+          By sharing this group, other staff members will have access to:
+        </DialogDescription>
+      </DialogHeader>
 
-        <ul className="list-disc space-y-1 pl-5 text-sm">
-          <li>View and send to the group</li>
-          <li>Edit the group name</li>
-          <li>Add or delete students</li>
-          <li>Share the group with other staff</li>
-        </ul>
+      <ul className="list-disc space-y-1 pl-5 text-sm">
+        <li>View and send to the group</li>
+        <li>Edit the group name</li>
+        <li>Add or delete students</li>
+        <li>Share the group with other staff</li>
+      </ul>
 
-        <div>
-          <StaffSelector value={selected} onChange={setSelected} staff={filteredStaff} />
-        </div>
+      <div>
+        <StaffSelector value={selected} onChange={setSelected} staff={filteredStaff} />
+      </div>
 
-        <DialogFooter>
-          <Button disabled={selected.length === 0 || submitting} onClick={handleShare}>
-            {submitting ? 'Sharing…' : 'Share group'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      <DialogFooter>
+        <Button disabled={selected.length === 0 || submitting} onClick={handleShare}>
+          {submitting ? 'Sharing…' : 'Share group'}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
   );
 };

--- a/web/components/groups/ShareGroupModal.tsx
+++ b/web/components/groups/ShareGroupModal.tsx
@@ -99,8 +99,9 @@ const ShareGroupModalContent: React.FC<{
     try {
       await onShare(newStaffIds);
       onClose();
-    } catch {
-      notify.error('Could not share the group. Please try again.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not share the group.';
+      notify.error(msg);
     } finally {
       setSubmitting(false);
     }

--- a/web/components/groups/ShareGroupModal.tsx
+++ b/web/components/groups/ShareGroupModal.tsx
@@ -1,0 +1,89 @@
+import React, { useMemo, useState } from 'react';
+
+import type { PGApiSchoolStaff } from '~/api/types';
+import { StaffSelector } from '~/components/comms/staff-selector';
+import type { SelectedStaff } from '~/components/comms/staff-selector';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui';
+import { notify } from '~/lib/notify';
+
+interface ShareGroupModalProps {
+  open: boolean;
+  onClose: () => void;
+  staff: PGApiSchoolStaff[];
+  excludeStaffIds: number[];
+  onShare: (staffIds: number[]) => Promise<void>;
+}
+
+export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
+  open,
+  onClose,
+  staff,
+  excludeStaffIds,
+  onShare,
+}) => {
+  const [selected, setSelected] = useState<SelectedStaff[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  const excludeSet = useMemo(() => new Set(excludeStaffIds), [excludeStaffIds]);
+  const filteredStaff = useMemo(
+    () => staff.filter((s) => !excludeSet.has(s.staffId)),
+    [staff, excludeSet],
+  );
+
+  async function handleShare() {
+    if (selected.length === 0) return;
+    setSubmitting(true);
+    try {
+      const staffIds = selected.map((s) => Number(s.id));
+      await onShare(staffIds);
+      onClose();
+    } catch {
+      notify.error('Could not share the group. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Share group</DialogTitle>
+          <DialogDescription>
+            By sharing this group, other staff members will have access to:
+          </DialogDescription>
+        </DialogHeader>
+
+        <ul className="list-disc space-y-1 pl-5 text-sm">
+          <li>View and send to the group</li>
+          <li>Edit the group name</li>
+          <li>Add or delete students</li>
+          <li>Share the group with other staff</li>
+        </ul>
+
+        <div>
+          <StaffSelector value={selected} onChange={setSelected} staff={filteredStaff} />
+        </div>
+
+        <DialogFooter>
+          <Button disabled={selected.length === 0 || submitting} onClick={handleShare}>
+            {submitting ? 'Sharing…' : 'Share group'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/web/components/groups/ShareGroupModal.tsx
+++ b/web/components/groups/ShareGroupModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import type { PGApiSchoolStaff } from '~/api/types';
 import { StaffSelector } from '~/components/comms/staff-selector';
@@ -18,7 +18,8 @@ interface ShareGroupModalProps {
   open: boolean;
   onClose: () => void;
   staff: PGApiSchoolStaff[];
-  excludeStaffIds: number[];
+  creatorStaffId: number;
+  alreadySharedStaffIds: number[];
   onShare: (staffIds: number[]) => Promise<void>;
 }
 
@@ -26,7 +27,8 @@ export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
   open,
   onClose,
   staff,
-  excludeStaffIds,
+  creatorStaffId,
+  alreadySharedStaffIds,
   onShare,
 }) => {
   return (
@@ -39,7 +41,8 @@ export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
       {open && (
         <ShareGroupModalContent
           staff={staff}
-          excludeStaffIds={excludeStaffIds}
+          creatorStaffId={creatorStaffId}
+          alreadySharedStaffIds={alreadySharedStaffIds}
           onShare={onShare}
           onClose={onClose}
         />
@@ -50,25 +53,51 @@ export const ShareGroupModal: React.FC<ShareGroupModalProps> = ({
 
 const ShareGroupModalContent: React.FC<{
   staff: PGApiSchoolStaff[];
-  excludeStaffIds: number[];
+  creatorStaffId: number;
+  alreadySharedStaffIds: number[];
   onShare: (staffIds: number[]) => Promise<void>;
   onClose: () => void;
-}> = ({ staff, excludeStaffIds, onShare, onClose }) => {
-  const [selected, setSelected] = useState<SelectedStaff[]>([]);
+}> = ({ staff, creatorStaffId, alreadySharedStaffIds, onShare, onClose }) => {
+  const [selectorReady, setSelectorReady] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  const excludeSet = useMemo(() => new Set(excludeStaffIds), [excludeStaffIds]);
-  const filteredStaff = useMemo(
-    () => staff.filter((s) => !excludeSet.has(s.staffId)),
-    [staff, excludeSet],
+  const alreadySharedSet = useMemo(() => new Set(alreadySharedStaffIds), [alreadySharedStaffIds]);
+
+  const pickerStaff = useMemo(
+    () => staff.filter((s) => s.staffId !== creatorStaffId),
+    [staff, creatorStaffId],
   );
 
+  const initialSelected = useMemo<SelectedStaff[]>(
+    () =>
+      staff
+        .filter((s) => alreadySharedSet.has(s.staffId))
+        .map((s) => ({
+          id: s.staffId.toString(),
+          label: s.name,
+          type: 'individual' as const,
+          count: 1,
+        })),
+    [staff, alreadySharedSet],
+  );
+
+  const [selected, setSelected] = useState<SelectedStaff[]>(initialSelected);
+
+  const newStaffIds = useMemo(
+    () => selected.map((s) => Number(s.id)).filter((id) => !alreadySharedSet.has(id)),
+    [selected, alreadySharedSet],
+  );
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setSelectorReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
   async function handleShare() {
-    if (selected.length === 0) return;
+    if (newStaffIds.length === 0) return;
     setSubmitting(true);
     try {
-      const staffIds = selected.map((s) => Number(s.id));
-      await onShare(staffIds);
+      await onShare(newStaffIds);
       onClose();
     } catch {
       notify.error('Could not share the group. Please try again.');
@@ -94,11 +123,13 @@ const ShareGroupModalContent: React.FC<{
       </ul>
 
       <div>
-        <StaffSelector value={selected} onChange={setSelected} staff={filteredStaff} />
+        {selectorReady && (
+          <StaffSelector value={selected} onChange={setSelected} staff={pickerStaff} />
+        )}
       </div>
 
       <DialogFooter>
-        <Button disabled={selected.length === 0 || submitting} onClick={handleShare}>
+        <Button disabled={newStaffIds.length === 0 || submitting} onClick={handleShare}>
           {submitting ? 'Sharing…' : 'Share group'}
         </Button>
       </DialogFooter>

--- a/web/components/groups/StudentFilterBar.test.tsx
+++ b/web/components/groups/StudentFilterBar.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { StudentFilterBar } from './StudentFilterBar';
+
+const baseProps = {
+  query: '',
+  onQueryChange: vi.fn(),
+  levelOptions: ['HIGHER 6', 'PRIMARY 1'],
+  level: '',
+  onLevelChange: vi.fn(),
+  classOptions: [
+    { label: 'P1 KINDNESS (2026)', value: 1005 },
+    { label: 'H6 KINDNESS (2026)', value: 1018 },
+  ],
+  classId: '',
+  onClassChange: vi.fn(),
+};
+
+describe('StudentFilterBar', () => {
+  it('renders the search input with the spec placeholder', () => {
+    render(<StudentFilterBar {...baseProps} />);
+    expect(screen.getByPlaceholderText(/search student name or class name/i)).toBeInTheDocument();
+  });
+
+  it('emits onQueryChange when the user types', () => {
+    const onQueryChange = vi.fn();
+    render(<StudentFilterBar {...baseProps} onQueryChange={onQueryChange} />);
+    fireEvent.change(screen.getByPlaceholderText(/search student/i), {
+      target: { value: 'al' },
+    });
+    expect(onQueryChange).toHaveBeenCalledWith('al');
+  });
+
+  it('renders one Level option per provided level + an "All levels" sentinel', () => {
+    render(<StudentFilterBar {...baseProps} />);
+    const select = screen.getByLabelText(/level/i) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.label);
+    expect(options).toEqual(['All levels', 'HIGHER 6', 'PRIMARY 1']);
+  });
+
+  it('renders one Form Class option per provided class + an "All classes" sentinel', () => {
+    render(<StudentFilterBar {...baseProps} />);
+    const select = screen.getByLabelText(/form class/i) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.label);
+    expect(options).toEqual(['All classes', 'P1 KINDNESS (2026)', 'H6 KINDNESS (2026)']);
+  });
+});

--- a/web/components/groups/StudentFilterBar.tsx
+++ b/web/components/groups/StudentFilterBar.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { Input } from '~/components/ui';
+
+interface ClassOption {
+  label: string;
+  value: number;
+}
+
+interface StudentFilterBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  levelOptions: string[];
+  level: string;
+  onLevelChange: (level: string) => void;
+  classOptions: ClassOption[];
+  classId: string;
+  onClassChange: (classId: string) => void;
+}
+
+export const StudentFilterBar: React.FC<StudentFilterBarProps> = ({
+  query,
+  onQueryChange,
+  levelOptions,
+  level,
+  onLevelChange,
+  classOptions,
+  classId,
+  onClassChange,
+}) => {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+      <Input
+        placeholder="Search student name or class name"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        className="sm:col-span-2"
+      />
+      <label className="flex flex-col gap-1 text-xs font-medium">
+        Level
+        <select
+          aria-label="Level"
+          value={level}
+          onChange={(e) => onLevelChange(e.target.value)}
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+        >
+          <option value="">All levels</option>
+          {levelOptions.map((l) => (
+            <option key={l} value={l}>
+              {l}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label className="flex flex-col gap-1 text-xs font-medium">
+        Form Class
+        <select
+          aria-label="Form Class"
+          value={classId}
+          onChange={(e) => onClassChange(e.target.value)}
+          className="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+        >
+          <option value="">All classes</option>
+          {classOptions.map((c) => (
+            <option key={c.value} value={c.value}>
+              {c.label}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+};

--- a/web/components/groups/StudentResultsTable.test.tsx
+++ b/web/components/groups/StudentResultsTable.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PGApiSchoolStudent } from '~/api/types';
+
+import { StudentResultsTable } from './StudentResultsTable';
+
+const aldddin: PGApiSchoolStudent = {
+  studentId: 1025,
+  studentName: 'ALDDIN ANG MO KIO',
+  uinFinNo: 'S9000003A',
+  classSerialNo: '15',
+  classCode: 'H6-05',
+  className: 'H6 KINDNESS',
+  levelCode: 'H6',
+  levelDescription: 'HIGHER 6',
+  cca: [],
+};
+
+describe('StudentResultsTable', () => {
+  it('renders empty state copy when there are no rows', () => {
+    render(
+      <StudentResultsTable
+        rows={[]}
+        selectedIds={new Set()}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no students match/i)).toBeInTheDocument();
+  });
+
+  it('renders one row per student with name, UIN, class', () => {
+    render(
+      <StudentResultsTable
+        rows={[aldddin]}
+        selectedIds={new Set()}
+        onToggle={vi.fn()}
+        onToggleAll={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('ALDDIN ANG MO KIO')).toBeInTheDocument();
+    expect(screen.getByText(/S9000003A/i)).toBeInTheDocument();
+    expect(screen.getByText(/H6 KINDNESS/i)).toBeInTheDocument();
+  });
+
+  it('calls onToggle with the studentId when a row checkbox is clicked', () => {
+    const onToggle = vi.fn();
+    render(
+      <StudentResultsTable
+        rows={[aldddin]}
+        selectedIds={new Set()}
+        onToggle={onToggle}
+        onToggleAll={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /select alddin/i }));
+    expect(onToggle).toHaveBeenCalledWith(1025);
+  });
+
+  it('calls onToggleAll with the visible row ids when select-all is clicked', () => {
+    const onToggleAll = vi.fn();
+    render(
+      <StudentResultsTable
+        rows={[aldddin]}
+        selectedIds={new Set()}
+        onToggle={vi.fn()}
+        onToggleAll={onToggleAll}
+      />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: /select all on this page/i }));
+    expect(onToggleAll).toHaveBeenCalledWith([1025]);
+  });
+});

--- a/web/components/groups/StudentResultsTable.tsx
+++ b/web/components/groups/StudentResultsTable.tsx
@@ -36,41 +36,43 @@ export const StudentResultsTable: React.FC<StudentResultsTableProps> = ({
   const rowIds = rows.map((r) => r.studentId);
 
   return (
-    <Table>
-      <TableHeader>
-        <TableRow>
-          <TableHead className="w-10">
-            <Checkbox
-              aria-label="Select all on this page"
-              checked={allSelected}
-              onCheckedChange={() => onToggleAll(rowIds)}
-            />
-          </TableHead>
-          <TableHead>Name</TableHead>
-          <TableHead>Class / Index</TableHead>
-        </TableRow>
-      </TableHeader>
-      <TableBody>
-        {rows.map((s) => (
-          <TableRow key={s.studentId}>
-            <TableCell>
+    <div className="max-h-[40rem] overflow-auto rounded-md border">
+      <Table>
+        <TableHeader className="sticky top-0 z-10 bg-background">
+          <TableRow>
+            <TableHead className="w-10">
               <Checkbox
-                aria-label={`Select ${s.studentName}`}
-                checked={selectedIds.has(s.studentId)}
-                onCheckedChange={() => onToggle(s.studentId)}
+                aria-label="Select all on this page"
+                checked={allSelected}
+                onCheckedChange={() => onToggleAll(rowIds)}
               />
-            </TableCell>
-            <TableCell>
-              <div className="font-medium">{s.studentName}</div>
-              <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
-            </TableCell>
-            <TableCell>
-              <div>{s.className}</div>
-              <div className="text-xs text-muted-foreground">#{s.classSerialNo}</div>
-            </TableCell>
+            </TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Class / Index</TableHead>
           </TableRow>
-        ))}
-      </TableBody>
-    </Table>
+        </TableHeader>
+        <TableBody>
+          {rows.map((s) => (
+            <TableRow key={s.studentId}>
+              <TableCell>
+                <Checkbox
+                  aria-label={`Select ${s.studentName}`}
+                  checked={selectedIds.has(s.studentId)}
+                  onCheckedChange={() => onToggle(s.studentId)}
+                />
+              </TableCell>
+              <TableCell>
+                <div className="font-medium">{s.studentName}</div>
+                <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
+              </TableCell>
+              <TableCell>
+                <div>{s.className}</div>
+                <div className="text-xs text-muted-foreground">#{s.classSerialNo}</div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 };

--- a/web/components/groups/StudentResultsTable.tsx
+++ b/web/components/groups/StudentResultsTable.tsx
@@ -36,7 +36,7 @@ export const StudentResultsTable: React.FC<StudentResultsTableProps> = ({
   const rowIds = rows.map((r) => r.studentId);
 
   return (
-    <div className="max-h-[40rem] overflow-auto rounded-md border">
+    <div className="h-full overflow-auto rounded-md border">
       <Table>
         <TableHeader className="sticky top-0 z-10 bg-background">
           <TableRow>

--- a/web/components/groups/StudentResultsTable.tsx
+++ b/web/components/groups/StudentResultsTable.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import type { PGApiSchoolStudent } from '~/api/types';
+import {
+  Checkbox,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/ui';
+
+interface StudentResultsTableProps {
+  rows: PGApiSchoolStudent[];
+  selectedIds: Set<number>;
+  onToggle: (studentId: number) => void;
+  onToggleAll: (rowIds: number[]) => void;
+}
+
+export const StudentResultsTable: React.FC<StudentResultsTableProps> = ({
+  rows,
+  selectedIds,
+  onToggle,
+  onToggleAll,
+}) => {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No students match.
+      </div>
+    );
+  }
+
+  const allSelected = rows.every((r) => selectedIds.has(r.studentId));
+  const rowIds = rows.map((r) => r.studentId);
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead className="w-10">
+            <Checkbox
+              aria-label="Select all on this page"
+              checked={allSelected}
+              onCheckedChange={() => onToggleAll(rowIds)}
+            />
+          </TableHead>
+          <TableHead>Name</TableHead>
+          <TableHead>Class / Index</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map((s) => (
+          <TableRow key={s.studentId}>
+            <TableCell>
+              <Checkbox
+                aria-label={`Select ${s.studentName}`}
+                checked={selectedIds.has(s.studentId)}
+                onCheckedChange={() => onToggle(s.studentId)}
+              />
+            </TableCell>
+            <TableCell>
+              <div className="font-medium">{s.studentName}</div>
+              <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
+            </TableCell>
+            <TableCell>
+              <div>{s.className}</div>
+              <div className="text-xs text-muted-foreground">#{s.classSerialNo}</div>
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/web/components/groups/StudentsByClassList.test.tsx
+++ b/web/components/groups/StudentsByClassList.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiCustomGroupDetailStudent } from '~/api/types';
+
+import { StudentsByClassList } from './StudentsByClassList';
+
+const xiaoming: PGApiCustomGroupDetailStudent = {
+  studentId: 1,
+  studentName: 'TAN XIAO MING',
+  className: 'H6 KINDNESS',
+  indexNumber: 15,
+  uinFinNo: 'S9000001A',
+  ccas: ['BOXING'],
+};
+const ahkow: PGApiCustomGroupDetailStudent = {
+  studentId: 2,
+  studentName: 'LIM AH KOW',
+  className: 'P1 KINDNESS',
+  indexNumber: 2,
+  uinFinNo: 'S9000002B',
+  ccas: [],
+};
+
+describe('StudentsByClassList', () => {
+  it('groups students by className and shows count per group', () => {
+    render(<StudentsByClassList students={[xiaoming, ahkow]} />);
+    expect(screen.getByText(/H6 KINDNESS \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText(/P1 KINDNESS \(1\)/)).toBeInTheDocument();
+  });
+
+  it('renders student name + UIN under each class', () => {
+    render(<StudentsByClassList students={[xiaoming]} />);
+    expect(screen.getByText('TAN XIAO MING')).toBeInTheDocument();
+    expect(screen.getByText('S9000001A')).toBeInTheDocument();
+  });
+
+  it('renders empty-state copy when there are no students', () => {
+    render(<StudentsByClassList students={[]} />);
+    expect(screen.getByText(/no students in this group/i)).toBeInTheDocument();
+  });
+});

--- a/web/components/groups/StudentsByClassList.test.tsx
+++ b/web/components/groups/StudentsByClassList.test.tsx
@@ -29,10 +29,12 @@ describe('StudentsByClassList', () => {
     expect(screen.getByText(/P1 KINDNESS \(1\)/)).toBeInTheDocument();
   });
 
-  it('renders student name + UIN under each class', () => {
+  it('renders student name, UIN, index, and CCA in each row', () => {
     render(<StudentsByClassList students={[xiaoming]} />);
     expect(screen.getByText('TAN XIAO MING')).toBeInTheDocument();
-    expect(screen.getByText('S9000001A')).toBeInTheDocument();
+    expect(screen.getByText(/S9000001A/)).toBeInTheDocument();
+    expect(screen.getByText(/Index 15/)).toBeInTheDocument();
+    expect(screen.getByText('BOXING')).toBeInTheDocument();
   });
 
   it('renders empty-state copy when there are no students', () => {

--- a/web/components/groups/StudentsByClassList.tsx
+++ b/web/components/groups/StudentsByClassList.tsx
@@ -32,19 +32,31 @@ export const StudentsByClassList: React.FC<StudentsByClassListProps> = ({ studen
           <header className="border-b px-4 py-2 text-sm font-semibold">
             {className} ({rows.length})
           </header>
-          <ul className="divide-y">
-            {rows.map((s) => (
-              <li key={s.studentId} className="flex items-center justify-between px-4 py-3">
-                <div>
-                  <div className="font-medium">{s.studentName}</div>
-                  {s.uinFinNo ? (
-                    <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
-                  ) : null}
-                </div>
-                <div className="text-xs text-muted-foreground">—</div>
-              </li>
-            ))}
-          </ul>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="px-4 py-2 font-medium">Student / Index</th>
+                <th className="px-4 py-2 font-medium">CCA(s)</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {rows.map((s) => (
+                <tr key={s.studentId}>
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{s.studentName}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {[s.uinFinNo, s.indexNumber != null ? `Index ${s.indexNumber}` : null]
+                        .filter(Boolean)
+                        .join(' | ')}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {s.ccas && s.ccas.length > 0 ? s.ccas.join(', ') : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </section>
       ))}
     </div>

--- a/web/components/groups/StudentsByClassList.tsx
+++ b/web/components/groups/StudentsByClassList.tsx
@@ -1,0 +1,52 @@
+import React, { useMemo } from 'react';
+
+import type { PGApiCustomGroupDetailStudent } from '~/api/types';
+
+interface StudentsByClassListProps {
+  students: PGApiCustomGroupDetailStudent[];
+}
+
+export const StudentsByClassList: React.FC<StudentsByClassListProps> = ({ students }) => {
+  const groups = useMemo(() => {
+    const map = new Map<string, PGApiCustomGroupDetailStudent[]>();
+    for (const s of students) {
+      const list = map.get(s.className) ?? [];
+      list.push(s);
+      map.set(s.className, list);
+    }
+    return Array.from(map.entries()).sort(([a], [b]) => a.localeCompare(b));
+  }, [students]);
+
+  if (students.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+        No students in this group.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {groups.map(([className, rows]) => (
+        <section key={className} className="rounded-md border bg-card">
+          <header className="border-b px-4 py-2 text-sm font-semibold">
+            {className} ({rows.length})
+          </header>
+          <ul className="divide-y">
+            {rows.map((s) => (
+              <li key={s.studentId} className="flex items-center justify-between px-4 py-3">
+                <div>
+                  <div className="font-medium">{s.studentName}</div>
+                  {s.uinFinNo ? (
+                    <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
+                  ) : null}
+                </div>
+                <div className="text-xs text-muted-foreground">—</div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+};

--- a/web/containers/AddStudentsView.test.tsx
+++ b/web/containers/AddStudentsView.test.tsx
@@ -45,7 +45,15 @@ const classRoster: PGApiSchoolClass[] = [
 function renderWithData(
   studentsList: PGApiSchoolStudent[] = studentRoster,
   classes: PGApiSchoolClass[] = classRoster,
+  opts?: { alreadyAdded?: number[] },
 ) {
+  const entry = opts?.alreadyAdded
+    ? {
+        pathname: '/groups/customGroups/new/addStudents',
+        state: { alreadyAdded: opts.alreadyAdded },
+      }
+    : '/groups/customGroups/new/addStudents';
+
   const router = createMemoryRouter(
     [
       {
@@ -55,7 +63,7 @@ function renderWithData(
       },
       { path: '/groups/customGroups/new', element: <div>create page</div> },
     ],
-    { initialEntries: ['/groups/customGroups/new/addStudents'] },
+    { initialEntries: [entry] },
   );
   return render(<RouterProvider router={router} />);
 }
@@ -107,5 +115,13 @@ describe('AddStudentsView', () => {
   it('Add N selected button is disabled when nothing is selected', async () => {
     renderWithData();
     expect(await screen.findByRole('button', { name: /add 0 selected/i })).toBeDisabled();
+  });
+
+  it('pre-selects students passed via alreadyAdded state', async () => {
+    renderWithData(studentRoster, classRoster, { alreadyAdded: [1] });
+    const cb = await screen.findByRole('checkbox', { name: /select alddin ang/i });
+    expect(cb).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: /select bernice lim/i })).not.toBeChecked();
+    expect(screen.getByRole('button', { name: /add 1 selected/i })).toBeEnabled();
   });
 });

--- a/web/containers/AddStudentsView.test.tsx
+++ b/web/containers/AddStudentsView.test.tsx
@@ -1,36 +1,111 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
+import type { PGApiSchoolClass, PGApiSchoolStudent } from '~/api/types';
+
 import { Component as AddStudentsView } from './AddStudentsView';
 
-const stubLoader = () => ({ students: [], classes: [] });
+const studentRoster: PGApiSchoolStudent[] = [
+  {
+    studentId: 1,
+    studentName: 'ALDDIN ANG',
+    uinFinNo: 'S9000003A',
+    classSerialNo: '15',
+    classCode: 'H6-05',
+    className: 'H6 KINDNESS',
+    levelCode: 'H6',
+    levelDescription: 'HIGHER 6',
+    cca: [],
+  },
+  {
+    studentId: 2,
+    studentName: 'BERNICE LIM',
+    uinFinNo: 'S9000004B',
+    classSerialNo: '02',
+    classCode: 'P1-01',
+    className: 'P1 KINDNESS',
+    levelCode: 'P1',
+    levelDescription: 'PRIMARY 1',
+    cca: [],
+  },
+];
 
-function renderAt(path = '/groups/customGroups/new/addStudents') {
+const classRoster: PGApiSchoolClass[] = [
+  {
+    type: 'class',
+    label: 'P1 KINDNESS (2026)',
+    labelDescription: 'P1 KINDNESS',
+    value: 1001,
+    acadYear: '2026',
+    schoolId: 1,
+  },
+];
+
+function renderWithData(
+  studentsList: PGApiSchoolStudent[] = studentRoster,
+  classes: PGApiSchoolClass[] = classRoster,
+) {
   const router = createMemoryRouter(
     [
       {
         path: '/groups/customGroups/new/addStudents',
         Component: AddStudentsView,
-        loader: stubLoader,
+        loader: () => ({ students: studentsList, classes }),
       },
+      { path: '/groups/customGroups/new', element: <div>create page</div> },
     ],
-    { initialEntries: [path] },
+    { initialEntries: ['/groups/customGroups/new/addStudents'] },
   );
   return render(<RouterProvider router={router} />);
 }
 
 describe('AddStudentsView', () => {
   it('renders the page heading "Add students"', async () => {
-    renderAt();
+    renderWithData([], []);
     expect(
       await screen.findByRole('heading', { level: 1, name: /add students/i }),
     ).toBeInTheDocument();
   });
 
   it('renders a close link back to /groups/customGroups/new', async () => {
-    renderAt();
+    renderWithData([], []);
     const close = await screen.findByRole('link', { name: /close/i });
     expect(close).toHaveAttribute('href', '/groups/customGroups/new');
+  });
+
+  it('renders the full roster initially', async () => {
+    renderWithData();
+    expect(await screen.findByText('ALDDIN ANG')).toBeInTheDocument();
+    expect(screen.getByText('BERNICE LIM')).toBeInTheDocument();
+  });
+
+  it('toggling a row checkbox updates the "Add N selected" button', async () => {
+    renderWithData();
+    fireEvent.click(await screen.findByRole('checkbox', { name: /select alddin ang/i }));
+    expect(screen.getByRole('button', { name: /add 1 selected/i })).toBeEnabled();
+  });
+
+  it('search filters rows by name', async () => {
+    renderWithData();
+    fireEvent.change(await screen.findByPlaceholderText(/search student/i), {
+      target: { value: 'bernice' },
+    });
+    expect(screen.queryByText('ALDDIN ANG')).not.toBeInTheDocument();
+    expect(screen.getByText('BERNICE LIM')).toBeInTheDocument();
+  });
+
+  it('Level filter narrows by levelDescription', async () => {
+    renderWithData();
+    fireEvent.change(await screen.findByLabelText(/level/i), {
+      target: { value: 'PRIMARY 1' },
+    });
+    expect(screen.queryByText('ALDDIN ANG')).not.toBeInTheDocument();
+    expect(screen.getByText('BERNICE LIM')).toBeInTheDocument();
+  });
+
+  it('Add N selected button is disabled when nothing is selected', async () => {
+    renderWithData();
+    expect(await screen.findByRole('button', { name: /add 0 selected/i })).toBeDisabled();
   });
 });

--- a/web/containers/AddStudentsView.test.tsx
+++ b/web/containers/AddStudentsView.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Component as AddStudentsView } from './AddStudentsView';
+
+const stubLoader = () => ({ students: [], classes: [] });
+
+function renderAt(path = '/groups/customGroups/new/addStudents') {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/new/addStudents',
+        Component: AddStudentsView,
+        loader: stubLoader,
+      },
+    ],
+    { initialEntries: [path] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('AddStudentsView', () => {
+  it('renders the page heading "Add students"', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /add students/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a close link back to /groups/customGroups/new', async () => {
+    renderAt();
+    const close = await screen.findByRole('link', { name: /close/i });
+    expect(close).toHaveAttribute('href', '/groups/customGroups/new');
+  });
+});

--- a/web/containers/AddStudentsView.tsx
+++ b/web/containers/AddStudentsView.tsx
@@ -1,0 +1,39 @@
+import { X } from 'lucide-react';
+import React from 'react';
+import { Link, useLoaderData } from 'react-router';
+
+import { fetchSchoolClasses, fetchSchoolStudents } from '~/api/client';
+import type { PGApiSchoolClass, PGApiSchoolStudent } from '~/api/types';
+
+interface AddStudentsLoaderData {
+  students: PGApiSchoolStudent[];
+  classes: PGApiSchoolClass[];
+}
+
+export async function loader(): Promise<AddStudentsLoaderData> {
+  const [students, classes] = await Promise.all([fetchSchoolStudents(), fetchSchoolClasses()]);
+  return { students, classes };
+}
+
+const AddStudentsView: React.FC = () => {
+  const data = useLoaderData() as AddStudentsLoaderData;
+  void data;
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-4xl">
+        <header className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold">Add students</h1>
+          <Link
+            to="/groups/customGroups/new"
+            aria-label="Close"
+            className="rounded-md p-2 text-muted-foreground hover:bg-muted"
+          >
+            <X className="size-5" aria-hidden />
+          </Link>
+        </header>
+      </div>
+    </div>
+  );
+};
+
+export { AddStudentsView as Component };

--- a/web/containers/AddStudentsView.tsx
+++ b/web/containers/AddStudentsView.tsx
@@ -102,8 +102,8 @@ const AddStudentsView: React.FC = () => {
   }
 
   return (
-    <div className="flex justify-center px-6 py-6">
-      <div className="w-full max-w-4xl space-y-6">
+    <div className="flex h-[calc(100svh-3rem)] justify-center px-6 py-6">
+      <div className="flex min-h-0 w-full max-w-4xl flex-col gap-6">
         <header className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Add students</h1>
           <Link
@@ -130,14 +130,16 @@ const AddStudentsView: React.FC = () => {
           Showing {visibleRows.length} of {filtered.length} matching students.
         </p>
 
-        <StudentResultsTable
-          rows={visibleRows}
-          selectedIds={selectedIds}
-          onToggle={toggle}
-          onToggleAll={toggleAll}
-        />
+        <div className="min-h-0 flex-1">
+          <StudentResultsTable
+            rows={visibleRows}
+            selectedIds={selectedIds}
+            onToggle={toggle}
+            onToggleAll={toggleAll}
+          />
+        </div>
 
-        <footer className="flex items-center justify-end gap-3">
+        <footer className="flex items-center justify-end gap-3 pb-2">
           <Link
             to={parentPath}
             className="text-sm font-medium text-muted-foreground hover:underline"

--- a/web/containers/AddStudentsView.tsx
+++ b/web/containers/AddStudentsView.tsx
@@ -1,14 +1,27 @@
 import { X } from 'lucide-react';
-import React from 'react';
-import { Link, useLoaderData } from 'react-router';
+import React, { useMemo, useState } from 'react';
+import { Link, useLoaderData, useLocation, useNavigate } from 'react-router';
 
 import { fetchSchoolClasses, fetchSchoolStudents } from '~/api/client';
 import type { PGApiSchoolClass, PGApiSchoolStudent } from '~/api/types';
+import { StudentFilterBar } from '~/components/groups/StudentFilterBar';
+import { StudentResultsTable } from '~/components/groups/StudentResultsTable';
+import { Button } from '~/components/ui';
 
 interface AddStudentsLoaderData {
   students: PGApiSchoolStudent[];
   classes: PGApiSchoolClass[];
 }
+
+interface IncomingNavState {
+  alreadyAdded?: number[];
+}
+
+interface OutgoingNavState {
+  addedStudents: PGApiSchoolStudent[];
+}
+
+const PAGE_CAP = 200;
 
 export async function loader(): Promise<AddStudentsLoaderData> {
   const [students, classes] = await Promise.all([fetchSchoolStudents(), fetchSchoolClasses()]);
@@ -17,10 +30,77 @@ export async function loader(): Promise<AddStudentsLoaderData> {
 
 const AddStudentsView: React.FC = () => {
   const data = useLoaderData() as AddStudentsLoaderData;
-  void data;
+  const navigate = useNavigate();
+  const location = useLocation();
+  const incoming = (location.state as IncomingNavState | null) ?? {};
+  const alreadyAdded = useMemo(() => new Set(incoming.alreadyAdded ?? []), [incoming.alreadyAdded]);
+
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [query, setQuery] = useState('');
+  const [level, setLevel] = useState('');
+  const [classId, setClassId] = useState('');
+
+  const levelOptions = useMemo(() => {
+    const set = new Set(data.students.map((s) => s.levelDescription));
+    return Array.from(set).sort();
+  }, [data.students]);
+
+  const classOptions = useMemo(
+    () =>
+      data.classes.map((c) => ({
+        label: c.label,
+        value: c.value,
+      })),
+    [data.classes],
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.toLowerCase();
+    const selectedClass = data.classes.find((c) => c.value.toString() === classId);
+    return data.students.filter((s) => {
+      if (alreadyAdded.has(s.studentId)) return false;
+      if (level && s.levelDescription !== level) return false;
+      if (selectedClass && s.className !== selectedClass.labelDescription) return false;
+      if (q) {
+        const hay = `${s.studentName} ${s.className}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [data.students, data.classes, alreadyAdded, level, classId, query]);
+
+  const visibleRows = filtered.slice(0, PAGE_CAP);
+
+  function toggle(studentId: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(studentId)) next.delete(studentId);
+      else next.add(studentId);
+      return next;
+    });
+  }
+
+  function toggleAll(rowIds: number[]) {
+    setSelectedIds((prev) => {
+      const allSelected = rowIds.every((id) => prev.has(id));
+      const next = new Set(prev);
+      for (const id of rowIds) {
+        if (allSelected) next.delete(id);
+        else next.add(id);
+      }
+      return next;
+    });
+  }
+
+  function submit() {
+    const addedStudents = data.students.filter((s) => selectedIds.has(s.studentId));
+    const state: OutgoingNavState = { addedStudents };
+    navigate('/groups/customGroups/new', { state });
+  }
+
   return (
     <div className="flex justify-center px-6 py-6">
-      <div className="w-full max-w-4xl">
+      <div className="w-full max-w-4xl space-y-6">
         <header className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Add students</h1>
           <Link
@@ -31,6 +111,40 @@ const AddStudentsView: React.FC = () => {
             <X className="size-5" aria-hidden />
           </Link>
         </header>
+
+        <StudentFilterBar
+          query={query}
+          onQueryChange={setQuery}
+          levelOptions={levelOptions}
+          level={level}
+          onLevelChange={setLevel}
+          classOptions={classOptions}
+          classId={classId}
+          onClassChange={setClassId}
+        />
+
+        <p className="text-sm text-muted-foreground">
+          Showing {visibleRows.length} of {filtered.length} matching students.
+        </p>
+
+        <StudentResultsTable
+          rows={visibleRows}
+          selectedIds={selectedIds}
+          onToggle={toggle}
+          onToggleAll={toggleAll}
+        />
+
+        <footer className="flex items-center justify-end gap-3">
+          <Link
+            to="/groups/customGroups/new"
+            className="text-sm font-medium text-muted-foreground hover:underline"
+          >
+            Cancel
+          </Link>
+          <Button disabled={selectedIds.size === 0} onClick={submit}>
+            Add {selectedIds.size} selected
+          </Button>
+        </footer>
       </div>
     </div>
   );

--- a/web/containers/AddStudentsView.tsx
+++ b/web/containers/AddStudentsView.tsx
@@ -33,9 +33,7 @@ const AddStudentsView: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const incoming = (location.state as IncomingNavState | null) ?? {};
-  const alreadyAdded = useMemo(() => new Set(incoming.alreadyAdded ?? []), [incoming.alreadyAdded]);
-
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set(incoming.alreadyAdded ?? []));
   const [query, setQuery] = useState('');
   const [level, setLevel] = useState('');
   const [classId, setClassId] = useState('');
@@ -58,7 +56,6 @@ const AddStudentsView: React.FC = () => {
     const q = query.toLowerCase();
     const selectedClass = data.classes.find((c) => c.value.toString() === classId);
     return data.students.filter((s) => {
-      if (alreadyAdded.has(s.studentId)) return false;
       if (level && s.levelDescription !== level) return false;
       if (selectedClass && s.className !== selectedClass.labelDescription) return false;
       if (q) {
@@ -67,7 +64,7 @@ const AddStudentsView: React.FC = () => {
       }
       return true;
     });
-  }, [data.students, data.classes, alreadyAdded, level, classId, query]);
+  }, [data.students, data.classes, level, classId, query]);
 
   const visibleRows = filtered.slice(0, PAGE_CAP);
 

--- a/web/containers/AddStudentsView.tsx
+++ b/web/containers/AddStudentsView.tsx
@@ -92,10 +92,16 @@ const AddStudentsView: React.FC = () => {
     });
   }
 
+  // Strip the trailing /addStudents segment to return to whichever parent
+  // (create or edit) launched this subpage. Lets the same component back
+  // both `/groups/customGroups/new/addStudents` and
+  // `/groups/customGroups/:id/edit/addStudents`.
+  const parentPath = location.pathname.replace(/\/addStudents$/, '');
+
   function submit() {
     const addedStudents = data.students.filter((s) => selectedIds.has(s.studentId));
     const state: OutgoingNavState = { addedStudents };
-    navigate('/groups/customGroups/new', { state });
+    navigate(parentPath, { state });
   }
 
   return (
@@ -104,7 +110,7 @@ const AddStudentsView: React.FC = () => {
         <header className="flex items-center justify-between">
           <h1 className="text-2xl font-semibold">Add students</h1>
           <Link
-            to="/groups/customGroups/new"
+            to={parentPath}
             aria-label="Close"
             className="rounded-md p-2 text-muted-foreground hover:bg-muted"
           >
@@ -136,7 +142,7 @@ const AddStudentsView: React.FC = () => {
 
         <footer className="flex items-center justify-end gap-3">
           <Link
-            to="/groups/customGroups/new"
+            to={parentPath}
             className="text-sm font-medium text-muted-foreground hover:underline"
           >
             Cancel

--- a/web/containers/CreateCustomGroupView.test.tsx
+++ b/web/containers/CreateCustomGroupView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
@@ -18,5 +18,21 @@ describe('CreateCustomGroupView', () => {
     expect(
       await screen.findByRole('heading', { level: 1, name: /create new group/i }),
     ).toBeInTheDocument();
+  });
+
+  it('allows typing into the title input and shows the remaining-character counter', () => {
+    renderView();
+    const input = screen.getByLabelText(/title/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Olympiad Squad' } });
+    expect(input.value).toBe('Olympiad Squad');
+    expect(screen.getByText(/106 characters left/i)).toBeInTheDocument();
+  });
+
+  it('does not allow typing past 120 characters', () => {
+    renderView();
+    const input = screen.getByLabelText(/title/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'a'.repeat(150) } });
+    expect(input.value.length).toBe(120);
+    expect(screen.getByText(/0 characters left/i)).toBeInTheDocument();
   });
 });

--- a/web/containers/CreateCustomGroupView.test.tsx
+++ b/web/containers/CreateCustomGroupView.test.tsx
@@ -35,4 +35,39 @@ describe('CreateCustomGroupView', () => {
     expect(input.value.length).toBe(120);
     expect(screen.getByText(/0 characters left/i)).toBeInTheDocument();
   });
+
+  it('shows the empty students state with a "0 students added" counter and "No students added yet." copy', () => {
+    renderView();
+    expect(screen.getByText(/0 students added/i)).toBeInTheDocument();
+    expect(screen.getByText(/no students added yet/i)).toBeInTheDocument();
+  });
+
+  it('shows an "+ Add Students" dropdown with two disabled items', async () => {
+    renderView();
+    // `DropdownMenuTrigger asChild` wraps the inner Button, producing two
+    // matching elements; the first is the actual trigger.
+    const triggers = screen.getAllByRole('button', { name: /add students/i });
+    fireEvent.click(triggers[0]);
+    const manual = await screen.findByRole('menuitem', { name: /add manually/i });
+    const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
+    expect(manual).toHaveAttribute('aria-disabled', 'true');
+    expect(excel).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows a Cancel link that navigates back to /groups', async () => {
+    renderView();
+    const cancel = await screen.findByRole('link', { name: /cancel/i });
+    expect(cancel).toHaveAttribute('href', '/groups');
+  });
+
+  it('disables the Create Now button when there are no students', () => {
+    renderView();
+    const create = screen.getByRole('button', { name: /create now/i });
+    expect(create).toBeDisabled();
+
+    // Even with a title, no students → still disabled.
+    const input = screen.getByLabelText(/title/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Some title' } });
+    expect(create).toBeDisabled();
+  });
 });

--- a/web/containers/CreateCustomGroupView.test.tsx
+++ b/web/containers/CreateCustomGroupView.test.tsx
@@ -42,16 +42,50 @@ describe('CreateCustomGroupView', () => {
     expect(screen.getByText(/no students added yet/i)).toBeInTheDocument();
   });
 
-  it('shows an "+ Add Students" dropdown with two disabled items', async () => {
+  it('shows an "+ Add Students" dropdown with "Add manually" enabled (links to subpage) and "Upload via Excel" disabled', async () => {
     renderView();
-    // `DropdownMenuTrigger asChild` wraps the inner Button, producing two
-    // matching elements; the first is the actual trigger.
     const triggers = screen.getAllByRole('button', { name: /add students/i });
     fireEvent.click(triggers[0]);
     const manual = await screen.findByRole('menuitem', { name: /add manually/i });
     const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
-    expect(manual).toHaveAttribute('aria-disabled', 'true');
+    expect(manual).not.toHaveAttribute('aria-disabled', 'true');
     expect(excel).toHaveAttribute('aria-disabled', 'true');
+    // The menuitem renders a Link — assert it points at the subpage.
+    expect(manual.querySelector('a')).toHaveAttribute(
+      'href',
+      '/groups/customGroups/new/addStudents',
+    );
+  });
+
+  it('reads addedStudents from router state and renders counter + names', async () => {
+    const router = createMemoryRouter(
+      [{ path: '/groups/customGroups/new', Component: CreateCustomGroupView }],
+      {
+        initialEntries: [
+          {
+            pathname: '/groups/customGroups/new',
+            state: {
+              addedStudents: [
+                {
+                  studentId: 1,
+                  studentName: 'ALDDIN ANG',
+                  uinFinNo: 'S9000003A',
+                  classSerialNo: '15',
+                  classCode: 'H6-05',
+                  className: 'H6 KINDNESS',
+                  levelCode: 'H6',
+                  levelDescription: 'HIGHER 6',
+                  cca: [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    );
+    render(<RouterProvider router={router} />);
+    expect(await screen.findByText(/1 student added/i)).toBeInTheDocument();
+    expect(screen.getByText('ALDDIN ANG')).toBeInTheDocument();
   });
 
   it('shows a Cancel link that navigates back to /groups', async () => {

--- a/web/containers/CreateCustomGroupView.test.tsx
+++ b/web/containers/CreateCustomGroupView.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Component as CreateCustomGroupView } from './CreateCustomGroupView';
+
+function renderView() {
+  const router = createMemoryRouter(
+    [{ path: '/groups/customGroups/new', Component: CreateCustomGroupView }],
+    { initialEntries: ['/groups/customGroups/new'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('CreateCustomGroupView', () => {
+  it('renders the page heading "Create new group"', async () => {
+    renderView();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /create new group/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/containers/CreateCustomGroupView.test.tsx
+++ b/web/containers/CreateCustomGroupView.test.tsx
@@ -1,8 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Component as CreateCustomGroupView } from './CreateCustomGroupView';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createCustomGroup: vi.fn().mockResolvedValue({ customGroupId: 42 }),
+  };
+});
 
 function renderView() {
   const router = createMemoryRouter(
@@ -55,6 +63,45 @@ describe('CreateCustomGroupView', () => {
       'href',
       '/groups/customGroups/new/addStudents',
     );
+  });
+
+  it('clicking "Create Now" with a title and students POSTs and navigates to /groups/customGroups/:id', async () => {
+    const { createCustomGroup } = await import('~/api/client');
+    const router = createMemoryRouter(
+      [
+        { path: '/groups/customGroups/new', Component: CreateCustomGroupView },
+        { path: '/groups/customGroups/:id', element: <div>detail page</div> },
+      ],
+      {
+        initialEntries: [
+          {
+            pathname: '/groups/customGroups/new',
+            state: {
+              addedStudents: [
+                {
+                  studentId: 1,
+                  studentName: 'ALDDIN',
+                  uinFinNo: 'S9000003A',
+                  classSerialNo: '15',
+                  classCode: 'H6-05',
+                  className: 'H6 KINDNESS',
+                  levelCode: 'H6',
+                  levelDescription: 'HIGHER 6',
+                  cca: [],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    );
+    render(<RouterProvider router={router} />);
+
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Olympiad' } });
+    fireEvent.click(screen.getByRole('button', { name: /create now/i }));
+
+    await screen.findByText('detail page');
+    expect(createCustomGroup).toHaveBeenCalledWith({ name: 'Olympiad', studentIds: [1] });
   });
 
   it('reads addedStudents from router state and renders counter + names', async () => {

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -1,6 +1,15 @@
+import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
+import { Link } from 'react-router';
 
-import { Input } from '~/components/ui';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+} from '~/components/ui';
 
 const TITLE_MAX = 120;
 
@@ -25,6 +34,36 @@ const CreateCustomGroupView: React.FC = () => {
         <p className="mt-1 text-xs text-muted-foreground">
           {TITLE_MAX - title.length} characters left
         </p>
+
+        <div className="mt-6">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium">0 students added.</p>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline">
+                  <Plus className="size-4" aria-hidden />
+                  Add Students
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem disabled>Add manually</DropdownMenuItem>
+                <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+            No students added yet.
+          </div>
+        </div>
+
+        <div className="mt-8 flex items-center justify-end gap-3">
+          <Link to="/groups" className="text-sm font-medium text-muted-foreground hover:underline">
+            Cancel
+          </Link>
+          <Button disabled title="Add at least one student to create the group">
+            Create Now
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -17,52 +17,57 @@ const CreateCustomGroupView: React.FC = () => {
   const [title, setTitle] = useState('');
 
   return (
-    <div className="px-4 py-6 md:px-6">
-      <h1 className="text-2xl font-semibold">Create new group</h1>
-      <div className="mt-6 max-w-2xl">
-        <label htmlFor="group-title" className="text-sm font-medium">
-          Title<span className="text-destructive">*</span>
-        </label>
-        <Input
-          id="group-title"
-          value={title}
-          maxLength={TITLE_MAX}
-          onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
-          placeholder="What would you like to call your group?"
-          className="mt-1"
-        />
-        <p className="mt-1 text-xs text-muted-foreground">
-          {TITLE_MAX - title.length} characters left
-        </p>
-
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-2xl">
+        <h1 className="text-2xl font-semibold">Create new group</h1>
         <div className="mt-6">
-          <div className="flex items-center justify-between">
-            <p className="text-sm font-medium">0 students added.</p>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline">
-                  <Plus className="size-4" aria-hidden />
-                  Add Students
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem disabled>Add manually</DropdownMenuItem>
-                <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-          <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
-            No students added yet.
-          </div>
-        </div>
+          <label htmlFor="group-title" className="text-sm font-medium">
+            Title<span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="group-title"
+            value={title}
+            maxLength={TITLE_MAX}
+            onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+            placeholder="What would you like to call your group?"
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {TITLE_MAX - title.length} characters left
+          </p>
 
-        <div className="mt-8 flex items-center justify-end gap-3">
-          <Link to="/groups" className="text-sm font-medium text-muted-foreground hover:underline">
-            Cancel
-          </Link>
-          <Button disabled title="Add at least one student to create the group">
-            Create Now
-          </Button>
+          <div className="mt-6">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium">0 students added.</p>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline">
+                    <Plus className="size-4" aria-hidden />
+                    Add Students
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem disabled>Add manually</DropdownMenuItem>
+                  <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+              No students added yet.
+            </div>
+          </div>
+
+          <div className="mt-8 flex items-center justify-end gap-3">
+            <Link
+              to="/groups"
+              className="text-sm font-medium text-muted-foreground hover:underline"
+            >
+              Cancel
+            </Link>
+            <Button disabled title="Add at least one student to create the group">
+              Create Now
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -1,9 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+import { Input } from '~/components/ui';
+
+const TITLE_MAX = 120;
 
 const CreateCustomGroupView: React.FC = () => {
+  const [title, setTitle] = useState('');
+
   return (
     <div className="px-4 py-6 md:px-6">
       <h1 className="text-2xl font-semibold">Create new group</h1>
+      <div className="mt-6 max-w-2xl">
+        <label htmlFor="group-title" className="text-sm font-medium">
+          Title<span className="text-destructive">*</span>
+        </label>
+        <Input
+          id="group-title"
+          value={title}
+          maxLength={TITLE_MAX}
+          onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+          placeholder="What would you like to call your group?"
+          className="mt-1"
+        />
+        <p className="mt-1 text-xs text-muted-foreground">
+          {TITLE_MAX - title.length} characters left
+        </p>
+      </div>
     </div>
   );
 };

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -1,7 +1,8 @@
 import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
-import { Link, useLocation } from 'react-router';
+import { Link, useLocation, useNavigate } from 'react-router';
 
+import { createCustomGroup } from '~/api/client';
 import type { PGApiSchoolStudent } from '~/api/types';
 import {
   Button,
@@ -11,6 +12,7 @@ import {
   DropdownMenuTrigger,
   Input,
 } from '~/components/ui';
+import { notify } from '~/lib/notify';
 
 const TITLE_MAX = 120;
 
@@ -21,11 +23,29 @@ interface IncomingNavState {
 const CreateCustomGroupView: React.FC = () => {
   const [title, setTitle] = useState('');
   const location = useLocation();
+  const navigate = useNavigate();
   const navState = (location.state as IncomingNavState | null) ?? {};
   const [students] = useState<PGApiSchoolStudent[]>(navState.addedStudents ?? []);
+  const [submitting, setSubmitting] = useState(false);
 
   const studentCount = students.length;
   const canSave = title.trim().length > 0 && studentCount > 0;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    try {
+      const { customGroupId } = await createCustomGroup({
+        name: title.trim(),
+        studentIds: students.map((s) => s.studentId),
+      });
+      navigate(`/groups/customGroups/${customGroupId}`);
+    } catch (err) {
+      setSubmitting(false);
+      if (!(err instanceof Error)) throw err;
+      notify.error('Could not create the group. Please try again.');
+    }
+  }
 
   return (
     <div className="flex justify-center px-6 py-6">
@@ -96,10 +116,11 @@ const CreateCustomGroupView: React.FC = () => {
               Cancel
             </Link>
             <Button
-              disabled={!canSave}
+              disabled={!canSave || submitting}
               title={canSave ? undefined : 'Add at least one student to create the group'}
+              onClick={handleSave}
             >
-              Create Now
+              {submitting ? 'Creating…' : 'Create Now'}
             </Button>
           </div>
         </div>

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -1,7 +1,8 @@
 import { Plus } from 'lucide-react';
 import React, { useState } from 'react';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 
+import type { PGApiSchoolStudent } from '~/api/types';
 import {
   Button,
   DropdownMenu,
@@ -13,8 +14,18 @@ import {
 
 const TITLE_MAX = 120;
 
+interface IncomingNavState {
+  addedStudents?: PGApiSchoolStudent[];
+}
+
 const CreateCustomGroupView: React.FC = () => {
   const [title, setTitle] = useState('');
+  const location = useLocation();
+  const navState = (location.state as IncomingNavState | null) ?? {};
+  const [students] = useState<PGApiSchoolStudent[]>(navState.addedStudents ?? []);
+
+  const studentCount = students.length;
+  const canSave = title.trim().length > 0 && studentCount > 0;
 
   return (
     <div className="flex justify-center px-6 py-6">
@@ -38,7 +49,9 @@ const CreateCustomGroupView: React.FC = () => {
 
           <div className="mt-6">
             <div className="flex items-center justify-between">
-              <p className="text-sm font-medium">0 students added.</p>
+              <p className="text-sm font-medium">
+                {studentCount} student{studentCount === 1 ? '' : 's'} added.
+              </p>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <Button variant="outline">
@@ -47,14 +60,32 @@ const CreateCustomGroupView: React.FC = () => {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                  <DropdownMenuItem disabled>Add manually</DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/groups/customGroups/new/addStudents"
+                      state={{ alreadyAdded: students.map((s) => s.studentId) }}
+                    >
+                      Add manually
+                    </Link>
+                  </DropdownMenuItem>
                   <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-            <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
-              No students added yet.
-            </div>
+            {studentCount === 0 ? (
+              <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+                No students added yet.
+              </div>
+            ) : (
+              <ul className="mt-2 divide-y rounded-md border">
+                {students.map((s) => (
+                  <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
+                    <span>{s.studentName}</span>
+                    <span className="text-xs text-muted-foreground">{s.className}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
 
           <div className="mt-8 flex items-center justify-end gap-3">
@@ -64,7 +95,10 @@ const CreateCustomGroupView: React.FC = () => {
             >
               Cancel
             </Link>
-            <Button disabled title="Add at least one student to create the group">
+            <Button
+              disabled={!canSave}
+              title={canSave ? undefined : 'Add at least one student to create the group'}
+            >
               Create Now
             </Button>
           </div>

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const CreateCustomGroupView: React.FC = () => {
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <h1 className="text-2xl font-semibold">Create new group</h1>
+    </div>
+  );
+};
+
+export { CreateCustomGroupView as Component };

--- a/web/containers/CustomGroupDetailView.test.tsx
+++ b/web/containers/CustomGroupDetailView.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import type { PGApiCustomGroupDetail } from '~/api/types';
+
+import { Component as CustomGroupDetailView } from './CustomGroupDetailView';
+
+const detail: PGApiCustomGroupDetail = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  sharedWith: [],
+  students: [
+    {
+      studentId: 1,
+      studentName: 'TAN XIAO MING',
+      className: 'H6 KINDNESS',
+      indexNumber: 15,
+      uinFinNo: 'S9000001A',
+      ccas: ['BOXING'],
+    },
+  ],
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
+function renderAt(loaderData: PGApiCustomGroupDetail = detail) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/:id',
+        Component: CustomGroupDetailView,
+        loader: () => loaderData,
+      },
+    ],
+    { initialEntries: ['/groups/customGroups/5'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('CustomGroupDetailView', () => {
+  it('renders the group name as the page heading', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Olympiad Study Group' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders both tab triggers', async () => {
+    renderAt();
+    expect(await screen.findByRole('tab', { name: /students/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /details/i })).toBeInTheDocument();
+  });
+
+  it('renders the student count in the Students tab label', async () => {
+    renderAt();
+    expect(await screen.findByRole('tab', { name: /students \(1\)/i })).toBeInTheDocument();
+  });
+});

--- a/web/containers/CustomGroupDetailView.test.tsx
+++ b/web/containers/CustomGroupDetailView.test.tsx
@@ -58,4 +58,24 @@ describe('CustomGroupDetailView', () => {
     renderAt();
     expect(await screen.findByRole('tab', { name: /students \(1\)/i })).toBeInTheDocument();
   });
+
+  it('renders the student list on the Students tab by default', async () => {
+    renderAt();
+    expect(await screen.findByText('TAN XIAO MING')).toBeInTheDocument();
+  });
+
+  it('Details tab shows creator metadata + the three action cards', async () => {
+    const { fireEvent } = await import('@testing-library/react');
+    renderAt();
+    const detailsTab = await screen.findByRole('tab', { name: /details/i });
+    fireEvent.click(detailsTab);
+    expect(await screen.findByText(/created on/i)).toBeInTheDocument();
+    expect(screen.getByText(/TAN GUANG SHIN/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /edit group/i })).toHaveAttribute(
+      'href',
+      '/groups/customGroups/5/edit',
+    );
+    expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /delete forever/i })).toBeDisabled();
+  });
 });

--- a/web/containers/CustomGroupDetailView.test.tsx
+++ b/web/containers/CustomGroupDetailView.test.tsx
@@ -1,10 +1,34 @@
 import { render, screen } from '@testing-library/react';
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-import type { PGApiCustomGroupDetail } from '~/api/types';
+import type { PGApiCustomGroupDetail, PGApiSchoolStaff } from '~/api/types';
 
 import { Component as CustomGroupDetailView } from './CustomGroupDetailView';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    shareCustomGroup: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 const detail: PGApiCustomGroupDetail = {
   customGroupId: 5,
@@ -26,13 +50,18 @@ const detail: PGApiCustomGroupDetail = {
   createdAt: '2026-03-01T08:00:00.000Z',
 };
 
-function renderAt(loaderData: PGApiCustomGroupDetail = detail) {
+const staff: PGApiSchoolStaff[] = [
+  { staffId: 1013, name: 'TAN GUANG SHIN', email: 'gs@school.edu.sg', className: null },
+  { staffId: 1014, name: 'ALICE TAN', email: 'alice@school.edu.sg', className: 'P3 BEST' },
+];
+
+function renderAt(loaderDetail: PGApiCustomGroupDetail = detail) {
   const router = createMemoryRouter(
     [
       {
         path: '/groups/customGroups/:id',
         Component: CustomGroupDetailView,
-        loader: () => loaderData,
+        loader: () => ({ detail: loaderDetail, staff }),
       },
     ],
     { initialEntries: ['/groups/customGroups/5'] },
@@ -64,7 +93,7 @@ describe('CustomGroupDetailView', () => {
     expect(await screen.findByText('TAN XIAO MING')).toBeInTheDocument();
   });
 
-  it('Details tab shows creator metadata + the three action cards', async () => {
+  it('Details tab shows creator metadata + action cards with Share enabled', async () => {
     const { fireEvent } = await import('@testing-library/react');
     renderAt();
     const detailsTab = await screen.findByRole('tab', { name: /details/i });
@@ -75,7 +104,21 @@ describe('CustomGroupDetailView', () => {
       'href',
       '/groups/customGroups/5/edit',
     );
-    expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /share group/i })).toBeEnabled();
     expect(screen.getByRole('button', { name: /delete forever/i })).toBeDisabled();
+  });
+
+  it('renders shared-with names when group is shared', async () => {
+    const { fireEvent } = await import('@testing-library/react');
+    const shared: PGApiCustomGroupDetail = {
+      ...detail,
+      isShared: true,
+      sharedWith: [{ staffId: 1014, staffName: 'ALICE TAN' }],
+    };
+    renderAt(shared);
+    const detailsTab = await screen.findByRole('tab', { name: /details/i });
+    fireEvent.click(detailsTab);
+    expect(await screen.findByText(/group shared with/i)).toBeInTheDocument();
+    expect(screen.getByText(/ALICE TAN/)).toBeInTheDocument();
   });
 });

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -1,24 +1,36 @@
-import React from 'react';
-import { Link, useLoaderData } from 'react-router';
+import React, { useState } from 'react';
+import { Link, useLoaderData, useRevalidator } from 'react-router';
 
-import { fetchCustomGroupDetail } from '~/api/client';
-import type { PGApiCustomGroupDetail } from '~/api/types';
+import { fetchCustomGroupDetail, fetchSchoolStaff, shareCustomGroup } from '~/api/client';
+import type { PGApiCustomGroupDetail, PGApiSchoolStaff } from '~/api/types';
+import { ShareGroupModal } from '~/components/groups/ShareGroupModal';
 import { StudentsByClassList } from '~/components/groups/StudentsByClassList';
 import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
 import { formatDate } from '~/helpers/dateTime';
 
-export async function loader({
-  params,
-}: {
-  params: { id?: string };
-}): Promise<PGApiCustomGroupDetail> {
+interface LoaderData {
+  detail: PGApiCustomGroupDetail;
+  staff: PGApiSchoolStaff[];
+}
+
+export async function loader({ params }: { params: { id?: string } }): Promise<LoaderData> {
   const id = Number(params.id);
   if (!Number.isFinite(id)) throw new Response('Invalid group id', { status: 400 });
-  return fetchCustomGroupDetail(id);
+  const [detail, staff] = await Promise.all([fetchCustomGroupDetail(id), fetchSchoolStaff()]);
+  return { detail, staff };
 }
 
 const CustomGroupDetailView: React.FC = () => {
-  const data = useLoaderData() as PGApiCustomGroupDetail;
+  const { detail: data, staff } = useLoaderData() as LoaderData;
+  const revalidator = useRevalidator();
+  const [shareOpen, setShareOpen] = useState(false);
+
+  const excludeStaffIds = [data.createdBy, ...data.sharedWith.map((s) => s.staffId)];
+
+  async function handleShare(staffIds: number[]) {
+    await shareCustomGroup(data.customGroupId, staffIds);
+    revalidator.revalidate();
+  }
 
   return (
     <div className="flex justify-center px-6 py-6">
@@ -59,7 +71,7 @@ const CustomGroupDetailView: React.FC = () => {
                 <p className="mt-1 text-xs text-muted-foreground">
                   You will be granting access to edit this group. Please be certain.
                 </p>
-                <Button variant="outline" className="mt-3" disabled>
+                <Button variant="outline" className="mt-3" onClick={() => setShareOpen(true)}>
                   Share Group
                 </Button>
               </article>
@@ -75,6 +87,14 @@ const CustomGroupDetailView: React.FC = () => {
             </div>
           </TabsContent>
         </Tabs>
+
+        <ShareGroupModal
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+          staff={staff}
+          excludeStaffIds={excludeStaffIds}
+          onShare={handleShare}
+        />
       </div>
     </div>
   );

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { useLoaderData } from 'react-router';
+import { Link, useLoaderData } from 'react-router';
 
 import { fetchCustomGroupDetail } from '~/api/client';
 import type { PGApiCustomGroupDetail } from '~/api/types';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
+import { StudentsByClassList } from '~/components/groups/StudentsByClassList';
+import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
+import { formatDate } from '~/helpers/dateTime';
 
 export async function loader({
   params,
@@ -32,10 +34,45 @@ const CustomGroupDetailView: React.FC = () => {
             <TabsTrigger value="details">Details</TabsTrigger>
           </TabsList>
           <TabsContent value="students" className="mt-4">
-            {/* Task 4 */}
+            <StudentsByClassList students={data.students} />
           </TabsContent>
-          <TabsContent value="details" className="mt-4">
-            {/* Task 5 */}
+          <TabsContent value="details" className="mt-4 space-y-6">
+            <p className="text-sm text-muted-foreground">
+              Created on {formatDate(data.createdAt)} by {data.createdByName}.
+            </p>
+            {data.sharedWith.length > 0 ? (
+              <div className="text-sm">
+                <span className="font-medium">Group shared with:</span>{' '}
+                {data.sharedWith.map((s) => s.staffName).join(', ')}
+              </div>
+            ) : null}
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <article className="rounded-md border p-4">
+                <h3 className="font-semibold">Edit this custom group</h3>
+                <Button asChild variant="outline" className="mt-3">
+                  <Link to={`/groups/customGroups/${data.customGroupId}/edit`}>Edit Group</Link>
+                </Button>
+              </article>
+              <article className="rounded-md border p-4">
+                <h3 className="font-semibold">Share this custom group</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  You will be granting access to edit this group. Please be certain.
+                </p>
+                <Button variant="outline" className="mt-3" disabled>
+                  Share Group
+                </Button>
+              </article>
+              <article className="rounded-md border p-4">
+                <h3 className="font-semibold">Delete this custom group</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Once you delete this custom group, you can never get it back again.
+                </p>
+                <Button variant="outline" className="mt-3" disabled>
+                  Delete Forever
+                </Button>
+              </article>
+            </div>
           </TabsContent>
         </Tabs>
       </div>

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -25,8 +25,6 @@ const CustomGroupDetailView: React.FC = () => {
   const revalidator = useRevalidator();
   const [shareOpen, setShareOpen] = useState(false);
 
-  const excludeStaffIds = [data.createdBy, ...data.sharedWith.map((s) => s.staffId)];
-
   async function handleShare(staffIds: number[]) {
     await shareCustomGroup(data.customGroupId, staffIds);
     revalidator.revalidate();
@@ -92,7 +90,8 @@ const CustomGroupDetailView: React.FC = () => {
           open={shareOpen}
           onClose={() => setShareOpen(false)}
           staff={staff}
-          excludeStaffIds={excludeStaffIds}
+          creatorStaffId={data.createdBy}
+          alreadySharedStaffIds={data.sharedWith.map((s) => s.staffId)}
           onShare={handleShare}
         />
       </div>

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { useLoaderData } from 'react-router';
+
+import { fetchCustomGroupDetail } from '~/api/client';
+import type { PGApiCustomGroupDetail } from '~/api/types';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
+
+export async function loader({
+  params,
+}: {
+  params: { id?: string };
+}): Promise<PGApiCustomGroupDetail> {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) throw new Response('Invalid group id', { status: 400 });
+  return fetchCustomGroupDetail(id);
+}
+
+const CustomGroupDetailView: React.FC = () => {
+  const data = useLoaderData() as PGApiCustomGroupDetail;
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-4xl">
+        <header>
+          <p className="text-xs tracking-wide text-muted-foreground uppercase">Custom Group</p>
+          <h1 className="mt-1 text-2xl font-semibold">{data.name}</h1>
+        </header>
+
+        <Tabs defaultValue="students" className="mt-6">
+          <TabsList>
+            <TabsTrigger value="students">Students ({data.students.length})</TabsTrigger>
+            <TabsTrigger value="details">Details</TabsTrigger>
+          </TabsList>
+          <TabsContent value="students" className="mt-4">
+            {/* Task 4 */}
+          </TabsContent>
+          <TabsContent value="details" className="mt-4">
+            {/* Task 5 */}
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};
+
+export { CustomGroupDetailView as Component };

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeft } from 'lucide-react';
 import React, { useState } from 'react';
 import { Link, useLoaderData, useRevalidator } from 'react-router';
 
@@ -33,9 +34,21 @@ const CustomGroupDetailView: React.FC = () => {
   return (
     <div className="flex justify-center px-6 py-6">
       <div className="w-full max-w-4xl">
-        <header>
-          <p className="text-xs tracking-wide text-muted-foreground uppercase">Custom Group</p>
-          <h1 className="mt-1 text-2xl font-semibold">{data.name}</h1>
+        <header className="flex items-start gap-3">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            render={<Link to="/groups" />}
+            nativeButton={false}
+            aria-label="Back to Groups"
+            className="mt-1"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <p className="text-xs tracking-wide text-muted-foreground uppercase">Custom Group</p>
+            <h1 className="mt-1 text-2xl font-semibold">{data.name}</h1>
+          </div>
         </header>
 
         <Tabs defaultValue="students" className="mt-6">

--- a/web/containers/EditCustomGroupView.test.tsx
+++ b/web/containers/EditCustomGroupView.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PGApiCustomGroupDetail } from '~/api/types';
+
+import { Component as EditCustomGroupView } from './EditCustomGroupView';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    updateCustomGroup: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const detail: PGApiCustomGroupDetail = {
+  customGroupId: 5,
+  name: 'Olympiad Study Group',
+  createdBy: 1013,
+  createdByName: 'TAN GUANG SHIN',
+  isShared: false,
+  sharedWith: [],
+  students: [
+    {
+      studentId: 1,
+      studentName: 'TAN XIAO MING',
+      className: 'H6 KINDNESS',
+      indexNumber: 15,
+      uinFinNo: 'S9000001A',
+      ccas: ['BOXING'],
+    },
+  ],
+  createdAt: '2026-03-01T08:00:00.000Z',
+};
+
+function renderAt() {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups/customGroups/:id/edit',
+        Component: EditCustomGroupView,
+        loader: () => detail,
+      },
+      { path: '/groups/customGroups/:id', element: <div>detail page</div> },
+    ],
+    { initialEntries: ['/groups/customGroups/5/edit'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('EditCustomGroupView', () => {
+  it('renders the page heading "Edit group"', async () => {
+    renderAt();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /edit group/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('seeds the title input from the loaded detail', async () => {
+    renderAt();
+    const input = (await screen.findByLabelText(/title/i)) as HTMLInputElement;
+    expect(input.value).toBe('Olympiad Study Group');
+  });
+
+  it('shows the existing students count and names', async () => {
+    renderAt();
+    expect(await screen.findByText(/1 student added/i)).toBeInTheDocument();
+    expect(screen.getByText('TAN XIAO MING')).toBeInTheDocument();
+  });
+
+  it('clicking Save calls updateCustomGroup and navigates to the detail page', async () => {
+    const { updateCustomGroup } = await import('~/api/client');
+    renderAt();
+    fireEvent.change(await screen.findByLabelText(/title/i), {
+      target: { value: 'Olympiad Squad' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await screen.findByText('detail page');
+    expect(updateCustomGroup).toHaveBeenCalledWith(5, {
+      name: 'Olympiad Squad',
+      studentIds: [1],
+    });
+  });
+});

--- a/web/containers/EditCustomGroupView.tsx
+++ b/web/containers/EditCustomGroupView.tsx
@@ -1,0 +1,154 @@
+import { Plus } from 'lucide-react';
+import React, { useState } from 'react';
+import { Link, useLoaderData, useLocation, useNavigate, useParams } from 'react-router';
+
+import { fetchCustomGroupDetail, updateCustomGroup } from '~/api/client';
+import type { PGApiCustomGroupDetail, PGApiSchoolStudent } from '~/api/types';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Input,
+} from '~/components/ui';
+import { notify } from '~/lib/notify';
+
+const TITLE_MAX = 120;
+
+export async function loader({
+  params,
+}: {
+  params: { id?: string };
+}): Promise<PGApiCustomGroupDetail> {
+  const id = Number(params.id);
+  if (!Number.isFinite(id)) throw new Response('Invalid group id', { status: 400 });
+  return fetchCustomGroupDetail(id);
+}
+
+interface IncomingNavState {
+  addedStudents?: PGApiSchoolStudent[];
+}
+
+interface DisplayStudent {
+  studentId: number;
+  studentName: string;
+  className: string;
+}
+
+const EditCustomGroupView: React.FC = () => {
+  const detail = useLoaderData() as PGApiCustomGroupDetail;
+  const params = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const groupId = Number(params.id);
+
+  const navState = (location.state as IncomingNavState | null) ?? {};
+  const initialStudents: DisplayStudent[] = navState.addedStudents
+    ? navState.addedStudents.map((s) => ({
+        studentId: s.studentId,
+        studentName: s.studentName,
+        className: s.className,
+      }))
+    : detail.students.map((s) => ({
+        studentId: s.studentId,
+        studentName: s.studentName,
+        className: s.className,
+      }));
+
+  const [title, setTitle] = useState(detail.name);
+  const [students] = useState<DisplayStudent[]>(initialStudents);
+  const [submitting, setSubmitting] = useState(false);
+
+  const studentCount = students.length;
+  const dirty = title.trim() !== detail.name || navState.addedStudents !== undefined;
+  const canSave = title.trim().length > 0 && studentCount > 0 && dirty;
+
+  async function handleSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    try {
+      await updateCustomGroup(groupId, {
+        name: title.trim(),
+        studentIds: students.map((s) => s.studentId),
+      });
+      navigate(`/groups/customGroups/${groupId}`);
+    } catch (err) {
+      setSubmitting(false);
+      if (!(err instanceof Error)) throw err;
+      notify.error('Could not save the group. Please try again.');
+    }
+  }
+
+  return (
+    <div className="flex justify-center px-6 py-6">
+      <div className="w-full max-w-2xl">
+        <h1 className="text-2xl font-semibold">Edit group</h1>
+        <div className="mt-6">
+          <label htmlFor="group-title" className="text-sm font-medium">
+            Title<span className="text-destructive">*</span>
+          </label>
+          <Input
+            id="group-title"
+            value={title}
+            maxLength={TITLE_MAX}
+            onChange={(e) => setTitle(e.target.value.slice(0, TITLE_MAX))}
+            className="mt-1"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            {TITLE_MAX - title.length} characters left
+          </p>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium">
+                {studentCount} student{studentCount === 1 ? '' : 's'} added.
+              </p>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline">
+                    <Plus className="size-4" aria-hidden />
+                    Add Students
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to={`/groups/customGroups/${groupId}/edit/addStudents`}
+                      state={{ alreadyAdded: students.map((s) => s.studentId) }}
+                    >
+                      Add manually
+                    </Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <ul className="mt-2 divide-y rounded-md border">
+              {students.map((s) => (
+                <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
+                  <span>{s.studentName}</span>
+                  <span className="text-xs text-muted-foreground">{s.className}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div className="mt-8 flex items-center justify-end gap-3">
+            <Link
+              to={`/groups/customGroups/${groupId}`}
+              className="text-sm font-medium text-muted-foreground hover:underline"
+            >
+              Cancel
+            </Link>
+            <Button disabled={!canSave || submitting} onClick={handleSave}>
+              {submitting ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export { EditCustomGroupView as Component };

--- a/web/containers/GroupsView.test.tsx
+++ b/web/containers/GroupsView.test.tsx
@@ -29,6 +29,12 @@ describe('GroupsView', () => {
     expect(await screen.findByRole('heading', { level: 1, name: /groups/i })).toBeInTheDocument();
   });
 
+  it('shows a "Create custom group" CTA that links to /groups/customGroups/new', async () => {
+    renderAt();
+    const cta = await screen.findByRole('link', { name: /create custom group/i });
+    expect(cta).toHaveAttribute('href', '/groups/customGroups/new');
+  });
+
   it('renders the assigned-groups section above the custom-groups section', async () => {
     const router = createMemoryRouter(
       [

--- a/web/containers/GroupsView.test.tsx
+++ b/web/containers/GroupsView.test.tsx
@@ -18,6 +18,11 @@ function renderAt(path = '/groups') {
   return render(<RouterProvider router={router} />);
 }
 
+// The sidebar nav entry added to `RootLayout` (Task 2 of the plan) is not
+// covered by a unit test here: rendering the real `RootLayout` or even
+// `SidebarItem` in isolation pulls `@flow/icons` v0.1.0, whose ESM bundle
+// uses an unresolvable directory import. The wire-up is exercised by the
+// manual smoke test (Task 14 of the plan).
 describe('GroupsView', () => {
   it('renders the page heading', async () => {
     renderAt();

--- a/web/containers/GroupsView.test.tsx
+++ b/web/containers/GroupsView.test.tsx
@@ -29,6 +29,36 @@ describe('GroupsView', () => {
     expect(await screen.findByRole('heading', { level: 1, name: /groups/i })).toBeInTheDocument();
   });
 
+  it('renders the assigned-groups section above the custom-groups section', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/groups',
+          Component: GroupsView,
+          loader: () => ({
+            customGroups: [],
+            assigned: {
+              classes: [
+                {
+                  classId: 1005,
+                  className: 'P1 KINDNESS',
+                  level: 'P1',
+                  year: 2026,
+                  role: 'FT',
+                  studentCount: 30,
+                },
+              ],
+              ccaGroups: [],
+            },
+          }),
+        },
+      ],
+      { initialEntries: ['/groups'] },
+    );
+    render(<RouterProvider router={router} />);
+    expect(await screen.findByText('P1 KINDNESS')).toBeInTheDocument();
+  });
+
   it('renders the custom-groups table populated from the loader', async () => {
     const router = createMemoryRouter(
       [

--- a/web/containers/GroupsView.test.tsx
+++ b/web/containers/GroupsView.test.tsx
@@ -28,4 +28,32 @@ describe('GroupsView', () => {
     renderAt();
     expect(await screen.findByRole('heading', { level: 1, name: /groups/i })).toBeInTheDocument();
   });
+
+  it('renders the custom-groups table populated from the loader', async () => {
+    const router = createMemoryRouter(
+      [
+        {
+          path: '/groups',
+          Component: GroupsView,
+          loader: () => ({
+            customGroups: [
+              {
+                customGroupId: 5,
+                name: 'Olympiad Study Group',
+                studentCount: 8,
+                createdBy: 1013,
+                createdByName: 'TAN GUANG SHIN',
+                isShared: false,
+                createdAt: '2026-03-01T08:00:00.000Z',
+              },
+            ],
+            assigned: { classes: [], ccaGroups: [] },
+          }),
+        },
+      ],
+      { initialEntries: ['/groups'] },
+    );
+    render(<RouterProvider router={router} />);
+    expect(await screen.findByText('Olympiad Study Group')).toBeInTheDocument();
+  });
 });

--- a/web/containers/GroupsView.test.tsx
+++ b/web/containers/GroupsView.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { Component as GroupsView } from './GroupsView';
+
+function renderAt(path = '/groups') {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/groups',
+        Component: GroupsView,
+        loader: () => ({ customGroups: [], assigned: { classes: [], ccaGroups: [] } }),
+      },
+    ],
+    { initialEntries: [path] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('GroupsView', () => {
+  it('renders the page heading', async () => {
+    renderAt();
+    expect(await screen.findByRole('heading', { level: 1, name: /groups/i })).toBeInTheDocument();
+  });
+});

--- a/web/containers/GroupsView.tsx
+++ b/web/containers/GroupsView.tsx
@@ -3,6 +3,7 @@ import { useLoaderData } from 'react-router';
 
 import { fetchCustomGroups, fetchGroupsAssigned } from '~/api/client';
 import type { PGApiCustomGroupSummary, PGApiGroupsAssigned } from '~/api/types';
+import { CustomGroupsTable } from '~/components/groups/CustomGroupsTable';
 
 interface GroupsLoaderData {
   customGroups: PGApiCustomGroupSummary[];
@@ -16,10 +17,20 @@ export async function loader(): Promise<GroupsLoaderData> {
 
 const GroupsView: React.FC = () => {
   const data = useLoaderData() as GroupsLoaderData;
-  void data;
   return (
     <div className="px-4 py-6 md:px-6">
       <h1 className="text-2xl font-semibold">Groups</h1>
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold">
+          Custom Groups{' '}
+          <span className="text-sm font-normal text-muted-foreground">
+            ({data.customGroups.length} created)
+          </span>
+        </h2>
+        <div className="mt-3">
+          <CustomGroupsTable groups={data.customGroups} />
+        </div>
+      </section>
     </div>
   );
 };

--- a/web/containers/GroupsView.tsx
+++ b/web/containers/GroupsView.tsx
@@ -1,10 +1,12 @@
+import { Plus } from 'lucide-react';
 import React from 'react';
-import { useLoaderData } from 'react-router';
+import { Link, useLoaderData } from 'react-router';
 
 import { fetchCustomGroups, fetchGroupsAssigned } from '~/api/client';
 import type { PGApiCustomGroupSummary, PGApiGroupsAssigned } from '~/api/types';
 import { AssignedGroupsSection } from '~/components/groups/AssignedGroupsSection';
 import { CustomGroupsTable } from '~/components/groups/CustomGroupsTable';
+import { Button } from '~/components/ui';
 
 interface GroupsLoaderData {
   customGroups: PGApiCustomGroupSummary[];
@@ -20,7 +22,15 @@ const GroupsView: React.FC = () => {
   const data = useLoaderData() as GroupsLoaderData;
   return (
     <div className="px-4 py-6 md:px-6">
-      <h1 className="text-2xl font-semibold">Groups</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Groups</h1>
+        <Button asChild>
+          <Link to="/groups/customGroups/new">
+            <Plus className="size-4" aria-hidden />
+            Create custom group
+          </Link>
+        </Button>
+      </div>
       <section className="mt-6">
         <h2 className="text-lg font-semibold">Assigned Groups</h2>
         <div className="mt-3">

--- a/web/containers/GroupsView.tsx
+++ b/web/containers/GroupsView.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useLoaderData } from 'react-router';
+
+import { fetchCustomGroups, fetchGroupsAssigned } from '~/api/client';
+import type { PGApiCustomGroupSummary, PGApiGroupsAssigned } from '~/api/types';
+
+interface GroupsLoaderData {
+  customGroups: PGApiCustomGroupSummary[];
+  assigned: PGApiGroupsAssigned;
+}
+
+export async function loader(): Promise<GroupsLoaderData> {
+  const [customList, assigned] = await Promise.all([fetchCustomGroups(), fetchGroupsAssigned()]);
+  return { customGroups: customList.customGroups, assigned };
+}
+
+const GroupsView: React.FC = () => {
+  const data = useLoaderData() as GroupsLoaderData;
+  void data;
+  return (
+    <div className="px-4 py-6 md:px-6">
+      <h1 className="text-2xl font-semibold">Groups</h1>
+    </div>
+  );
+};
+
+export { GroupsView as Component };

--- a/web/containers/GroupsView.tsx
+++ b/web/containers/GroupsView.tsx
@@ -3,6 +3,7 @@ import { useLoaderData } from 'react-router';
 
 import { fetchCustomGroups, fetchGroupsAssigned } from '~/api/client';
 import type { PGApiCustomGroupSummary, PGApiGroupsAssigned } from '~/api/types';
+import { AssignedGroupsSection } from '~/components/groups/AssignedGroupsSection';
 import { CustomGroupsTable } from '~/components/groups/CustomGroupsTable';
 
 interface GroupsLoaderData {
@@ -20,6 +21,12 @@ const GroupsView: React.FC = () => {
   return (
     <div className="px-4 py-6 md:px-6">
       <h1 className="text-2xl font-semibold">Groups</h1>
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Assigned Groups</h2>
+        <div className="mt-3">
+          <AssignedGroupsSection assigned={data.assigned} />
+        </div>
+      </section>
       <section className="mt-8">
         <h2 className="text-lg font-semibold">
           Custom Groups{' '}

--- a/web/containers/RootLayout.tsx
+++ b/web/containers/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { TooltipProvider } from '@flow/core';
-import { HelpCircle, Home, Mail, UsersRound } from '@flow/icons';
+import { FolderKanban, HelpCircle, Home, Mail, UsersRound } from '@flow/icons';
 import React, { useMemo, useRef } from 'react';
 import { Outlet, useLocation } from 'react-router';
 
@@ -27,6 +27,7 @@ const RootLayout: React.FC = () => {
     switch (segment) {
       case 'students':
       case 'posts':
+      case 'groups':
         return segment;
       default:
         return '/';
@@ -61,6 +62,13 @@ const RootLayout: React.FC = () => {
                 tooltip="Posts"
                 to="/posts"
                 selected={selected === 'posts'}
+              />
+              <SidebarItem
+                icon={FolderKanban}
+                label="Groups"
+                tooltip="Groups"
+                to="/groups"
+                selected={selected === 'groups'}
               />
             </SidebarContent>
 


### PR DESCRIPTION
## Summary
- **PGTW-13a**: Groups module shell — sidebar nav, overview page with custom groups table + assigned groups cards, create-empty page with title input and student placeholder
- **PGTW-13b**: Add-students subpage — manual student selection with search, Level, and Form Class filters
- **PGTW-13c**: Detail page (Students tab with class-grouped table, Details tab with edit/share/delete cards), edit page reusing AddStudentsView
- **PGTW-14**: Share custom group modal with staff picker, pre-selected already-shared staff, permissions list
- Polish: back-navigation button on detail header, real error messages in share modal, StudentsByClassList upgraded to table with Index + CCA columns, viewport-fit fixes

## Test plan
- [x] `StudentsByClassList` unit tests pass (3/3)
- [x] Lint clean (oxlint 0 warnings, 0 errors)
- [ ] Manual: create a custom group → add students → save → verify detail page shows students grouped by class
- [ ] Manual: share group with another staff → verify pre-selection on reopen
- [ ] Manual: edit group → verify existing students pre-selected
- [ ] Manual: back button on detail page navigates to /groups

> **Note:** 2 pre-existing test failures in `CreatePostView.validation.test.tsx` — unrelated to groups work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)