### PR TITLE
fix(web): filter past time slots in schedule picker when today is selected

### DIFF
--- a/web/components/posts/SchedulePickerDialog.test.tsx
+++ b/web/components/posts/SchedulePickerDialog.test.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_SCHEDULE_WINDOW,
   SchedulePickerDialog,
   buildTimeSlots,
+  filterPastSlots,
 } from './SchedulePickerDialog';
 
 describe('buildTimeSlots', () => {
@@ -44,6 +45,33 @@ describe('buildTimeSlots', () => {
     const slots = buildTimeSlots({ start: '12:00', end: '13:00' });
     expect(slots[0]).toEqual({ value: '12:00', label: '12:00 PM' });
     expect(slots[slots.length - 1]).toEqual({ value: '13:00', label: '1:00 PM' });
+  });
+});
+
+describe('filterPastSlots', () => {
+  const allSlots = buildTimeSlots(DEFAULT_SCHEDULE_WINDOW);
+
+  it('removes slots within 15-min lead of current time', () => {
+    // 16:16 + 15 = 16:31 → ceil(991/15)*15 = 67*15 = 1005 min = 16:45
+    const filtered = filterPastSlots(allSlots, '16:16');
+    expect(filtered[0].value).toBe('16:45');
+    expect(filtered.every((s) => s.value >= '16:45')).toBe(true);
+  });
+
+  it('rounds cutoff up to the next 15-min slot boundary', () => {
+    // 16:28 + 15 = 16:43 → ceil(1003/15)*15 = 67*15 = 1005 min = 16:45
+    const filtered = filterPastSlots(allSlots, '16:28');
+    expect(filtered[0].value).toBe('16:45');
+  });
+
+  it('returns all slots when current time is before the window start minus lead', () => {
+    const filtered = filterPastSlots(allSlots, '06:00');
+    expect(filtered).toEqual(allSlots);
+  });
+
+  it('returns empty when current time is past the window end', () => {
+    const filtered = filterPastSlots(allSlots, '21:45');
+    expect(filtered).toEqual([]);
   });
 });
 

--- a/web/components/posts/SchedulePickerDialog.tsx
+++ b/web/components/posts/SchedulePickerDialog.tsx
@@ -1,5 +1,5 @@
 import { CalendarClock } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import {
   Button,
@@ -48,6 +48,16 @@ function toMinuteOfDay(hhmm: string): number {
 function isTimeInWindow(time: string, window: ScheduleWindow): boolean {
   const t = toMinuteOfDay(time);
   return t >= toMinuteOfDay(window.start) && t <= toMinuteOfDay(window.end);
+}
+
+export function filterPastSlots(
+  slots: { value: string; label: string }[],
+  currentTime: string,
+): { value: string; label: string }[] {
+  const nowMin = toMinuteOfDay(currentTime);
+  const leadMin = MIN_LEAD_MS / 60_000;
+  const cutoffSlot = Math.ceil((nowMin + leadMin) / SLOT_STEP_MIN) * SLOT_STEP_MIN;
+  return slots.filter((slot) => toMinuteOfDay(slot.value) >= cutoffSlot);
 }
 
 export function buildTimeSlots(window: ScheduleWindow): { value: string; label: string }[] {
@@ -133,6 +143,41 @@ export function SchedulePickerDialog({
 
   const slots = useMemo(() => buildTimeSlots(scheduleWindow), [scheduleWindow]);
 
+  const today = useMemo(() => {
+    const t = new Date();
+    t.setHours(0, 0, 0, 0);
+    return t;
+  }, []);
+
+  const maxDate = useMemo(() => {
+    const m = new Date();
+    m.setHours(23, 59, 59, 999);
+    m.setDate(m.getDate() + 21);
+    return m;
+  }, []);
+
+  const filteredSlots = useMemo(() => {
+    if (!date) return slots;
+    const isToday =
+      date.getFullYear() === today.getFullYear() &&
+      date.getMonth() === today.getMonth() &&
+      date.getDate() === today.getDate();
+    if (!isToday) return slots;
+    const sgtNow = new Intl.DateTimeFormat('en-GB', {
+      timeZone: 'Asia/Singapore',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(new Date());
+    return filterPastSlots(slots, sgtNow);
+  }, [date, today, slots]);
+
+  useEffect(() => {
+    if (date && filteredSlots.length > 0 && !filteredSlots.some((s) => s.value === time)) {
+      setTime(filteredSlots[0].value);
+    }
+  }, [date, filteredSlots, time]);
+
   const scheduledSendAt = useMemo(() => {
     if (!date) return null;
     return toSgtIso(date, time);
@@ -155,19 +200,6 @@ export function SchedulePickerDialog({
     }
     return { ok: true as const };
   }, [scheduledSendAt, time, scheduleWindow]);
-
-  const today = useMemo(() => {
-    const t = new Date();
-    t.setHours(0, 0, 0, 0);
-    return t;
-  }, []);
-
-  const maxDate = useMemo(() => {
-    const m = new Date();
-    m.setHours(23, 59, 59, 999);
-    m.setDate(m.getDate() + 21);
-    return m;
-  }, []);
 
   function handleConfirm() {
     if (!scheduledSendAt || !validation.ok) return;
@@ -215,7 +247,7 @@ export function SchedulePickerDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {slots.map((slot) => (
+                  {filteredSlots.map((slot) => (
                     <SelectItem key={slot.value} value={slot.value}>
                       {slot.label}
                     </SelectItem>


### PR DESCRIPTION
## Summary
- When today is selected in the schedule date picker, the time dropdown now filters out past time slots (those within the 15-minute minimum lead time), matching PG behaviour
- Auto-selects the earliest available slot if the current selection falls outside the filtered list
- Adds `filterPastSlots` helper with unit tests

Closes #50

## Test plan
- [x] Open the schedule picker dialog and select today — verify only future time slots (>= now + 15 min, rounded to next 15-min boundary) are shown
- [x] Select a future date — verify all time slots in the window are shown
- [ ] Switch from a future date back to today — verify past slots are removed and time auto-adjusts
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)