### PR TITLE
feat(groups): PGTW-20a delete + remove access for custom groups

### DIFF
--- a/docs/superpowers/specs/2026-05-04-pgtw-20a-delete-custom-group-design.md
+++ b/docs/superpowers/specs/2026-05-04-pgtw-20a-delete-custom-group-design.md
@@ -1,0 +1,45 @@
+# PGTW-20a: Delete Custom Group — Design Spec
+
+## Goal
+
+Wire the "Delete Forever" button on the custom group detail page to a confirmation modal that deletes the group via PGW's existing endpoint, matching PGW spec §7.6.
+
+## PGW Parity Reference
+
+- **Spec:** §7.6 "Delete Custom Group Modal"
+- **API:** `DELETE /api/web/2/staff/groups/custom/:customGroupId` — no request body, 204 No Content, requires CSRF
+- **Mock:** already stubbed in `server/internal/pg/mock.go` (line 279)
+
+## Modal UX (matching PGW §7.6)
+
+- **Title:** "Delete custom group?"
+- **Body:** `Are you sure you want to delete "[Group Name]"?`
+- **Checkbox (required):** "I understand that this action cannot be undone. This will permanently delete the custom group as I am the only staff with access to the group."
+- **Button:** "Delete" (disabled until checkbox ticked)
+- **No Cancel button** — only the X close icon on the dialog, matching PGW
+- **Submitting state:** button shows "Deleting…" and is disabled
+
+## Behaviour
+
+1. User clicks "Delete Forever" on the detail page's Details tab
+2. Confirmation dialog opens
+3. User ticks the acknowledgement checkbox
+4. User clicks "Delete"
+5. `DELETE /api/web/2/staff/groups/custom/:id` fires
+6. **Success:** navigate to `/groups`, show success toast "Custom group deleted."
+7. **Error:** show PGW's error message in a toast, dialog stays open, checkbox + button reset
+
+## Files
+
+| Action | Path                                                                   |
+| ------ | ---------------------------------------------------------------------- |
+| Create | `web/components/groups/DeleteGroupModal.tsx`                           |
+| Modify | `web/containers/CustomGroupDetailView.tsx` — wire button state + modal |
+| Modify | `web/api/client.ts` — add `deleteCustomGroup(id: number)`              |
+| Create | `web/components/groups/DeleteGroupModal.test.tsx`                      |
+
+## Out of Scope
+
+- Kebab menu delete action on overview rows (broader PGTW-20 scope)
+- Multi-select batch delete (deferred pending PG team confirmation)
+- Cascade behaviour when group is referenced by posts (open question for PG team)

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -884,8 +884,12 @@ export async function updateCustomGroup(
 
 export async function shareCustomGroup(id: number, staffIds: number[]): Promise<void> {
   await mutateApi<void>('PUT', `/groups/custom/${id}/share`, {
-    staffIds,
+    selectedStaff: staffIds,
   });
+}
+
+export async function removeAccessFromCustomGroup(id: number): Promise<void> {
+  await mutateApi<void>('PUT', `/groups/custom/${id}/removeAccess`, {});
 }
 
 export function deleteCustomGroup(id: number) {

--- a/web/api/client.ts
+++ b/web/api/client.ts
@@ -888,6 +888,10 @@ export async function shareCustomGroup(id: number, staffIds: number[]): Promise<
   });
 }
 
+export function deleteCustomGroup(id: number) {
+  return deleteApi(`/groups/custom/${id}`);
+}
+
 export function fetchClassDetail(classId: number) {
   return fetchApi<PGApiClassDetail>(`/groups/classes/${classId}`);
 }

