### PR TITLE
fix(web): add char limit validation to custom question fields

### DIFF
--- a/web/components/posts/QuestionBuilder.tsx
+++ b/web/components/posts/QuestionBuilder.tsx
@@ -6,6 +6,8 @@ import type { FormQuestion } from '~/data/mock-pg-announcements';
 import { cn } from '~/lib/utils';
 
 export const MAX_QUESTIONS = 5;
+export const MAX_QUESTION_TEXT_LENGTH = 120;
+export const MAX_QUESTION_DESCRIPTION_LENGTH = 250;
 const MIN_MCQ_OPTIONS = 2;
 const MAX_MCQ_OPTIONS = 6;
 
@@ -40,31 +42,43 @@ function QuestionBuilder({ questions, dispatch }: QuestionBuilderProps) {
         <div key={question.id} className="space-y-3 rounded-xl border p-4">
           <div className="flex items-start gap-2">
             <div className="flex-1 space-y-2">
-              <Input
-                placeholder={`Question ${index + 1}`}
-                value={question.text}
-                onChange={(e) =>
-                  dispatch({
-                    type: 'UPDATE_QUESTION',
-                    id: question.id,
-                    payload: { text: e.target.value },
-                  })
-                }
-              />
+              <div className="space-y-1">
+                <Input
+                  placeholder={`Question ${index + 1}`}
+                  value={question.text}
+                  maxLength={MAX_QUESTION_TEXT_LENGTH}
+                  onChange={(e) =>
+                    dispatch({
+                      type: 'UPDATE_QUESTION',
+                      id: question.id,
+                      payload: { text: e.target.value },
+                    })
+                  }
+                />
+                <span className="block text-right text-xs text-muted-foreground tabular-nums">
+                  {question.text.length}/{MAX_QUESTION_TEXT_LENGTH}
+                </span>
+              </div>
 
-              <Textarea
-                placeholder="Helper text (optional)"
-                value={question.description ?? ''}
-                rows={2}
-                className="resize-none text-sm"
-                onChange={(e) =>
-                  dispatch({
-                    type: 'UPDATE_QUESTION',
-                    id: question.id,
-                    payload: { description: e.target.value || undefined },
-                  })
-                }
-              />
+              <div className="space-y-1">
+                <Textarea
+                  placeholder="Helper text (optional)"
+                  value={question.description ?? ''}
+                  rows={2}
+                  maxLength={MAX_QUESTION_DESCRIPTION_LENGTH}
+                  className="resize-none text-sm"
+                  onChange={(e) =>
+                    dispatch({
+                      type: 'UPDATE_QUESTION',
+                      id: question.id,
+                      payload: { description: e.target.value || undefined },
+                    })
+                  }
+                />
+                <span className="block text-right text-xs text-muted-foreground tabular-nums">
+                  {(question.description ?? '').length}/{MAX_QUESTION_DESCRIPTION_LENGTH}
+                </span>
+              </div>
 
               <div className="flex items-center gap-2">
                 <Button

--- a/web/containers/CreatePostView.validation.test.tsx
+++ b/web/containers/CreatePostView.validation.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { SelectedEntity } from '~/components/comms/entity-selector';
-import type { ReminderConfig } from '~/data/mock-pg-announcements';
+import type { FormQuestion, ReminderConfig } from '~/data/mock-pg-announcements';
 
 import { isCreatePostFormValid } from './createPostValidation';
 import type { PostFormState } from './CreatePostView';
@@ -87,5 +87,41 @@ describe('isCreatePostFormValid — post-with-response (form)', () => {
     // PGW allows NONE as a valid reminder choice.
     const reminder: ReminderConfig = { type: 'NONE' };
     expect(isCreatePostFormValid({ ...formBase, reminder }, 'post-with-response')).toBe(true);
+  });
+
+  const question: FormQuestion = { id: '1', text: 'Favourite colour?', type: 'free-text' };
+
+  it('passes with valid custom questions', () => {
+    expect(
+      isCreatePostFormValid({ ...formBase, questions: [question] }, 'post-with-response'),
+    ).toBe(true);
+  });
+
+  it('fails when question text exceeds 120 characters', () => {
+    const long: FormQuestion = { ...question, text: 'a'.repeat(121) };
+    expect(isCreatePostFormValid({ ...formBase, questions: [long] }, 'post-with-response')).toBe(
+      false,
+    );
+  });
+
+  it('passes when question text is exactly 120 characters', () => {
+    const atLimit: FormQuestion = { ...question, text: 'a'.repeat(120) };
+    expect(isCreatePostFormValid({ ...formBase, questions: [atLimit] }, 'post-with-response')).toBe(
+      true,
+    );
+  });
+
+  it('fails when question description exceeds 250 characters', () => {
+    const long: FormQuestion = { ...question, description: 'a'.repeat(251) };
+    expect(isCreatePostFormValid({ ...formBase, questions: [long] }, 'post-with-response')).toBe(
+      false,
+    );
+  });
+
+  it('passes when question description is exactly 250 characters', () => {
+    const atLimit: FormQuestion = { ...question, description: 'a'.repeat(250) };
+    expect(isCreatePostFormValid({ ...formBase, questions: [atLimit] }, 'post-with-response')).toBe(
+      true,
+    );
   });
 });

--- a/web/containers/createPostValidation.ts
+++ b/web/containers/createPostValidation.ts
@@ -1,4 +1,8 @@
 import type { PostKind } from '~/components/posts/PostTypePicker';
+import {
+  MAX_QUESTION_DESCRIPTION_LENGTH,
+  MAX_QUESTION_TEXT_LENGTH,
+} from '~/components/posts/QuestionBuilder';
 
 import type { PostFormState } from './CreatePostView';
 
@@ -55,6 +59,12 @@ export function isCreatePostFormValid(
     const min = addDaysIso(today, 1);
     const max = addDaysIso(state.dueDate, -1);
     if (r < min || r > max) return false;
+  }
+
+  // Gate 4: custom-question character limits (PG enforces 120 / 250).
+  for (const q of state.questions) {
+    if (q.text.length > MAX_QUESTION_TEXT_LENGTH) return false;
+    if ((q.description ?? '').length > MAX_QUESTION_DESCRIPTION_LENGTH) return false;
   }
 
   return true;


### PR DESCRIPTION
## Summary
- Add 120-char limit on custom question text and 250-char limit on helper text (description), matching PG's validation
- Add `maxLength` + character counters to `QuestionBuilder` inputs (same pattern as title/venue fields)
- Add form-level validation in `isCreatePostFormValid` so the submit button disables when limits are exceeded
- Add unit tests for boundary conditions (at limit, over limit)

Closes #45

> **Note:** The 120/250 limits are based on the PG screenshot in the issue. Since we run in mock mode, these have not been verified against actual PGW FE/BE validation. Cross-check with the PGW codebase before merging.

## Test plan
- [ ] Verify question text input stops at 120 characters and shows counter
- [ ] Verify helper text textarea stops at 250 characters and shows counter
- [ ] Verify submit button disables if limits are somehow exceeded
- [ ] Cross-check char limits against PGW FE/BE codebase (mock mode — can't test live)
- [ ] `pnpm test` passes (5 new validation tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)