### PR TITLE
feat(web): add Excel upload for custom groups (PGTW-13d)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-router": "^7.12.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
@@ -1850,6 +1853,10 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -1894,6 +1901,10 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1919,6 +1930,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -1935,6 +1950,11 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -2051,6 +2071,10 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   framer-motion@12.27.1:
     resolution: {integrity: sha512-cEAqO69kcZt3gL0TGua8WTgRQfv4J57nqt1zxHtLKwYhAwA0x9kDS/JbMa1hJbwkGY74AGJKvZ9pX/IqWZtZWQ==}
@@ -2520,6 +2544,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -2751,9 +2779,22 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -4312,6 +4353,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  adler-32@1.3.1: {}
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -4344,6 +4387,11 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@6.2.2: {}
 
   class-variance-authority@0.7.1:
@@ -4373,6 +4421,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   colorette@2.0.20: {}
 
   colorjs.io@0.6.1: {}
@@ -4382,6 +4432,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  crc-32@1.2.2: {}
 
   crelt@1.0.6: {}
 
@@ -4493,6 +4545,8 @@ snapshots:
   fflate@0.8.2: {}
 
   flatted@3.4.2: {}
+
+  frac@1.1.2: {}
 
   framer-motion@12.27.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -5004,6 +5058,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
@@ -5163,11 +5221,25 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-name-validator@5.0.0: {}
 

--- a/server/internal/pg/fixtures/validate_students_results.json
+++ b/server/internal/pg/fixtures/validate_students_results.json
@@ -1,0 +1,48 @@
+{
+  "status": "success",
+  "data": {
+    "validStudents": [
+      {
+        "pgStudentId": 1,
+        "studentId": "T0412345A",
+        "studentName": "TAN XIAO MING",
+        "className": "4A",
+        "classCode": "4A",
+        "levelCode": "SEC4",
+        "levelCodeDescription": "SECONDARY 4",
+        "indexNumber": "15",
+        "cca": [{ "ccaId": 1, "ccaDescription": "BOXING" }]
+      },
+      {
+        "pgStudentId": 2,
+        "studentId": "T0412346B",
+        "studentName": "LEE WEI LIANG",
+        "className": "4A",
+        "classCode": "4A",
+        "levelCode": "SEC4",
+        "levelCodeDescription": "SECONDARY 4",
+        "indexNumber": "8",
+        "cca": [{ "ccaId": 2, "ccaDescription": "CHOIR" }]
+      },
+      {
+        "pgStudentId": 3,
+        "studentId": "T0412347C",
+        "studentName": "CAROL CHEN HUI",
+        "className": "4A",
+        "classCode": "4A",
+        "levelCode": "SEC4",
+        "levelCodeDescription": "SECONDARY 4",
+        "indexNumber": "3",
+        "cca": [{ "ccaId": 1, "ccaDescription": "BOXING" }]
+      }
+    ],
+    "invalidStudents": [
+      {
+        "studentId": "T9999999Z",
+        "message": "Student not found in school records",
+        "row": 4
+      }
+    ]
+  },
+  "error": null
+}

--- a/server/internal/pg/mock.go
+++ b/server/internal/pg/mock.go
@@ -270,8 +270,8 @@ func registerMockGroups(mux *http.ServeMux) {
 
 	// Writes
 	mux.HandleFunc("POST /api/web/2/staff/groups/custom", jsonStub(http.StatusCreated, `{"customGroupId":6}`))
-	mux.HandleFunc("POST /api/web/2/staff/groups/custom/validateStudents", jsonStub(http.StatusOK, `{"valid":true}`))
-	mux.HandleFunc("POST /api/web/2/staff/groups/custom/validateStudents/results", jsonStub(http.StatusOK, `{"valid":true,"errors":[]}`))
+	mux.HandleFunc("POST /api/web/2/staff/groups/custom/validateStudents", handleValidateStudents)
+	mux.HandleFunc("POST /api/web/2/staff/groups/custom/validateStudents/results", handleValidateStudentsResults)
 	mux.HandleFunc("POST /api/web/2/staff/groups/student/count", jsonStub(http.StatusOK, `{"count":30}`))
 	mux.HandleFunc("PUT /api/web/2/staff/groups/custom/{customGroupId}", jsonStub(http.StatusOK, `{}`))
 	mux.HandleFunc("PUT /api/web/2/staff/groups/custom/{customGroupId}/share", jsonStub(http.StatusOK, `{}`))
@@ -380,6 +380,48 @@ func handleMockPreUpload(w http.ResponseWriter, r *http.Request) {
 func registerMockPlatform(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/feature/2/flags", serveFixture("fixtures/feature_flags.json"))
 	mux.HandleFunc("GET /api/web/2/webNotification", serveFixture("fixtures/web_notifications.json"))
+}
+
+// ─── Validate students (Excel upload two-step mock) ───────────────────────
+
+var validateStudentsToken atomic.Uint64
+
+func handleValidateStudents(w http.ResponseWriter, r *http.Request) {
+	seq := validateStudentsToken.Add(1)
+	token := "mock-token-" + strconv.FormatUint(seq, 10)
+
+	resp := map[string]any{
+		"body":       map[string]any{"token": token},
+		"resultCode": 1,
+		"message":    "Success",
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func handleValidateStudentsResults(w http.ResponseWriter, r *http.Request) {
+	fixtureData, err := fixtures.ReadFile("fixtures/validate_students_results.json")
+	if err != nil {
+		http.Error(w, "fixture not found", http.StatusInternalServerError)
+		return
+	}
+
+	var inner any
+	_ = json.Unmarshal(fixtureData, &inner)
+
+	resp := map[string]any{
+		"body":       inner,
+		"resultCode": 1,
+		"message":    "Success",
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // ─── Helpers ────────────────────────────────────────────────────────────────

--- a/web/components/groups/ExcelUploadPanel.test.tsx
+++ b/web/components/groups/ExcelUploadPanel.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ExcelUploadPanel } from './ExcelUploadPanel';
+
+vi.mock('./parse-excel-file', () => ({
+  parseExcelFile: vi.fn(),
+}));
+
+vi.mock('./validate-upload-students', () => ({
+  validateUploadStudents: vi.fn(),
+}));
+
+import { parseExcelFile } from './parse-excel-file';
+import { validateUploadStudents } from './validate-upload-students';
+
+const mockedParse = vi.mocked(parseExcelFile);
+const mockedValidate = vi.mocked(validateUploadStudents);
+
+function xlsxFile(name = 'students.xlsx') {
+  return new File(['fake'], name, {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+}
+
+describe('ExcelUploadPanel', () => {
+  it('renders upload instructions for MS schools', () => {
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    expect(screen.getAllByText(/Name/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Class/).length).toBeGreaterThan(0);
+  });
+
+  it('renders upload instructions for IHL schools', () => {
+    render(<ExcelUploadPanel isIhl={true} onResult={vi.fn()} />);
+    expect(screen.getAllByText(/Student ID/).length).toBeGreaterThan(0);
+  });
+
+  it('shows file input accepting only .xlsx', () => {
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i) as HTMLInputElement;
+    expect(input.accept).toContain('.xlsx');
+  });
+
+  it('shows validation error when file is blank', async () => {
+    mockedParse.mockResolvedValue([]);
+
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/empty/i);
+    });
+  });
+
+  it('shows validation error for missing headers (MS)', async () => {
+    mockedParse.mockResolvedValue([{ StudentId: 'S123' }]);
+
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/Name.*Class/);
+    });
+  });
+
+  it('shows validation error for duplicate headers', async () => {
+    mockedParse.mockResolvedValue([{ Name: 'A', Class: '1A', name: 'dup' }]);
+
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/more than once/);
+    });
+  });
+
+  it('shows validation error when over max capacity', async () => {
+    const rows = Array.from({ length: 5001 }, (_, i) => ({
+      Name: `Student ${i}`,
+      Class: '1A',
+    }));
+    mockedParse.mockResolvedValue(rows);
+
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/5000/);
+    });
+  });
+
+  it('calls validateUploadStudents and onResult on success (MS)', async () => {
+    const rows = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '2B' },
+    ];
+    mockedParse.mockResolvedValue(rows);
+
+    const validStudents = [
+      {
+        pgStudentId: 1,
+        studentId: 'S1',
+        studentName: 'Alice',
+        className: '1A',
+        classCode: 'C1',
+        levelCode: 'L1',
+        levelCodeDescription: 'Level 1',
+      },
+    ];
+    const invalidStudents = [{ name: 'Bob', className: '2B', message: 'Not found', row: 3 }];
+    mockedValidate.mockResolvedValue({ validStudents, invalidStudents });
+
+    const onResult = vi.fn();
+    render(<ExcelUploadPanel isIhl={false} onResult={onResult} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(onResult).toHaveBeenCalledWith({ validStudents, invalidStudents });
+    });
+
+    expect(mockedValidate).toHaveBeenCalledWith({
+      type: 'ms',
+      students: [
+        { name: 'Alice', className: '1A' },
+        { name: 'Bob', className: '2B' },
+      ],
+    });
+  });
+
+  it('calls validateUploadStudents with IHL payload shape', async () => {
+    const rows = [{ 'Student ID': 'S1111111A' }, { 'Student ID': 'S2222222B' }];
+    mockedParse.mockResolvedValue(rows);
+    mockedValidate.mockResolvedValue({ validStudents: [], invalidStudents: [] });
+
+    const onResult = vi.fn();
+    render(<ExcelUploadPanel isIhl={true} onResult={onResult} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(mockedValidate).toHaveBeenCalledWith({
+        type: 'ihl',
+        students: [{ studentId: 'S1111111A' }, { studentId: 'S2222222B' }],
+      });
+    });
+  });
+
+  it('shows server error when validateUploadStudents rejects', async () => {
+    const rows = [{ Name: 'Alice', Class: '1A' }];
+    mockedParse.mockResolvedValue(rows);
+    mockedValidate.mockRejectedValue(new Error('Processing failed'));
+
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/unexpected error/i);
+    });
+  });
+
+  it('shows loading state while validating', async () => {
+    const rows = [{ Name: 'Alice', Class: '1A' }];
+    mockedParse.mockResolvedValue(rows);
+    let resolveValidation: (v: unknown) => void;
+    mockedValidate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveValidation = resolve;
+        }),
+    );
+
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/validating/i)).toBeInTheDocument();
+    });
+
+    resolveValidation!({ validStudents: [], invalidStudents: [] });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/validating/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('rejects files over 5MB', async () => {
+    render(<ExcelUploadPanel isIhl={false} onResult={vi.fn()} />);
+    const input = screen.getByLabelText(/upload/i);
+    const bigFile = new File(['x'.repeat(6 * 1024 * 1024)], 'big.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+    fireEvent.change(input, { target: { files: [bigFile] } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/5\s*MB/i);
+    });
+  });
+});

