### PR TITLE
fix(web): allow typing past 2000-char description limit

### DIFF
--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -1115,8 +1115,17 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   <Label id="post-description-label">
                     Description <span className="text-destructive">*</span>
                   </Label>
-                  <span className="text-xs text-muted-foreground tabular-nums">
-                    {state.description.length}/2000
+                  <span
+                    className={cn(
+                      'text-xs tabular-nums',
+                      state.description.length > 2000
+                        ? 'font-medium text-info-foreground'
+                        : 'text-muted-foreground',
+                    )}
+                  >
+                    {state.description.length > 2000
+                      ? `Exceeded by ${state.description.length - 2000} characters`
+                      : `${state.description.length}/2000`}
                   </span>
                 </div>
                 <RichTextEditor

--- a/web/containers/CreatePostView.validation.test.tsx
+++ b/web/containers/CreatePostView.validation.test.tsx
@@ -48,6 +48,16 @@ describe('isCreatePostFormValid — announcement', () => {
     expect(isCreatePostFormValid({ ...validBase, description: '' }, 'post')).toBe(false);
   });
 
+  it('fails when description exceeds 2000 characters', () => {
+    const longDesc = 'a'.repeat(2001);
+    expect(isCreatePostFormValid({ ...validBase, description: longDesc }, 'post')).toBe(false);
+  });
+
+  it('passes when description is exactly 2000 characters', () => {
+    const maxDesc = 'a'.repeat(2000);
+    expect(isCreatePostFormValid({ ...validBase, description: maxDesc }, 'post')).toBe(true);
+  });
+
   it('fails when enquiry email is empty', () => {
     expect(isCreatePostFormValid({ ...validBase, enquiryEmail: '' }, 'post')).toBe(false);
   });
@@ -62,7 +72,7 @@ describe('isCreatePostFormValid — post-with-response (form)', () => {
     ...validBase,
     kind: 'form',
     responseType: 'acknowledge',
-    dueDate: '2026-05-01',
+    dueDate: '2099-12-31',
   };
 
   it('passes with all required fields for acknowledge', () => {

--- a/web/containers/createPostValidation.ts
+++ b/web/containers/createPostValidation.ts
@@ -21,7 +21,8 @@ export function isCreatePostFormValid(
     state.title.trim().length > 0 &&
     state.enquiryEmail.trim().length > 0 &&
     state.selectedRecipients.length > 0 &&
-    state.description.trim().length > 0;
+    state.description.trim().length > 0 &&
+    state.description.length <= 2000;
 
   if (!baseValid) return false;
 

--- a/web/helpers/tiptap.ts
+++ b/web/helpers/tiptap.ts
@@ -44,7 +44,7 @@ export function createRichTextExtensions(opts?: { maxLength?: number }) {
       types: ['paragraph', 'orderedList', 'bulletList'],
       alignments: ['left', 'center', 'right', 'justify'],
     }),
-    ...(opts?.maxLength != null ? [CharacterCount.configure({ limit: opts.maxLength })] : []),
+    ...(opts?.maxLength != null ? [CharacterCount.configure({ limit: null })] : []),
   ];
 }
 


### PR DESCRIPTION
## Summary

Closes #21
Closes #20

- Removed hard character limit from Tiptap's `CharacterCount` extension so users can type past 2000 characters (matching PG behavior)
- Counter now shows "Exceeded by X characters" in blue when over 2000, instead of silently blocking input
- Added `description.length <= 2000` to form validation so Send/Schedule buttons are disabled while over the limit
- Fixes external paste (e.g. from ChatGPT) being silently rejected — the hard `limit` on `CharacterCount` was blocking the entire paste when content exceeded 2000 chars

## Test plan

- [ ] Create a post, type past 2000 characters in the Description field — typing is not blocked
- [ ] Counter switches from `N/2000` to `Exceeded by X characters` in blue once past 2000
- [ ] Send/Schedule buttons are disabled while description exceeds 2000 characters
- [ ] Delete text back under 2000 — counter reverts to `N/2000`, buttons re-enable
- [ ] Copy ~2118 chars from an external source (e.g. ChatGPT) and paste into Description — paste succeeds, shows "Exceeded by X characters"
- [ ] `pnpm test` passes (209 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)