### PR TITLE
fix(web): enforce 40-char limit on website link description

### DIFF
--- a/web/components/posts/WebsiteLinksSection.tsx
+++ b/web/components/posts/WebsiteLinksSection.tsx
@@ -11,6 +11,7 @@ import { Button, Input, Label } from '~/components/ui';
  * into `webLinkList` for both kinds.
  */
 const MAX_WEBSITE_LINKS = 3;
+const MAX_LINK_DESCRIPTION_LENGTH = 40;
 
 export interface WebsiteLink {
   /** Raw URL the teacher typed. Forwarded verbatim into `webLink`. */
@@ -85,6 +86,7 @@ function WebsiteLinksSection({ value, dispatch }: WebsiteLinksSectionProps) {
                 <Input
                   id={`website-link-title-${index}`}
                   placeholder="Link description"
+                  maxLength={MAX_LINK_DESCRIPTION_LENGTH}
                   value={link.title}
                   onChange={(e) =>
                     dispatch({


### PR DESCRIPTION
## Summary
- Adds `maxLength={40}` to the link description input in `WebsiteLinksSection`, matching PG's enforced limit

Closes #22

## Test plan
- [ ] Create/edit a post, add a website link, confirm you cannot type more than 40 characters in the description field

🤖 Generated with [Claude Code](https://claude.com/claude-code)