### PR TITLE
fix(groups): share field name, UIN masking, dirty check

### DIFF
--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -850,6 +850,10 @@ export async function fetchCustomGroupDetail(id: number): Promise<PGApiCustomGro
   if (!item) {
     throw new Response('Group not found', { status: 404 });
   }
+  if (Array.isArray(raw) && raw.length > 1) {
+    // eslint-disable-next-line no-console -- intentional diagnostic for unexpected PGW shape
+    console.warn('fetchCustomGroupDetail: expected 1 element, got %d', raw.length);
+  }
   return mapPgwCustomGroupDetail(item);
 }
 
@@ -880,7 +884,7 @@ export async function updateCustomGroup(
 
 export async function shareCustomGroup(id: number, staffIds: number[]): Promise<void> {
   await mutateApi<void>('PUT', `/groups/custom/${id}/share`, {
-    selectedStaff: staffIds,
+    staffIds,
   });
 }
 

--- a/web/components/groups/StudentResultsTable.test.tsx
+++ b/web/components/groups/StudentResultsTable.test.tsx
@@ -40,7 +40,7 @@ describe('StudentResultsTable', () => {
       />,
     );
     expect(screen.getByText('ALDDIN ANG MO KIO')).toBeInTheDocument();
-    expect(screen.getByText(/S9000003A/i)).toBeInTheDocument();
+    expect(screen.getByText(/S\*{5}03A/)).toBeInTheDocument();
     expect(screen.getByText(/H6 KINDNESS/i)).toBeInTheDocument();
   });
 

--- a/web/components/groups/StudentResultsTable.tsx
+++ b/web/components/groups/StudentResultsTable.tsx
@@ -63,7 +63,11 @@ export const StudentResultsTable: React.FC<StudentResultsTableProps> = ({
               </TableCell>
               <TableCell>
                 <div className="font-medium">{s.studentName}</div>
-                <div className="text-xs text-muted-foreground">{s.uinFinNo}</div>
+                <div className="text-xs text-muted-foreground">
+                  {s.uinFinNo
+                    ? `${s.uinFinNo.slice(0, 1)}${'*'.repeat(Math.max(0, s.uinFinNo.length - 4))}${s.uinFinNo.slice(-3)}`
+                    : ''}
+                </div>
               </TableCell>
               <TableCell>
                 <div>{s.className}</div>

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -8,6 +8,7 @@ import { ShareGroupModal } from '~/components/groups/ShareGroupModal';
 import { StudentsByClassList } from '~/components/groups/StudentsByClassList';
 import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
 import { formatDate } from '~/helpers/dateTime';
+import { notify } from '~/lib/notify';
 
 interface LoaderData {
   detail: PGApiCustomGroupDetail;
@@ -28,7 +29,11 @@ const CustomGroupDetailView: React.FC = () => {
 
   async function handleShare(staffIds: number[]) {
     await shareCustomGroup(data.customGroupId, staffIds);
-    revalidator.revalidate();
+    try {
+      revalidator.revalidate();
+    } catch {
+      notify.error('Shared successfully, but could not refresh the page. Please reload.');
+    }
   }
 
   return (

--- a/web/containers/EditCustomGroupView.tsx
+++ b/web/containers/EditCustomGroupView.tsx
@@ -61,7 +61,11 @@ const EditCustomGroupView: React.FC = () => {
   const [submitting, setSubmitting] = useState(false);
 
   const studentCount = students.length;
-  const dirty = title.trim() !== detail.name || navState.addedStudents !== undefined;
+  const originalIds = detail.students.map((s) => s.studentId).sort((a, b) => a - b);
+  const currentIds = students.map((s) => s.studentId).sort((a, b) => a - b);
+  const studentsChanged =
+    originalIds.length !== currentIds.length || originalIds.some((id, i) => id !== currentIds[i]);
+  const dirty = title.trim() !== detail.name || studentsChanged;
   const canSave = title.trim().length > 0 && studentCount > 0 && dirty;
 
   async function handleSave() {


### PR DESCRIPTION
## Summary
Post-merge review fixes for PR #23:

- **Blocking**: `shareCustomGroup` was sending `selectedStaff` but PGW contract expects `staffIds` — share was silently broken
- **PII**: mask UIN/FIN (NRIC) in `StudentResultsTable` student picker (`S9000003A` → `S*****03A`)
- **Robustness**: catch `revalidate()` throw in detail view so a refresh failure doesn't unmount the page; replace coarse `navState.addedStudents !== undefined` dirty check with actual student-ID comparison in edit view
- **Diagnostic**: warn when `fetchCustomGroupDetail` receives unexpected multi-element array

## Test plan
- [x] All 31 groups tests pass
- [x] Lint clean (0 warnings, 0 errors)
- [ ] Manual: share a group → verify the PUT payload contains `staffIds` (not `selectedStaff`)
- [ ] Manual: open add-students page → verify UIN is masked (e.g. `S*****03A`)
- [ ] Manual: edit group → navigate to add-students → return with same students → verify Save stays disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)