--- a/web/components/groups/ExcelUploadPanel.tsx
+++ b/web/components/groups/ExcelUploadPanel.tsx
@@ -1,0 +1,252 @@
+import React, { useCallback, useState } from 'react';
+
+import {
+  checkForDuplicateEntries,
+  checkForDuplicateHeaders,
+  checkForDuplicateStudentIds,
+  checkForMissingHeaders,
+  checkForMissingValues,
+  checkIsBlank,
+  isOverMaxCapacity,
+  mapStudentDataHeaders,
+  MAX_STUDENTS,
+} from './excel-upload-validation';
+import { parseExcelFile } from './parse-excel-file';
+import { validateUploadStudents, type ValidateResult } from './validate-upload-students';
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+interface ExcelUploadPanelProps {
+  isIhl: boolean;
+  onResult: (result: ValidateResult) => void;
+}
+
+export const ExcelUploadPanel: React.FC<ExcelUploadPanelProps> = ({ isIhl, onResult }) => {
+  const [error, setError] = useState<string | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      setError(null);
+
+      if (file.size > MAX_FILE_SIZE) {
+        setError('File size exceeds the 5 MB limit. Please upload a smaller file.');
+        return;
+      }
+
+      try {
+        const rows = await parseExcelFile(file);
+
+        if (checkIsBlank(rows)) {
+          setError('The file is empty. Please check it and re-upload.');
+          return;
+        }
+
+        if (isIhl) {
+          const ihlRows = rows as { 'Student ID': string }[];
+          const dupIds = checkForDuplicateStudentIds(ihlRows);
+          if (dupIds) {
+            setError(dupIds);
+            return;
+          }
+
+          if (isOverMaxCapacity(ihlRows.length)) {
+            setError(
+              `You may only upload up to ${MAX_STUDENTS} Student IDs. Please amend and re-upload.`,
+            );
+            return;
+          }
+
+          setIsValidating(true);
+          const result = await validateUploadStudents({
+            type: 'ihl',
+            students: ihlRows.map((r) => ({ studentId: String(r['Student ID']).trim() })),
+          });
+          onResult(result);
+        } else {
+          const dupHeaders = checkForDuplicateHeaders(rows as Record<string, string>[]);
+          if (dupHeaders) {
+            setError(dupHeaders);
+            return;
+          }
+
+          const missingHeaders = checkForMissingHeaders(rows as Record<string, string>[]);
+          if (missingHeaders) {
+            setError(missingHeaders);
+            return;
+          }
+
+          const mapped = mapStudentDataHeaders(rows as Record<string, string>[]) as {
+            Name: string;
+            Class: string;
+          }[];
+
+          const { hasMissing } = checkForMissingValues(mapped);
+          if (hasMissing) {
+            setError(
+              "Your file has rows missing 'Name' or 'Class' entries. Please update and re-upload.",
+            );
+            return;
+          }
+
+          if (isOverMaxCapacity(mapped.length)) {
+            setError(
+              `You may only upload up to ${MAX_STUDENTS} students. Please reduce the number and re-upload.`,
+            );
+            return;
+          }
+
+          const dupEntries = checkForDuplicateEntries(mapped);
+          if (dupEntries) {
+            setError(dupEntries);
+            return;
+          }
+
+          setIsValidating(true);
+          const result = await validateUploadStudents({
+            type: 'ms',
+            students: mapped.map((r) => ({ name: r.Name, className: r.Class })),
+          });
+          onResult(result);
+        }
+      } catch {
+        setError('Sorry, an unexpected error occurred on our side. Please try again later.');
+      } finally {
+        setIsValidating(false);
+      }
+    },
+    [isIhl, onResult],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-sm text-muted-foreground">
+        {isIhl ? (
+          <>
+            <p>
+              Please create a new <b>Excel file</b>, label the first column as{' '}
+              <b>&apos;Student ID&apos;</b>, and enter the unique student IDs beneath the header.
+              Save and upload the file below.
+            </p>
+            <p className="mt-3 text-xs font-semibold">Sample file to upload:</p>
+            <table className="mt-1 border border-border text-xs">
+              <thead>
+                <tr className="bg-muted">
+                  <th className="w-8 border-r border-border px-1 py-0.5 text-center font-normal text-muted-foreground/60" />
+                  <th className="px-3 py-1 text-left font-semibold">A</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    1
+                  </td>
+                  <td className="px-3 py-1 font-semibold">Student ID</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    2
+                  </td>
+                  <td className="px-3 py-1">S1234567A</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    3
+                  </td>
+                  <td className="px-3 py-1">S2345678B</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    4
+                  </td>
+                  <td className="px-3 py-1">S3456789C</td>
+                </tr>
+              </tbody>
+            </table>
+          </>
+        ) : (
+          <>
+            <p>
+              Upload an Excel file (.xlsx) with two columns: <b>&apos;Name&apos;</b> and{' '}
+              <b>&apos;Class&apos;</b>.
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              <li>
+                The columns can be in <b>any order and any position</b>, as long as they are named
+                correctly.
+              </li>
+              <li>Include student details that match the records in School Cockpit.</li>
+            </ul>
+            <p className="mt-3 text-xs font-semibold">Sample file to upload:</p>
+            <table className="mt-1 border border-border text-xs">
+              <thead>
+                <tr className="bg-muted">
+                  <th className="w-8 border-r border-border px-1 py-0.5 text-center font-normal text-muted-foreground/60" />
+                  <th className="border-r border-border px-3 py-1 text-left font-semibold">A</th>
+                  <th className="px-3 py-1 text-left font-semibold">B</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    1
+                  </td>
+                  <td className="border-r border-border px-3 py-1 font-semibold">Name</td>
+                  <td className="px-3 py-1 font-semibold">Class</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    2
+                  </td>
+                  <td className="border-r border-border px-3 py-1">CHEN WEI JIA</td>
+                  <td className="px-3 py-1">P1-DILIGENCE</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    3
+                  </td>
+                  <td className="border-r border-border px-3 py-1">RONALD TONG YING MING</td>
+                  <td className="px-3 py-1">P1-DILIGENCE</td>
+                </tr>
+                <tr className="border-t border-border">
+                  <td className="border-r border-border px-1 py-0.5 text-center text-muted-foreground/60">
+                    4
+                  </td>
+                  <td className="border-r border-border px-3 py-1">RAJESH KUMAR</td>
+                  <td className="px-3 py-1">P1-DILIGENCE</td>
+                </tr>
+              </tbody>
+            </table>
+          </>
+        )}
+      </div>
+
+      <label className="flex cursor-pointer flex-col items-center gap-2 rounded-lg border-2 border-dashed border-muted-foreground/25 px-6 py-8 text-center transition-colors hover:border-muted-foreground/50">
+        <span className="text-sm font-medium">
+          {isValidating ? 'Validating...' : 'Click to upload .xlsx file'}
+        </span>
+        <span className="text-xs text-muted-foreground">Max 5 MB</span>
+        <input
+          type="file"
+          className="sr-only"
+          accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          aria-label="Upload Excel file"
+          onChange={handleFileChange}
+          disabled={isValidating}
+        />
+      </label>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/web/components/groups/excel-upload-validation.test.ts
+++ b/web/components/groups/excel-upload-validation.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  checkIsBlank,
+  checkForMissingHeaders,
+  checkForDuplicateHeaders,
+  checkForMissingValues,
+  checkForDuplicateEntries,
+  mapStudentDataHeaders,
+  isOverMaxCapacity,
+  checkForDuplicateStudentIds,
+  MAX_STUDENTS,
+} from './excel-upload-validation';
+
+describe('checkIsBlank', () => {
+  it('returns true for empty array', () => {
+    expect(checkIsBlank([])).toBe(true);
+  });
+
+  it('returns false for non-empty array', () => {
+    expect(checkIsBlank([{ Name: 'Alice', Class: '1A' }])).toBe(false);
+  });
+});
+
+describe('checkForMissingHeaders (MS)', () => {
+  it('returns false when Name and Class headers present', () => {
+    const rows = [{ Name: 'Alice', Class: '1A' }];
+    expect(checkForMissingHeaders(rows)).toBe(false);
+  });
+
+  it('returns error when Name header missing', () => {
+    const rows = [{ StudentName: 'Alice', Class: '1A' }];
+    expect(checkForMissingHeaders(rows)).toContain('Name');
+    expect(checkForMissingHeaders(rows)).toContain('Class');
+  });
+
+  it('returns error when Class header missing', () => {
+    const rows = [{ Name: 'Alice', Classroom: '1A' }];
+    expect(checkForMissingHeaders(rows)).toBeTruthy();
+  });
+
+  it('returns error for empty array', () => {
+    expect(checkForMissingHeaders([])).toBeTruthy();
+  });
+});
+
+describe('checkForDuplicateHeaders', () => {
+  it('returns false when no duplicate headers', () => {
+    const rows = [{ Name: 'Alice', Class: '1A' }];
+    expect(checkForDuplicateHeaders(rows)).toBe(false);
+  });
+
+  it('returns false for empty array', () => {
+    expect(checkForDuplicateHeaders([])).toBe(false);
+  });
+
+  it('detects duplicate case-insensitive Name headers', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', name: 'dup' }];
+    expect(checkForDuplicateHeaders(rows)).toBeTruthy();
+  });
+
+  it('detects duplicate case-insensitive Class headers', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', class: 'dup' }];
+    expect(checkForDuplicateHeaders(rows)).toBeTruthy();
+  });
+
+  it('detects Name headers with whitespace', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', ' Name ': 'dup' }];
+    expect(checkForDuplicateHeaders(rows)).toBeTruthy();
+  });
+
+  it('detects Class headers with whitespace', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', 'Class ': 'dup' }];
+    expect(checkForDuplicateHeaders(rows)).toBeTruthy();
+  });
+
+  it('detects xlsx duplicate suffix headers (Name_1)', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', Name_1: 'dup' }];
+    expect(checkForDuplicateHeaders(rows)).toBeTruthy();
+  });
+
+  it('detects xlsx duplicate suffix headers (Class_1)', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', Class_1: 'dup' }];
+    expect(checkForDuplicateHeaders(rows)).toBeTruthy();
+  });
+
+  it('ignores substrings that do not start with header names', () => {
+    const rows = [{ Name: 'Alice', Class: '1A', myName: 'ok', myClass: 'ok' }];
+    expect(checkForDuplicateHeaders(rows)).toBe(false);
+  });
+});
+
+describe('mapStudentDataHeaders', () => {
+  it('standardises differently-cased Name and Class headers', () => {
+    const input = [
+      { name: 'Alice', class: '1A' },
+      { NAME: 'Bob', CLASS: '2B' },
+      { Name: 'Charlie', Class: '3C' },
+    ];
+    expect(mapStudentDataHeaders(input as Record<string, string>[])).toEqual([
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '2B' },
+      { Name: 'Charlie', Class: '3C' },
+    ]);
+  });
+
+  it('trims whitespace from headers and values', () => {
+    const input = [{ ' name ': '  Alice  ', ' class ': '  1A  ' }];
+    expect(mapStudentDataHeaders(input as Record<string, string>[])).toEqual([
+      { Name: 'Alice', Class: '1A' },
+    ]);
+  });
+
+  it('returns original row if Name or Class key not found', () => {
+    const input = [
+      { Name: 'Alice', Classroom: '1A' },
+      { StudentName: 'Bob', Class: '2B' },
+    ];
+    expect(mapStudentDataHeaders(input as Record<string, string>[])).toEqual(input);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(mapStudentDataHeaders([])).toEqual([]);
+  });
+
+  it('casts numeric values to strings', () => {
+    const input = [{ name: 10003, class: 5.1 }];
+    expect(mapStudentDataHeaders(input as unknown as Record<string, string>[])).toEqual([
+      { Name: '10003', Class: '5.1' },
+    ]);
+  });
+
+  it('handles mixed header variations in same dataset', () => {
+    const input = [
+      { name: 'Alice', class: '1A' },
+      { 'Name ': 'Bob', ' Class ': '2B' },
+      { NAME: 'Charlie', CLASS: '3C' },
+    ];
+    expect(mapStudentDataHeaders(input as Record<string, string>[])).toEqual([
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '2B' },
+      { Name: 'Charlie', Class: '3C' },
+    ]);
+  });
+});
+
+describe('checkForMissingValues', () => {
+  it('returns no missing rows when all rows complete', () => {
+    const rows = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '2B' },
+    ];
+    const result = checkForMissingValues(rows);
+    expect(result.hasMissing).toBe(false);
+    expect(result.missingRows).toEqual([]);
+  });
+
+  it('reports rows missing Name', () => {
+    const rows = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: '', Class: '2B' },
+    ];
+    const result = checkForMissingValues(rows);
+    expect(result.hasMissing).toBe(true);
+    expect(result.missingRows).toEqual([3]);
+  });
+
+  it('reports rows missing Class', () => {
+    const rows = [{ Name: 'Alice', Class: '' }];
+    const result = checkForMissingValues(rows);
+    expect(result.hasMissing).toBe(true);
+    expect(result.missingRows).toEqual([2]);
+  });
+
+  it('uses 1-based row numbers offset by header row', () => {
+    const rows = [
+      { Name: '', Class: '' },
+      { Name: 'Bob', Class: '2B' },
+      { Name: '', Class: '3C' },
+    ];
+    const result = checkForMissingValues(rows);
+    expect(result.missingRows).toEqual([2, 4]);
+  });
+});
+
+describe('checkForDuplicateEntries (MS — Name+Class)', () => {
+  it('returns false when no duplicates', () => {
+    const students = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '1A' },
+      { Name: 'Alice', Class: '1B' },
+    ];
+    expect(checkForDuplicateEntries(students)).toBe(false);
+  });
+
+  it('detects duplicate Name+Class entries', () => {
+    const students = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '1B' },
+    ];
+    const result = checkForDuplicateEntries(students);
+    expect(result).toBeTruthy();
+    expect(result).toContain('Alice in rows 2, 3');
+  });
+
+  it('handles multiple duplicate groups', () => {
+    const students = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '1B' },
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Charlie', Class: '2C' },
+      { Name: 'Bob', Class: '1B' },
+      { Name: 'Charlie', Class: '2C' },
+    ];
+    const result = checkForDuplicateEntries(students);
+    expect(result).toBeTruthy();
+    expect(result).toContain('Alice in rows 2, 4');
+    expect(result).toContain('Bob in rows 3, 6');
+    expect(result).toContain('Charlie in rows 5, 7');
+  });
+
+  it('returns false for empty array', () => {
+    expect(checkForDuplicateEntries([])).toBe(false);
+  });
+
+  it('limits displayed duplicates to 5 and shows remainder count', () => {
+    const students: { Name: string; Class: string }[] = [];
+    for (let i = 1; i <= 15; i++) {
+      students.push({ Name: `Student ${i}`, Class: `Class ${i}` });
+      students.push({ Name: `Student ${i}`, Class: `Class ${i}` });
+    }
+    const result = checkForDuplicateEntries(students);
+    expect(result).toBeTruthy();
+    for (let i = 1; i <= 5; i++) {
+      expect(result).toContain(`Student ${i} in rows`);
+    }
+    expect(result).not.toContain('Student 6 in rows');
+    expect(result).toContain('and 10 more');
+  });
+
+  it('treats comparison as case-insensitive', () => {
+    const students = [
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'ALICE', Class: '1A' },
+    ];
+    const result = checkForDuplicateEntries(students);
+    expect(result).toBeTruthy();
+    expect(result).toContain('Alice in rows 2, 3');
+  });
+
+  it('handles names with special characters', () => {
+    const students = [
+      { Name: "João-Maria O'Connor", Class: '1A' },
+      { Name: "João-Maria O'Connor", Class: '1a' },
+    ];
+    const result = checkForDuplicateEntries(students);
+    expect(result).toBeTruthy();
+    expect(result).toContain("João-Maria O'Connor in rows 2, 3");
+  });
+});
+
+describe('checkForDuplicateStudentIds (IHL)', () => {
+  it('returns false when no duplicate IDs', () => {
+    const rows = [{ 'Student ID': 'S1111111A' }, { 'Student ID': 'S2222222B' }];
+    expect(checkForDuplicateStudentIds(rows)).toBe(false);
+  });
+
+  it('returns error with count when duplicates found', () => {
+    const rows = [
+      { 'Student ID': 'S1111111A' },
+      { 'Student ID': 'S2222222B' },
+      { 'Student ID': 'S1111111A' },
+    ];
+    const result = checkForDuplicateStudentIds(rows);
+    expect(result).toBeTruthy();
+    expect(result).toContain('1');
+    expect(result).toContain('duplicate');
+  });
+
+  it('counts distinct duplicate IDs, not total occurrences', () => {
+    const rows = [
+      { 'Student ID': 'S1111111A' },
+      { 'Student ID': 'S1111111A' },
+      { 'Student ID': 'S2222222B' },
+      { 'Student ID': 'S2222222B' },
+      { 'Student ID': 'S2222222B' },
+    ];
+    const result = checkForDuplicateStudentIds(rows);
+    expect(result).toBeTruthy();
+    expect(result).toContain('2');
+  });
+});
+
+describe('isOverMaxCapacity', () => {
+  it('returns false at exactly MAX_STUDENTS', () => {
+    expect(isOverMaxCapacity(MAX_STUDENTS)).toBe(false);
+  });
+
+  it('returns true above MAX_STUDENTS', () => {
+    expect(isOverMaxCapacity(MAX_STUDENTS + 1)).toBe(true);
+  });
+
+  it('returns false below MAX_STUDENTS', () => {
+    expect(isOverMaxCapacity(0)).toBe(false);
+  });
+});

