### PR TITLE
fix(web): cap schedule date picker to today + 21 days

### DIFF
--- a/web/components/posts/SchedulePickerDialog.tsx
+++ b/web/components/posts/SchedulePickerDialog.tsx
@@ -32,11 +32,11 @@ export interface ScheduleWindow {
 // change, not a code change.
 export const DEFAULT_SCHEDULE_WINDOW: ScheduleWindow = { start: '07:00', end: '21:45' };
 
-// pgw accepts a 15-min minimum lead time and a 30-day maximum. Both are
+// pgw accepts a 15-min minimum lead time and a 21-day maximum. Both are
 // PG-team-confirmable — defaulting here to the provisional values called out
 // in the plan; adjust when PG confirms.
 const MIN_LEAD_MS = 15 * 60 * 1000;
-const MAX_LEAD_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_LEAD_MS = 21 * 24 * 60 * 60 * 1000;
 const SLOT_STEP_MIN = 15;
 const DEFAULT_TIME = '09:00';
 
@@ -165,7 +165,7 @@ export function SchedulePickerDialog({
   const maxDate = useMemo(() => {
     const m = new Date();
     m.setHours(23, 59, 59, 999);
-    m.setDate(m.getDate() + 30);
+    m.setDate(m.getDate() + 21);
     return m;
   }, []);
 


### PR DESCRIPTION
## Summary
- Reduces the schedule post date picker maximum from 30 days to 21 days to match PG's constraint
- Updates both the calendar UI disabled-date range and the `MAX_LEAD_MS` validation constant in `SchedulePickerDialog.tsx`

Closes #51

## Test plan
- [x] Open the schedule post dialog and verify the calendar only allows dates up to 21 days from today
- [x] Confirm dates beyond 21 days are greyed out / unselectable
- [x] Verify selecting a date at the boundary (day 21) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)