--- a/web/components/groups/DeleteGroupModal.test.tsx
+++ b/web/components/groups/DeleteGroupModal.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DeleteGroupModal } from './DeleteGroupModal';
+
+function renderModal(onDelete = vi.fn().mockResolvedValue(undefined)) {
+  const onClose = vi.fn();
+  render(
+    <DeleteGroupModal
+      open={true}
+      onClose={onClose}
+      groupName="Olympiad Study Group"
+      onDelete={onDelete}
+    />,
+  );
+  return { onDelete, onClose };
+}
+
+describe('DeleteGroupModal', () => {
+  it('renders the dialog title and group name', () => {
+    renderModal();
+    expect(screen.getByRole('heading', { name: 'Delete custom group?' })).toBeInTheDocument();
+    expect(screen.getByText(/Olympiad Study Group/)).toBeInTheDocument();
+  });
+
+  it('renders the acknowledgement checkbox unchecked by default', () => {
+    renderModal();
+    expect(screen.getByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('renders the Delete button disabled until checkbox is ticked', () => {
+    renderModal();
+    const deleteBtn = screen.getByRole('button', { name: /delete/i });
+    expect(deleteBtn).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(deleteBtn).toBeEnabled();
+  });
+
+  it('calls onDelete when checkbox is ticked and Delete is clicked', async () => {
+    const { onDelete } = renderModal();
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+});

--- a/web/components/groups/DeleteGroupModal.tsx
+++ b/web/components/groups/DeleteGroupModal.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '~/components/ui';
+import { notify } from '~/lib/notify';
 
 interface DeleteGroupModalProps {
   open: boolean;
@@ -31,9 +32,7 @@ export const DeleteGroupModal: React.FC<DeleteGroupModalProps> = ({
         if (!nextOpen) onClose();
       }}
     >
-      {open && (
-        <DeleteGroupModalContent groupName={groupName} onDelete={onDelete} onClose={onClose} />
-      )}
+      {open && <DeleteGroupModalContent groupName={groupName} onDelete={onDelete} />}
     </Dialog>
   );
 };
@@ -41,8 +40,7 @@ export const DeleteGroupModal: React.FC<DeleteGroupModalProps> = ({
 const DeleteGroupModalContent: React.FC<{
   groupName: string;
   onDelete: () => Promise<void>;
-  onClose: () => void;
-}> = ({ groupName, onDelete, onClose }) => {
+}> = ({ groupName, onDelete }) => {
   const [confirmed, setConfirmed] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -51,8 +49,9 @@ const DeleteGroupModalContent: React.FC<{
     setDeleting(true);
     try {
       await onDelete();
-      onClose();
-    } catch {
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not delete the group.';
+      notify.error(msg);
       setDeleting(false);
     }
   }

--- a/web/components/groups/DeleteGroupModal.tsx
+++ b/web/components/groups/DeleteGroupModal.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react';
+
+import {
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/ui';
+
+interface DeleteGroupModalProps {
+  open: boolean;
+  onClose: () => void;
+  groupName: string;
+  onDelete: () => Promise<void>;
+}
+
+export const DeleteGroupModal: React.FC<DeleteGroupModalProps> = ({
+  open,
+  onClose,
+  groupName,
+  onDelete,
+}) => {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      {open && (
+        <DeleteGroupModalContent groupName={groupName} onDelete={onDelete} onClose={onClose} />
+      )}
+    </Dialog>
+  );
+};
+
+const DeleteGroupModalContent: React.FC<{
+  groupName: string;
+  onDelete: () => Promise<void>;
+  onClose: () => void;
+}> = ({ groupName, onDelete, onClose }) => {
+  const [confirmed, setConfirmed] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  async function handleDelete() {
+    if (!confirmed) return;
+    setDeleting(true);
+    try {
+      await onDelete();
+      onClose();
+    } catch {
+      setDeleting(false);
+    }
+  }
+
+  return (
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Delete custom group?</DialogTitle>
+        <DialogDescription>
+          Are you sure you want to delete &ldquo;{groupName}&rdquo;?
+        </DialogDescription>
+      </DialogHeader>
+
+      <label className="flex items-start gap-3 py-2">
+        <Checkbox
+          checked={confirmed}
+          onCheckedChange={(val) => setConfirmed(val === true)}
+          className="mt-0.5"
+        />
+        <span className="text-sm">
+          I understand that this action cannot be undone. This will permanently delete the custom
+          group as I am the only staff with access to the group.
+        </span>
+      </label>
+
+      <DialogFooter>
+        <Button variant="destructive" disabled={!confirmed || deleting} onClick={handleDelete}>
+          {deleting ? 'Deleting…' : 'Delete'}
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  );
+};

--- a/web/components/groups/ShareGroupModal.test.tsx
+++ b/web/components/groups/ShareGroupModal.test.tsx
@@ -63,4 +63,9 @@ describe('ShareGroupModal', () => {
     renderModal();
     expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
   });
+
+  it('renders the button disabled even when staff are already shared', () => {
+    renderModal(vi.fn().mockResolvedValue(undefined), [1002]);
+    expect(screen.getByRole('button', { name: /share group/i })).toBeDisabled();
+  });
 });

--- a/web/components/groups/ShareGroupModal.tsx
+++ b/web/components/groups/ShareGroupModal.tsx
@@ -64,29 +64,11 @@ const ShareGroupModalContent: React.FC<{
   const alreadySharedSet = useMemo(() => new Set(alreadySharedStaffIds), [alreadySharedStaffIds]);
 
   const pickerStaff = useMemo(
-    () => staff.filter((s) => s.staffId !== creatorStaffId),
-    [staff, creatorStaffId],
+    () => staff.filter((s) => s.staffId !== creatorStaffId && !alreadySharedSet.has(s.staffId)),
+    [staff, creatorStaffId, alreadySharedSet],
   );
 
-  const initialSelected = useMemo<SelectedStaff[]>(
-    () =>
-      staff
-        .filter((s) => alreadySharedSet.has(s.staffId))
-        .map((s) => ({
-          id: s.staffId.toString(),
-          label: s.name,
-          type: 'individual' as const,
-          count: 1,
-        })),
-    [staff, alreadySharedSet],
-  );
-
-  const [selected, setSelected] = useState<SelectedStaff[]>(initialSelected);
-
-  const newStaffIds = useMemo(
-    () => selected.map((s) => Number(s.id)).filter((id) => !alreadySharedSet.has(id)),
-    [selected, alreadySharedSet],
-  );
+  const [selected, setSelected] = useState<SelectedStaff[]>([]);
 
   useEffect(() => {
     const id = requestAnimationFrame(() => setSelectorReady(true));
@@ -94,10 +76,10 @@ const ShareGroupModalContent: React.FC<{
   }, []);
 
   async function handleShare() {
-    if (newStaffIds.length === 0) return;
+    if (selected.length === 0) return;
     setSubmitting(true);
     try {
-      await onShare(newStaffIds);
+      await onShare(selected.map((s) => Number(s.id)));
       onClose();
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Could not share the group.';
@@ -130,7 +112,7 @@ const ShareGroupModalContent: React.FC<{
       </div>
 
       <DialogFooter>
-        <Button disabled={newStaffIds.length === 0 || submitting} onClick={handleShare}>
+        <Button disabled={selected.length === 0 || submitting} onClick={handleShare}>
           {submitting ? 'Sharing…' : 'Share group'}
         </Button>
       </DialogFooter>

--- a/web/containers/CustomGroupDetailView.test.tsx
+++ b/web/containers/CustomGroupDetailView.test.tsx
@@ -105,7 +105,7 @@ describe('CustomGroupDetailView', () => {
       '/groups/customGroups/5/edit',
     );
     expect(screen.getByRole('button', { name: /share group/i })).toBeEnabled();
-    expect(screen.getByRole('button', { name: /delete forever/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /delete forever/i })).toBeEnabled();
   });
 
   it('renders shared-with names when group is shared', async () => {

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -42,21 +42,19 @@ const CustomGroupDetailView: React.FC = () => {
     navigate('/groups');
   }
 
-  async function handleShare(desiredStaffIds: number[]) {
-    const previousIds = new Set(data.sharedWith.map((s) => s.staffId));
-    const desiredIds = new Set(desiredStaffIds);
-
-    const added = desiredStaffIds.filter((id) => !previousIds.has(id));
-    const removed = data.sharedWith.map((s) => s.staffId).filter((id) => !desiredIds.has(id));
-
-    if (added.length > 0) await shareCustomGroup(data.customGroupId, added);
-    await Promise.all(removed.map((id) => removeAccessFromCustomGroup(data.customGroupId, id)));
-
+  async function handleShare(staffIds: number[]) {
+    await shareCustomGroup(data.customGroupId, staffIds);
     try {
       revalidator.revalidate();
     } catch {
-      notify.error('Updated successfully, but could not refresh the page. Please reload.');
+      notify.error('Shared successfully, but could not refresh the page. Please reload.');
     }
+  }
+
+  async function handleRemoveAccess() {
+    await removeAccessFromCustomGroup(data.customGroupId);
+    notify.success('Access removed.');
+    navigate('/groups');
   }
 
   return (
@@ -130,7 +128,7 @@ const CustomGroupDetailView: React.FC = () => {
                   <p className="mt-1 text-xs text-muted-foreground">
                     You will lose access to this shared group. Other staff will still retain access.
                   </p>
-                  <Button variant="outline" className="mt-3" disabled>
+                  <Button variant="outline" className="mt-3" onClick={handleRemoveAccess}>
                     Remove Access
                   </Button>
                 </article>

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -1,9 +1,15 @@
 import { ArrowLeft } from 'lucide-react';
 import React, { useState } from 'react';
-import { Link, useLoaderData, useRevalidator } from 'react-router';
+import { Link, useLoaderData, useNavigate, useRevalidator } from 'react-router';
 
-import { fetchCustomGroupDetail, fetchSchoolStaff, shareCustomGroup } from '~/api/client';
+import {
+  deleteCustomGroup,
+  fetchCustomGroupDetail,
+  fetchSchoolStaff,
+  shareCustomGroup,
+} from '~/api/client';
 import type { PGApiCustomGroupDetail, PGApiSchoolStaff } from '~/api/types';
+import { DeleteGroupModal } from '~/components/groups/DeleteGroupModal';
 import { ShareGroupModal } from '~/components/groups/ShareGroupModal';
 import { StudentsByClassList } from '~/components/groups/StudentsByClassList';
 import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui';
@@ -24,8 +30,16 @@ export async function loader({ params }: { params: { id?: string } }): Promise<L
 
 const CustomGroupDetailView: React.FC = () => {
   const { detail: data, staff } = useLoaderData() as LoaderData;
+  const navigate = useNavigate();
   const revalidator = useRevalidator();
   const [shareOpen, setShareOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  async function handleDelete() {
+    await deleteCustomGroup(data.customGroupId);
+    notify.success('Custom group deleted.');
+    navigate('/groups');
+  }
 
   async function handleShare(staffIds: number[]) {
     await shareCustomGroup(data.customGroupId, staffIds);
@@ -96,13 +110,20 @@ const CustomGroupDetailView: React.FC = () => {
                 <p className="mt-1 text-xs text-muted-foreground">
                   Once you delete this custom group, you can never get it back again.
                 </p>
-                <Button variant="outline" className="mt-3" disabled>
+                <Button variant="outline" className="mt-3" onClick={() => setDeleteOpen(true)}>
                   Delete Forever
                 </Button>
               </article>
             </div>
           </TabsContent>
         </Tabs>
+
+        <DeleteGroupModal
+          open={deleteOpen}
+          onClose={() => setDeleteOpen(false)}
+          groupName={data.name}
+          onDelete={handleDelete}
+        />
 
         <ShareGroupModal
           open={shareOpen}

--- a/web/containers/CustomGroupDetailView.tsx
+++ b/web/containers/CustomGroupDetailView.tsx
@@ -6,6 +6,7 @@ import {
   deleteCustomGroup,
   fetchCustomGroupDetail,
   fetchSchoolStaff,
+  removeAccessFromCustomGroup,
   shareCustomGroup,
 } from '~/api/client';
 import type { PGApiCustomGroupDetail, PGApiSchoolStaff } from '~/api/types';
@@ -41,12 +42,20 @@ const CustomGroupDetailView: React.FC = () => {
     navigate('/groups');
   }
 
-  async function handleShare(staffIds: number[]) {
-    await shareCustomGroup(data.customGroupId, staffIds);
+  async function handleShare(desiredStaffIds: number[]) {
+    const previousIds = new Set(data.sharedWith.map((s) => s.staffId));
+    const desiredIds = new Set(desiredStaffIds);
+
+    const added = desiredStaffIds.filter((id) => !previousIds.has(id));
+    const removed = data.sharedWith.map((s) => s.staffId).filter((id) => !desiredIds.has(id));
+
+    if (added.length > 0) await shareCustomGroup(data.customGroupId, added);
+    await Promise.all(removed.map((id) => removeAccessFromCustomGroup(data.customGroupId, id)));
+
     try {
       revalidator.revalidate();
     } catch {
-      notify.error('Shared successfully, but could not refresh the page. Please reload.');
+      notify.error('Updated successfully, but could not refresh the page. Please reload.');
     }
   }
 
@@ -105,15 +114,27 @@ const CustomGroupDetailView: React.FC = () => {
                   Share Group
                 </Button>
               </article>
-              <article className="rounded-md border p-4">
-                <h3 className="font-semibold">Delete this custom group</h3>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Once you delete this custom group, you can never get it back again.
-                </p>
-                <Button variant="outline" className="mt-3" onClick={() => setDeleteOpen(true)}>
-                  Delete Forever
-                </Button>
-              </article>
+              {data.sharedWith.length === 0 ? (
+                <article className="rounded-md border p-4">
+                  <h3 className="font-semibold">Delete this custom group</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Once you delete this custom group, you can never get it back again.
+                  </p>
+                  <Button variant="outline" className="mt-3" onClick={() => setDeleteOpen(true)}>
+                    Delete Forever
+                  </Button>
+                </article>
+              ) : (
+                <article className="rounded-md border p-4">
+                  <h3 className="font-semibold">Remove access to this group</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    You will lose access to this shared group. Other staff will still retain access.
+                  </p>
+                  <Button variant="outline" className="mt-3" disabled>
+                    Remove Access
+                  </Button>
+                </article>
+              )}
             </div>
           </TabsContent>
         </Tabs>


### PR DESCRIPTION
## Summary
- **PGTW-20a**: Delete custom group — confirmation modal with required acknowledgement checkbox matching PGW §7.6
- Conditionally show "Delete Forever" (unshared groups) vs "Remove Access" (shared groups), matching PGW's `owners.length` check
- Add `removeAccessFromCustomGroup` API function + wire Remove Access button
- Simplify share modal: exclude already-shared staff from picker instead of pre-selecting
- Add back-navigation arrow to group detail page header
- Upgrade student list to table layout with Index + CCA columns
- Surface actual PGW error messages in share/delete toasts

## Test plan
- [ ] Unshared group: "Delete Forever" button visible → opens modal with checkbox → tick + Delete → navigates to `/groups`
- [ ] Shared group: shows "Remove Access" instead of "Delete Forever"
- [ ] Remove Access button navigates to `/groups` after success
- [ ] Share modal excludes already-shared staff from picker
- [ ] Back arrow navigates to `/groups`
- [ ] All tests pass (`pnpm vitest run web/components/groups/ web/containers/CustomGroupDetailView.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)