--- a/web/components/groups/excel-upload-validation.ts
+++ b/web/components/groups/excel-upload-validation.ts
@@ -1,0 +1,147 @@
+export const MAX_STUDENTS = 5000;
+
+const DISPLAY_LIMIT = 5;
+
+export function checkIsBlank(rows: Record<string, unknown>[]): boolean {
+  return rows.length === 0;
+}
+
+export function checkForMissingHeaders(rows: Record<string, string>[]): string | false {
+  if (rows.length === 0) {
+    return "The columns 'Name' and/or 'Class' are missing. Please add them and re-upload.";
+  }
+
+  const hasName = rows.some((row) =>
+    Object.keys(row).some((k) => k.trim().toLowerCase() === 'name'),
+  );
+  const hasClass = rows.some((row) =>
+    Object.keys(row).some((k) => k.trim().toLowerCase() === 'class'),
+  );
+
+  if (!hasName || !hasClass) {
+    return "The columns 'Name' and/or 'Class' are missing. Please add them and re-upload.";
+  }
+
+  return false;
+}
+
+export function checkForDuplicateHeaders(rows: Record<string, string>[]): string | false {
+  if (rows.length === 0) return false;
+
+  const keys = Object.keys(rows[0]);
+
+  const nameMatches = keys.filter((k) => {
+    const normalized = k.trim().toLowerCase();
+    return normalized === 'name' || (normalized.startsWith('name') && normalized !== 'name');
+  });
+
+  const classMatches = keys.filter((k) => {
+    const normalized = k.trim().toLowerCase();
+    return normalized === 'class' || (normalized.startsWith('class') && normalized !== 'class');
+  });
+
+  if (nameMatches.length > 1 || classMatches.length > 1) {
+    return "The column 'Name' and/or 'Class' appears more than once. Please remove the duplicate(s) and re-upload.";
+  }
+
+  return false;
+}
+
+export function mapStudentDataHeaders(rows: Record<string, unknown>[]): Record<string, string>[] {
+  return rows.map((row) => {
+    const keys = Object.keys(row);
+    let nameKey: string | undefined;
+    let classKey: string | undefined;
+
+    for (const key of keys) {
+      const lower = key.trim().toLowerCase();
+      if (lower === 'name') nameKey = key;
+      else if (lower === 'class') classKey = key;
+      if (nameKey && classKey) break;
+    }
+
+    if (nameKey && classKey) {
+      return {
+        Name: String(row[nameKey] ?? '').trim(),
+        Class: String(row[classKey] ?? '').trim(),
+      };
+    }
+    return row as Record<string, string>;
+  });
+}
+
+export function checkForMissingValues(rows: { Name: string; Class: string }[]): {
+  hasMissing: boolean;
+  missingRows: number[];
+} {
+  const missingRows: number[] = [];
+
+  rows.forEach((row, index) => {
+    if (!row.Name || !row.Class) {
+      missingRows.push(index + 2);
+    }
+  });
+
+  return { hasMissing: missingRows.length > 0, missingRows };
+}
+
+export function checkForDuplicateEntries(
+  students: { Name: string; Class: string }[],
+): string | false {
+  const seen = new Map<string, number[]>();
+  const duplicates = new Map<string, { rows: number[]; originalName: string }>();
+
+  students.forEach((student, index) => {
+    const key = `${student.Name.toLowerCase()}+${student.Class.toLowerCase()}`;
+    const rowNum = index + 2;
+
+    if (!seen.has(key)) {
+      seen.set(key, [rowNum]);
+    } else {
+      const existing = seen.get(key)!;
+      existing.push(rowNum);
+
+      if (!duplicates.has(key)) {
+        const firstIndex = existing[0] - 2;
+        duplicates.set(key, { rows: existing, originalName: students[firstIndex].Name });
+      } else {
+        duplicates.get(key)!.rows = existing;
+      }
+    }
+  });
+
+  if (duplicates.size === 0) return false;
+
+  const entries = Array.from(duplicates.entries()).slice(0, DISPLAY_LIMIT);
+  const formatted = entries
+    .map(([, data]) => `${data.originalName} in rows ${data.rows.join(', ')}`)
+    .join('\n\t• ');
+
+  const extra =
+    duplicates.size > DISPLAY_LIMIT ? ` and ${duplicates.size - DISPLAY_LIMIT} more` : '';
+
+  return `We found duplicate entries with the same 'Name' and 'Class':\n\n\t• ${formatted}${extra}.\n\nPlease remove the duplicates and re-upload.`;
+}
+
+export function checkForDuplicateStudentIds(rows: { 'Student ID': string }[]): string | false {
+  const seen = new Set<string>();
+  const dupes = new Set<string>();
+
+  for (const row of rows) {
+    const id = row['Student ID'];
+    if (seen.has(id)) {
+      dupes.add(id);
+    } else {
+      seen.add(id);
+    }
+  }
+
+  if (dupes.size === 0) return false;
+
+  const s = dupes.size > 1 ? 's' : '';
+  return `We found ${dupes.size} duplicate Student ID${s}. Please amend and re-upload.`;
+}
+
+export function isOverMaxCapacity(count: number): boolean {
+  return count > MAX_STUDENTS;
+}

