### PR TITLE
feat: show student name in post preview (#19)

### DIFF
--- a/web/components/posts/PostPreview.tsx
+++ b/web/components/posts/PostPreview.tsx
@@ -20,6 +20,8 @@ import { formatFileSize } from '~/helpers/attachments';
 import { formatDateTime, formatLocalDate, formatLocalDateTimeRange } from '~/helpers/dateTime';
 import { createRichTextExtensions, extractTextFromTiptap } from '~/helpers/tiptap';
 
+import { summariseRecipients } from './summarise-recipients';
+
 // Built once — `generateHTML` only reads the schema, so the extensions never
 // need a maxLength here (CharacterCount has no effect on static rendering).
 const RICH_TEXT_EXTENSIONS = createRichTextExtensions();
@@ -350,18 +352,6 @@ function PreviewPhoto({ photo, large = false }: { photo: UploadingFile; large?: 
       className={`rounded-lg object-cover ${large ? 'aspect-video w-full' : 'aspect-square w-full'}`}
     />
   );
-}
-
-/** Pick a single label to stand in for the per-parent child-name line.
- *  Prefers an individual-student selection; falls back to the first group's
- *  label. Returns null when nothing is selected so the placeholder shows. */
-function summariseRecipients(recipients: PostFormState['selectedRecipients']): string | null {
-  if (recipients.length === 0) return null;
-  const individual = recipients.find((r) => r.type === 'individual');
-  const primary = individual ?? recipients[0];
-  const extra = recipients.length - 1;
-  const base = primary.label.toUpperCase();
-  return extra > 0 ? `${base} · +${extra} more` : base;
 }
 
 export { PostPreview };

--- a/web/components/posts/summarise-recipients.test.ts
+++ b/web/components/posts/summarise-recipients.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { SelectedEntity } from '~/components/comms/entity-selector';
+
+import { summariseRecipients } from './summarise-recipients';
+
+const group = (overrides: Partial<SelectedEntity> = {}): SelectedEntity => ({
+  id: '101',
+  label: '4A (2026)',
+  type: 'group',
+  count: 30,
+  groupType: 'class',
+  memberNames: ['TAN XIAO MING', 'LEE WEI LING', 'KUMAR RAVI'],
+  ...overrides,
+});
+
+const individual = (overrides: Partial<SelectedEntity> = {}): SelectedEntity => ({
+  id: '501',
+  label: 'TAN XIAO MING',
+  type: 'individual',
+  count: 1,
+  ...overrides,
+});
+
+describe('summariseRecipients', () => {
+  it('returns null when no recipients are selected', () => {
+    expect(summariseRecipients([])).toBeNull();
+  });
+
+  it('returns the student name from a group memberNames', () => {
+    expect(summariseRecipients([group()])).toBe('TAN XIAO MING');
+  });
+
+  it('returns null when group has no memberNames', () => {
+    expect(summariseRecipients([group({ memberNames: undefined })])).toBeNull();
+  });
+
+  it('returns null when group has empty memberNames', () => {
+    expect(summariseRecipients([group({ memberNames: [] })])).toBeNull();
+  });
+
+  it('returns the individual label directly', () => {
+    expect(summariseRecipients([individual()])).toBe('TAN XIAO MING');
+  });
+
+  it('prefers individual over group', () => {
+    expect(summariseRecipients([group(), individual({ label: 'LEE AH KOW' })])).toBe('LEE AH KOW');
+  });
+
+  it('returns first group student name when multiple groups selected', () => {
+    expect(
+      summariseRecipients([
+        group(),
+        group({ id: '102', label: '4B (2026)', memberNames: ['WONG MEI LING'] }),
+      ]),
+    ).toBe('TAN XIAO MING');
+  });
+
+  it('uppercases the individual label', () => {
+    expect(summariseRecipients([individual({ label: 'tan xiao ming' })])).toBe('TAN XIAO MING');
+  });
+
+  it('falls back to null when groups exist but none have memberNames', () => {
+    expect(
+      summariseRecipients([
+        group({ memberNames: undefined }),
+        group({ id: '102', memberNames: [] }),
+      ]),
+    ).toBeNull();
+  });
+});

--- a/web/components/posts/summarise-recipients.ts
+++ b/web/components/posts/summarise-recipients.ts
@@ -1,0 +1,16 @@
+import type { SelectedEntity } from '~/components/comms/entity-selector';
+
+export function summariseRecipients(recipients: SelectedEntity[]): string | null {
+  if (recipients.length === 0) return null;
+
+  const individual = recipients.find((r) => r.type === 'individual');
+  if (individual) return individual.label.toUpperCase();
+
+  for (const r of recipients) {
+    if (r.memberNames && r.memberNames.length > 0) {
+      return r.memberNames[0].toUpperCase();
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Extract `summariseRecipients()` from `PostPreview.tsx` into its own testable module
- Rewrite it to resolve groups into a student name via `memberNames[0]` instead of showing the group label (e.g. "4A (2026) · +1 MORE")
- Prefers individual student selections; falls back to first group member; shows placeholder when no names available

Closes #19

## Test plan

- [ ] Select a class group with students (e.g. P1 HAPPINESS) → preview shows a student name
- [ ] Select an individual student → preview shows that student's name
- [ ] Select a group with 0 students → preview shows "STUDENT NAME" placeholder
- [ ] No recipients selected → preview shows muted "STUDENT NAME" placeholder
- [ ] `pnpm vitest run` — 9 new tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)