--- a/web/components/groups/parse-excel-file.test.ts
+++ b/web/components/groups/parse-excel-file.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import * as XLSX from 'xlsx';
+
+import { parseExcelFile } from './parse-excel-file';
+
+function createXlsxBlob(rows: Record<string, unknown>[], sheetName = 'Sheet1'): File {
+  const ws = XLSX.utils.json_to_sheet(rows);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, sheetName);
+  const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+  return new File([buf], 'test.xlsx', {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+}
+
+function createEmptyXlsx(): File {
+  const ws = XLSX.utils.aoa_to_sheet([]);
+  const wb = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(wb, ws, 'Sheet1');
+  const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+  return new File([buf], 'empty.xlsx', {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+}
+
+describe('parseExcelFile', () => {
+  it('parses rows from the first sheet', async () => {
+    const file = createXlsxBlob([
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '2B' },
+    ]);
+    const rows = await parseExcelFile(file);
+    expect(rows).toEqual([
+      { Name: 'Alice', Class: '1A' },
+      { Name: 'Bob', Class: '2B' },
+    ]);
+  });
+
+  it('returns empty array for blank file', async () => {
+    const file = createEmptyXlsx();
+    const rows = await parseExcelFile(file);
+    expect(rows).toEqual([]);
+  });
+
+  it('reads only the first sheet even if multiple exist', async () => {
+    const ws1 = XLSX.utils.json_to_sheet([{ Name: 'Alice', Class: '1A' }]);
+    const ws2 = XLSX.utils.json_to_sheet([{ Name: 'Ignored', Class: 'X' }]);
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws1, 'First');
+    XLSX.utils.book_append_sheet(wb, ws2, 'Second');
+    const buf = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
+    const file = new File([buf], 'multi.xlsx', {
+      type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+
+    const rows = await parseExcelFile(file);
+    expect(rows).toEqual([{ Name: 'Alice', Class: '1A' }]);
+  });
+
+  it('preserves numeric values as-is from xlsx', async () => {
+    const file = createXlsxBlob([{ 'Student ID': 'S1234567A' }, { 'Student ID': 'S9876543Z' }]);
+    const rows = await parseExcelFile(file);
+    expect(rows).toEqual([{ 'Student ID': 'S1234567A' }, { 'Student ID': 'S9876543Z' }]);
+  });
+});

--- a/web/components/groups/parse-excel-file.ts
+++ b/web/components/groups/parse-excel-file.ts
@@ -1,0 +1,9 @@
+import * as XLSX from 'xlsx';
+
+export async function parseExcelFile<T = Record<string, unknown>>(file: File): Promise<T[]> {
+  const buffer = await file.arrayBuffer();
+  const workbook = XLSX.read(buffer, { type: 'array' });
+  const sheetName = workbook.SheetNames[0];
+  if (!sheetName) return [];
+  return XLSX.utils.sheet_to_json<T>(workbook.Sheets[sheetName]);
+}

--- a/web/components/groups/validate-upload-students.test.ts
+++ b/web/components/groups/validate-upload-students.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  validateUploadStudents,
+  type ValidStudent,
+  type InvalidStudent,
+} from './validate-upload-students';
+
+function mockFetchSequence(responses: { body: unknown; status?: number }[]) {
+  const fetchMock = vi.fn();
+  for (const resp of responses) {
+    fetchMock.mockResolvedValueOnce({
+      ok: (resp.status ?? 200) < 400,
+      status: resp.status ?? 200,
+      json: () => Promise.resolve(resp.body),
+    });
+  }
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('validateUploadStudents', () => {
+  it('sends IHL payload and returns valid/invalid students after polling', async () => {
+    const validStudents: ValidStudent[] = [
+      {
+        pgStudentId: 1001,
+        studentId: 'S1111111A',
+        studentName: 'Alice',
+        className: 'T02',
+        classCode: 'IHL-TP-2-002',
+        levelCode: 'IHL-TP-001',
+        levelCodeDescription: 'COMMON BUSINESS',
+      },
+    ];
+    const invalidStudents: InvalidStudent[] = [
+      { studentId: 'S9999999Z', message: 'Student not found', row: 2 },
+    ];
+
+    const fetchMock = mockFetchSequence([
+      { body: { body: { token: 'abc123' }, resultCode: 1, message: 'ok' } },
+      {
+        body: {
+          body: { status: 'success', data: { validStudents, invalidStudents }, error: null },
+          resultCode: 1,
+          message: 'ok',
+        },
+      },
+    ]);
+
+    const promise = validateUploadStudents({
+      type: 'ihl',
+      students: [{ studentId: 'S1111111A' }, { studentId: 'S9999999Z' }],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    const result = await promise;
+
+    expect(result.validStudents).toEqual(validStudents);
+    expect(result.invalidStudents).toEqual(invalidStudents);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const [firstUrl, firstOpts] = fetchMock.mock.calls[0];
+    expect(firstUrl).toContain('/groups/custom/validateStudents');
+    expect(JSON.parse(firstOpts.body)).toEqual([
+      { studentId: 'S1111111A' },
+      { studentId: 'S9999999Z' },
+    ]);
+  });
+
+  it('sends MS payload with name+className fields', async () => {
+    const fetchMock = mockFetchSequence([
+      { body: { body: { token: 'tok' }, resultCode: 1, message: 'ok' } },
+      {
+        body: {
+          body: {
+            status: 'success',
+            data: { validStudents: [], invalidStudents: [] },
+            error: null,
+          },
+          resultCode: 1,
+          message: 'ok',
+        },
+      },
+    ]);
+
+    const promise = validateUploadStudents({
+      type: 'ms',
+      students: [{ name: 'Alice', className: '1A' }],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await promise;
+
+    const [, firstOpts] = fetchMock.mock.calls[0];
+    expect(JSON.parse(firstOpts.body)).toEqual([{ name: 'Alice', className: '1A' }]);
+  });
+
+  it('polls until status is success', async () => {
+    const fetchMock = mockFetchSequence([
+      { body: { body: { token: 'tok' }, resultCode: 1, message: 'ok' } },
+      {
+        body: {
+          body: {
+            status: 'pending',
+            data: { validStudents: [], invalidStudents: [] },
+            error: null,
+          },
+          resultCode: 1,
+          message: 'ok',
+        },
+      },
+      {
+        body: {
+          body: {
+            status: 'pending',
+            data: { validStudents: [], invalidStudents: [] },
+            error: null,
+          },
+          resultCode: 1,
+          message: 'ok',
+        },
+      },
+      {
+        body: {
+          body: {
+            status: 'success',
+            data: {
+              validStudents: [
+                {
+                  pgStudentId: 1,
+                  studentId: 'S1',
+                  studentName: 'A',
+                  className: 'B',
+                  classCode: 'C',
+                  levelCode: 'D',
+                  levelCodeDescription: 'E',
+                },
+              ],
+              invalidStudents: [],
+            },
+            error: null,
+          },
+          resultCode: 1,
+          message: 'ok',
+        },
+      },
+    ]);
+
+    const promise = validateUploadStudents({ type: 'ihl', students: [{ studentId: 'S1' }] });
+
+    // First poll returns pending
+    await vi.advanceTimersByTimeAsync(3000);
+    // Second poll returns pending
+    await vi.advanceTimersByTimeAsync(3000);
+    // Third poll returns success
+    await vi.advanceTimersByTimeAsync(3000);
+
+    const result = await promise;
+    expect(result.validStudents).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it('throws when server returns error status in poll', async () => {
+    mockFetchSequence([
+      { body: { body: { token: 'tok' }, resultCode: 1, message: 'ok' } },
+      {
+        body: {
+          body: { status: 'error', data: null, error: 'Processing failed' },
+          resultCode: 1,
+          message: 'ok',
+        },
+      },
+    ]);
+
+    await expect(
+      validateUploadStudents({ type: 'ihl', students: [{ studentId: 'S1' }] }),
+    ).rejects.toThrow('Processing failed');
+  });
+
+  it('throws when initial validate call fails', async () => {
+    mockFetchSequence([{ body: { resultCode: -1, message: 'Bad request' }, status: 400 }]);
+
+    await expect(validateUploadStudents({ type: 'ihl', students: [] })).rejects.toThrow(
+      'Bad request',
+    );
+  });
+});

--- a/web/components/groups/validate-upload-students.ts
+++ b/web/components/groups/validate-upload-students.ts
@@ -1,0 +1,96 @@
+const API_BASE = '/api/web/2/staff';
+const POLL_INTERVAL_MS = 3000;
+const MAX_POLL_ATTEMPTS = 100;
+
+export interface ValidStudent {
+  pgStudentId: number;
+  studentId: string;
+  studentName: string;
+  className: string;
+  classCode: string;
+  levelCode: string;
+  levelCodeDescription: string;
+  uinFinNo?: string;
+  indexNumber?: string;
+  cca?: { ccaId: number; ccaDescription: string }[];
+}
+
+export interface InvalidStudent {
+  studentId?: string;
+  name?: string;
+  className?: string;
+  message: string;
+  row: number;
+}
+
+export interface ValidateResult {
+  validStudents: ValidStudent[];
+  invalidStudents: InvalidStudent[];
+}
+
+interface IhlPayload {
+  type: 'ihl';
+  students: { studentId: string }[];
+}
+interface MsPayload {
+  type: 'ms';
+  students: { name: string; className: string }[];
+}
+
+export async function validateUploadStudents(
+  payload: IhlPayload | MsPayload,
+): Promise<ValidateResult> {
+  const body = JSON.stringify(payload.students);
+
+  const res = await fetch(`${API_BASE}/groups/custom/validateStudents`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body,
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { message?: string }).message ?? 'Validation request failed');
+  }
+
+  const json = (await res.json()) as { body: { token: string }; resultCode: number };
+  const { token } = json.body;
+
+  return pollResults(token);
+}
+
+async function pollResults(token: string): Promise<ValidateResult> {
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await sleep(POLL_INTERVAL_MS);
+    }
+
+    const res = await fetch(`${API_BASE}/groups/custom/validateStudents/results`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ token }),
+    });
+
+    const json = (await res.json()) as {
+      body: { status: string; data: ValidateResult | null; error: string | null };
+    };
+
+    const { status, data, error } = json.body;
+
+    if (status === 'success' && data) {
+      return data;
+    }
+
+    if (status === 'error') {
+      throw new Error(error ?? 'Validation failed');
+    }
+  }
+
+  throw new Error(`Validation timed out after ${MAX_POLL_ATTEMPTS} attempts`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/web/containers/CreateCustomGroupView.excel.test.tsx
+++ b/web/containers/CreateCustomGroupView.excel.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Component as CreateCustomGroupView } from './CreateCustomGroupView';
+
+vi.mock('~/api/client', async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createCustomGroup: vi.fn().mockResolvedValue({ customGroupId: 42 }),
+  };
+});
+
+vi.mock('~/components/groups/parse-excel-file', () => ({
+  parseExcelFile: vi.fn(),
+}));
+
+vi.mock('~/components/groups/validate-upload-students', () => ({
+  validateUploadStudents: vi.fn(),
+}));
+
+import { parseExcelFile } from '~/components/groups/parse-excel-file';
+import { validateUploadStudents } from '~/components/groups/validate-upload-students';
+
+const mockedParse = vi.mocked(parseExcelFile);
+const mockedValidate = vi.mocked(validateUploadStudents);
+
+function renderView() {
+  const router = createMemoryRouter(
+    [{ path: '/groups/customGroups/new', Component: CreateCustomGroupView }],
+    { initialEntries: ['/groups/customGroups/new'] },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+function xlsxFile(name = 'students.xlsx') {
+  return new File(['fake'], name, {
+    type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  });
+}
+
+describe('CreateCustomGroupView — Excel upload integration', () => {
+  it('enables "Upload via Excel" in the dropdown when no students exist', async () => {
+    renderView();
+    const trigger = screen.getAllByRole('button', { name: /add students/i })[0];
+    fireEvent.click(trigger);
+    const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
+    expect(excel).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('clicking "Upload via Excel" shows the ExcelUploadPanel', async () => {
+    renderView();
+    const trigger = screen.getAllByRole('button', { name: /add students/i })[0];
+    fireEvent.click(trigger);
+    const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
+    fireEvent.click(excel);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/upload/i)).toBeInTheDocument();
+    });
+  });
+
+  it('adds valid students from Excel upload to the student list', async () => {
+    mockedParse.mockResolvedValue([
+      { Name: 'Alice Tan', Class: '1A' },
+      { Name: 'Bob Lee', Class: '2B' },
+    ]);
+    mockedValidate.mockResolvedValue({
+      validStudents: [
+        {
+          pgStudentId: 101,
+          studentId: 'S1111111A',
+          studentName: 'Alice Tan',
+          className: '1A',
+          classCode: 'P1-01',
+          levelCode: 'P1',
+          levelCodeDescription: 'PRIMARY 1',
+        },
+        {
+          pgStudentId: 102,
+          studentId: 'S2222222B',
+          studentName: 'Bob Lee',
+          className: '2B',
+          classCode: 'P2-01',
+          levelCode: 'P2',
+          levelCodeDescription: 'PRIMARY 2',
+        },
+      ],
+      invalidStudents: [],
+    });
+
+    renderView();
+
+    // Open dropdown, click Upload via Excel
+    fireEvent.click(screen.getAllByRole('button', { name: /add students/i })[0]);
+    fireEvent.click(await screen.findByRole('menuitem', { name: /upload via excel/i }));
+
+    // Upload a file
+    const input = await screen.findByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    // Results screen shows, click confirm to add
+    const confirm = await screen.findByRole('button', { name: /add 2 student/i });
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alice Tan')).toBeInTheDocument();
+      expect(screen.getByText('Bob Lee')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/2 students added/i)).toBeInTheDocument();
+  });
+
+  it('shows invalid students with error messages after upload', async () => {
+    mockedParse.mockResolvedValue([
+      { Name: 'Alice Tan', Class: '1A' },
+      { Name: 'Unknown', Class: '9Z' },
+    ]);
+    mockedValidate.mockResolvedValue({
+      validStudents: [
+        {
+          pgStudentId: 101,
+          studentId: 'S1111111A',
+          studentName: 'Alice Tan',
+          className: '1A',
+          classCode: 'P1-01',
+          levelCode: 'P1',
+          levelCodeDescription: 'PRIMARY 1',
+        },
+      ],
+      invalidStudents: [{ name: 'Unknown', className: '9Z', message: 'Student not found', row: 3 }],
+    });
+
+    renderView();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /add students/i })[0]);
+    fireEvent.click(await screen.findByRole('menuitem', { name: /upload via excel/i }));
+
+    const input = await screen.findByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 valid/i)).toBeInTheDocument();
+      expect(screen.getByText(/1 invalid/i)).toBeInTheDocument();
+      expect(screen.getByText(/student not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('hides the upload panel and shows student list after confirming upload results', async () => {
+    mockedParse.mockResolvedValue([{ Name: 'Alice', Class: '1A' }]);
+    mockedValidate.mockResolvedValue({
+      validStudents: [
+        {
+          pgStudentId: 101,
+          studentId: 'S1',
+          studentName: 'Alice',
+          className: '1A',
+          classCode: 'P1-01',
+          levelCode: 'P1',
+          levelCodeDescription: 'PRIMARY 1',
+        },
+      ],
+      invalidStudents: [],
+    });
+
+    renderView();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /add students/i })[0]);
+    fireEvent.click(await screen.findByRole('menuitem', { name: /upload via excel/i }));
+
+    const input = await screen.findByLabelText(/upload/i);
+    fireEvent.change(input, { target: { files: [xlsxFile()] } });
+
+    // After results come back, a confirm button appears
+    const confirm = await screen.findByRole('button', { name: /add.*student/i });
+    fireEvent.click(confirm);
+
+    // Upload panel goes away, student list shows
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/upload/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+    });
+  });
+});

--- a/web/containers/CreateCustomGroupView.test.tsx
+++ b/web/containers/CreateCustomGroupView.test.tsx
@@ -50,15 +50,14 @@ describe('CreateCustomGroupView', () => {
     expect(screen.getByText(/no students added yet/i)).toBeInTheDocument();
   });
 
-  it('shows an "+ Add Students" dropdown with "Add manually" enabled (links to subpage) and "Upload via Excel" disabled', async () => {
+  it('shows an "+ Add Students" dropdown with "Add manually" (links to subpage) and "Upload via Excel" enabled when no students', async () => {
     renderView();
     const triggers = screen.getAllByRole('button', { name: /add students/i });
     fireEvent.click(triggers[0]);
     const manual = await screen.findByRole('menuitem', { name: /add manually/i });
     const excel = await screen.findByRole('menuitem', { name: /upload via excel/i });
     expect(manual).not.toHaveAttribute('aria-disabled', 'true');
-    expect(excel).toHaveAttribute('aria-disabled', 'true');
-    // The menuitem IS the <a> tag (rendered via `render={<Link />}`) — assert it points at the subpage.
+    expect(excel).not.toHaveAttribute('aria-disabled', 'true');
     expect(manual).toHaveAttribute('href', '/groups/customGroups/new/addStudents');
   });
 

--- a/web/containers/CreateCustomGroupView.tsx
+++ b/web/containers/CreateCustomGroupView.tsx
@@ -1,9 +1,11 @@
 import { Plus } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
 
 import { createCustomGroup } from '~/api/client';
 import type { PGApiSchoolStudent } from '~/api/types';
+import { ExcelUploadPanel } from '~/components/groups/ExcelUploadPanel';
+import type { ValidateResult } from '~/components/groups/validate-upload-students';
 import {
   Button,
   DropdownMenu,
@@ -20,13 +22,17 @@ interface IncomingNavState {
   addedStudents?: PGApiSchoolStudent[];
 }
 
+type ViewMode = 'list' | 'excel-upload' | 'excel-results';
+
 const CreateCustomGroupView: React.FC = () => {
   const [title, setTitle] = useState('');
   const location = useLocation();
   const navigate = useNavigate();
   const navState = (location.state as IncomingNavState | null) ?? {};
-  const [students] = useState<PGApiSchoolStudent[]>(navState.addedStudents ?? []);
+  const [students, setStudents] = useState<PGApiSchoolStudent[]>(navState.addedStudents ?? []);
   const [submitting, setSubmitting] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [uploadResult, setUploadResult] = useState<ValidateResult | null>(null);
 
   const studentCount = students.length;
   const canSave = title.trim().length > 0 && studentCount > 0;
@@ -45,6 +51,29 @@ const CreateCustomGroupView: React.FC = () => {
       if (!(err instanceof Error)) throw err;
       notify.error('Could not create the group. Please try again.');
     }
+  }
+
+  const handleUploadResult = useCallback((result: ValidateResult) => {
+    setUploadResult(result);
+    setViewMode('excel-results');
+  }, []);
+
+  function confirmUploadResults() {
+    if (!uploadResult) return;
+    const mapped: PGApiSchoolStudent[] = uploadResult.validStudents.map((s) => ({
+      studentId: s.pgStudentId,
+      studentName: s.studentName,
+      uinFinNo: s.uinFinNo ?? '',
+      classSerialNo: s.indexNumber ?? '',
+      classCode: s.classCode,
+      className: s.className,
+      levelCode: s.levelCode,
+      levelDescription: s.levelCodeDescription,
+      cca: s.cca?.map((c) => c.ccaDescription) ?? [],
+    }));
+    setStudents((prev) => [...prev, ...mapped]);
+    setUploadResult(null);
+    setViewMode('list');
   }
 
   return (
@@ -68,47 +97,116 @@ const CreateCustomGroupView: React.FC = () => {
           </p>
 
           <div className="mt-6">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium">
-                {studentCount} student{studentCount === 1 ? '' : 's'} added.
-              </p>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button variant="secondary">
-                      <Plus className="size-4" aria-hidden />
-                      Add Students
-                    </Button>
-                  }
-                />
-                <DropdownMenuContent>
-                  <DropdownMenuItem
-                    render={
-                      <Link
-                        to="/groups/customGroups/new/addStudents"
-                        state={{ alreadyAdded: students.map((s) => s.studentId) }}
-                      />
-                    }
-                  >
-                    Add manually
-                  </DropdownMenuItem>
-                  <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-            {studentCount === 0 ? (
-              <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
-                No students added yet.
+            {viewMode === 'list' && (
+              <>
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium">
+                    {studentCount} student{studentCount === 1 ? '' : 's'} added.
+                  </p>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button variant="secondary">
+                          <Plus className="size-4" aria-hidden />
+                          Add Students
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent>
+                      <DropdownMenuItem
+                        render={
+                          <Link
+                            to="/groups/customGroups/new/addStudents"
+                            state={{ alreadyAdded: students.map((s) => s.studentId) }}
+                          />
+                        }
+                      >
+                        Add manually
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={studentCount > 0}
+                        onClick={() => setViewMode('excel-upload')}
+                      >
+                        Upload via Excel
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                {studentCount === 0 ? (
+                  <div className="mt-2 rounded-md bg-muted p-6 text-center text-sm text-muted-foreground">
+                    No students added yet.
+                  </div>
+                ) : (
+                  <ul className="mt-2 divide-y rounded-md border">
+                    {students.map((s) => (
+                      <li
+                        key={s.studentId}
+                        className="flex items-center justify-between p-3 text-sm"
+                      >
+                        <span>{s.studentName}</span>
+                        <span className="text-xs text-muted-foreground">{s.className}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+
+            {viewMode === 'excel-upload' && (
+              <div>
+                <div className="mb-4 flex items-center justify-between">
+                  <h2 className="text-lg font-medium">Upload via Excel</h2>
+                  <Button variant="ghost" size="sm" onClick={() => setViewMode('list')}>
+                    Cancel
+                  </Button>
+                </div>
+                <ExcelUploadPanel isIhl={false} onResult={handleUploadResult} />
               </div>
-            ) : (
-              <ul className="mt-2 divide-y rounded-md border">
-                {students.map((s) => (
-                  <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
-                    <span>{s.studentName}</span>
-                    <span className="text-xs text-muted-foreground">{s.className}</span>
-                  </li>
-                ))}
-              </ul>
+            )}
+
+            {viewMode === 'excel-results' && uploadResult && (
+              <div>
+                <h2 className="text-lg font-medium">Upload results</h2>
+                <div className="mt-4 space-y-3">
+                  {uploadResult.validStudents.length > 0 && (
+                    <p className="text-sm text-green-700">
+                      {uploadResult.validStudents.length} valid student
+                      {uploadResult.validStudents.length === 1 ? '' : 's'}
+                    </p>
+                  )}
+                  {uploadResult.invalidStudents.length > 0 && (
+                    <div>
+                      <p className="text-sm text-destructive">
+                        {uploadResult.invalidStudents.length} invalid student
+                        {uploadResult.invalidStudents.length === 1 ? '' : 's'}
+                      </p>
+                      <ul className="mt-2 divide-y rounded-md border border-destructive/20">
+                        {uploadResult.invalidStudents.map((s, i) => (
+                          <li key={i} className="px-3 py-2 text-sm">
+                            <span className="font-medium">Row {s.row}:</span>{' '}
+                            {s.name || s.studentId || '—'} — {s.message}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-4 flex gap-3">
+                  <Button onClick={confirmUploadResults}>
+                    Add {uploadResult.validStudents.length} student
+                    {uploadResult.validStudents.length === 1 ? '' : 's'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setUploadResult(null);
+                      setViewMode('excel-upload');
+                    }}
+                  >
+                    Upload another file
+                  </Button>
+                </div>
+              </div>
             )}
           </div>
 

--- a/web/containers/EditCustomGroupView.tsx
+++ b/web/containers/EditCustomGroupView.tsx
@@ -1,9 +1,11 @@
 import { Plus } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Link, useLoaderData, useLocation, useNavigate, useParams } from 'react-router';
 
 import { fetchCustomGroupDetail, updateCustomGroup } from '~/api/client';
 import type { PGApiCustomGroupDetail, PGApiSchoolStudent } from '~/api/types';
+import { ExcelUploadPanel } from '~/components/groups/ExcelUploadPanel';
+import type { ValidateResult } from '~/components/groups/validate-upload-students';
 import {
   Button,
   DropdownMenu,
@@ -29,6 +31,8 @@ export async function loader({
 interface IncomingNavState {
   addedStudents?: PGApiSchoolStudent[];
 }
+
+type ViewMode = 'list' | 'excel-upload' | 'excel-results';
 
 interface DisplayStudent {
   studentId: number;
@@ -57,8 +61,10 @@ const EditCustomGroupView: React.FC = () => {
       }));
 
   const [title, setTitle] = useState(detail.name);
-  const [students] = useState<DisplayStudent[]>(initialStudents);
+  const [students, setStudents] = useState<DisplayStudent[]>(initialStudents);
   const [submitting, setSubmitting] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [uploadResult, setUploadResult] = useState<ValidateResult | null>(null);
 
   const studentCount = students.length;
   const originalIds = detail.students.map((s) => s.studentId).sort((a, b) => a - b);
@@ -84,6 +90,23 @@ const EditCustomGroupView: React.FC = () => {
     }
   }
 
+  const handleUploadResult = useCallback((result: ValidateResult) => {
+    setUploadResult(result);
+    setViewMode('excel-results');
+  }, []);
+
+  function confirmUploadResults() {
+    if (!uploadResult) return;
+    const mapped: DisplayStudent[] = uploadResult.validStudents.map((s) => ({
+      studentId: s.pgStudentId,
+      studentName: s.studentName,
+      className: s.className,
+    }));
+    setStudents((prev) => [...prev, ...mapped]);
+    setUploadResult(null);
+    setViewMode('list');
+  }
+
   return (
     <div className="flex justify-center px-6 py-6">
       <div className="w-full max-w-2xl">
@@ -104,42 +127,108 @@ const EditCustomGroupView: React.FC = () => {
           </p>
 
           <div className="mt-6">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-medium">
-                {studentCount} student{studentCount === 1 ? '' : 's'} added.
-              </p>
-              <DropdownMenu>
-                <DropdownMenuTrigger
-                  render={
-                    <Button variant="secondary">
-                      <Plus className="size-4" aria-hidden />
-                      Add Students
-                    </Button>
-                  }
-                />
-                <DropdownMenuContent>
-                  <DropdownMenuItem
-                    render={
-                      <Link
-                        to={`/groups/customGroups/${groupId}/edit/addStudents`}
-                        state={{ alreadyAdded: students.map((s) => s.studentId) }}
-                      />
-                    }
+            {viewMode === 'list' && (
+              <>
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium">
+                    {studentCount} student{studentCount === 1 ? '' : 's'} added.
+                  </p>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={
+                        <Button variant="secondary">
+                          <Plus className="size-4" aria-hidden />
+                          Add Students
+                        </Button>
+                      }
+                    />
+                    <DropdownMenuContent>
+                      <DropdownMenuItem
+                        render={
+                          <Link
+                            to={`/groups/customGroups/${groupId}/edit/addStudents`}
+                            state={{ alreadyAdded: students.map((s) => s.studentId) }}
+                          />
+                        }
+                      >
+                        Add manually
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        disabled={studentCount > 0}
+                        onClick={() => setViewMode('excel-upload')}
+                      >
+                        Upload via Excel
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                <ul className="mt-2 divide-y rounded-md border">
+                  {students.map((s) => (
+                    <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
+                      <span>{s.studentName}</span>
+                      <span className="text-xs text-muted-foreground">{s.className}</span>
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+
+            {viewMode === 'excel-upload' && (
+              <div>
+                <div className="mb-4 flex items-center justify-between">
+                  <h2 className="text-lg font-medium">Upload via Excel</h2>
+                  <Button variant="ghost" size="sm" onClick={() => setViewMode('list')}>
+                    Cancel
+                  </Button>
+                </div>
+                <ExcelUploadPanel isIhl={false} onResult={handleUploadResult} />
+              </div>
+            )}
+
+            {viewMode === 'excel-results' && uploadResult && (
+              <div>
+                <h2 className="text-lg font-medium">Upload results</h2>
+                <div className="mt-4 space-y-3">
+                  {uploadResult.validStudents.length > 0 && (
+                    <p className="text-sm text-green-700">
+                      {uploadResult.validStudents.length} valid student
+                      {uploadResult.validStudents.length === 1 ? '' : 's'}
+                    </p>
+                  )}
+                  {uploadResult.invalidStudents.length > 0 && (
+                    <div>
+                      <p className="text-sm text-destructive">
+                        {uploadResult.invalidStudents.length} invalid student
+                        {uploadResult.invalidStudents.length === 1 ? '' : 's'}
+                      </p>
+                      <ul className="mt-2 divide-y rounded-md border border-destructive/20">
+                        {uploadResult.invalidStudents.map((s, i) => (
+                          <li key={i} className="px-3 py-2 text-sm">
+                            <span className="font-medium">Row {s.row}:</span>{' '}
+                            {s.name || s.studentId || '—'} — {s.message}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+                <div className="mt-4 flex gap-3">
+                  <Button onClick={confirmUploadResults}>
+                    Add {uploadResult.validStudents.length} student
+                    {uploadResult.validStudents.length === 1 ? '' : 's'}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    onClick={() => {
+                      setUploadResult(null);
+                      setViewMode('excel-upload');
+                    }}
                   >
-                    Add manually
-                  </DropdownMenuItem>
-                  <DropdownMenuItem disabled>Upload via Excel</DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-            <ul className="mt-2 divide-y rounded-md border">
-              {students.map((s) => (
-                <li key={s.studentId} className="flex items-center justify-between p-3 text-sm">
-                  <span>{s.studentName}</span>
-                  <span className="text-xs text-muted-foreground">{s.className}</span>
-                </li>
-              ))}
-            </ul>
+                    Upload another file
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
 
           <div className="mt-8 flex items-center justify-end gap-3">


### PR DESCRIPTION
## Summary
- Add client-side Excel (.xlsx) parsing and validation for custom group student uploads, supporting both MS (Name+Class) and IHL (Student ID) school types
- Validate blank files, missing/duplicate headers, missing values, duplicate entries, max capacity (5000), and duplicate student IDs before calling the server
- Integrate upload flow into Create and Edit custom group views with results screen showing valid/invalid students
- Add BFF mock handlers for the two-step `validateStudents` → `results` polling protocol
- 59 new tests covering validation logic, Excel parsing, API layer, upload panel, and view integration

## Test plan
- [x] 274 frontend tests pass (`pnpm test`)
- [x] Go tests pass (`go test ./...`)
- [x] Lint clean (`pnpm lint`)
- [x] Smoke tested upload flow in browser (mock mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)