### PR TITLE
feat: create post UX polish — validation, spacing, event conflicts, question preview nav

### DIFF
--- a/web/components/posts/AttachmentSection.tsx
+++ b/web/components/posts/AttachmentSection.tsx
@@ -490,7 +490,7 @@ function DropZoneButton({
         e.preventDefault();
         if (e.dataTransfer.files.length > 0) onDrop(e.dataTransfer.files);
       }}
-      className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-muted-foreground/25 py-7 text-muted-foreground transition-colors hover:border-muted-foreground/50 hover:bg-muted/30"
+      className="flex cursor-pointer flex-col items-center justify-center gap-1.5 rounded-xl border-2 border-dashed border-muted-foreground/25 py-4 text-muted-foreground transition-colors hover:border-muted-foreground/50 hover:bg-muted/30"
     >
       {icon}
       <p className="text-sm">Drop {label} here or click to add more</p>

--- a/web/components/posts/EventScheduleSection.tsx
+++ b/web/components/posts/EventScheduleSection.tsx
@@ -1,5 +1,5 @@
 import { CalendarIcon } from 'lucide-react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import {
   Calendar,
@@ -38,6 +38,22 @@ function buildTimeSlots(): { value: string; label: string }[] {
 }
 
 const TIME_SLOTS = buildTimeSlots();
+
+/** Advance a HH:MM time by 30 minutes, capped at 23:30. */
+function nextSlot(time: string): string {
+  const [hStr, mStr] = time.split(':');
+  const totalMin = Number(hStr) * 60 + Number(mStr) + 30;
+  if (totalMin >= 24 * 60) return '23:30';
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/** Return true when both datetimes are fully set and start ≥ end. */
+function hasConflict(sDate: string, sTime: string, eDate: string, eTime: string): boolean {
+  if (!sDate || !eDate || !sTime || !eTime) return false;
+  return `${sDate}T${sTime}` >= `${eDate}T${eTime}`;
+}
 
 /** Split a `YYYY-MM-DDTHH:MM` string into its date and time parts. */
 function splitDatetime(dt: string): { date: string; time: string } {
@@ -86,21 +102,50 @@ function EventScheduleSection({ value, onChange }: EventScheduleSectionProps) {
   // Min date for end calendar = start date (end cannot be before start).
   const endMinDate = startDateObj ?? today;
 
+  // Show an error when the user manually picks an end time that conflicts.
+  const [endTimeError, setEndTimeError] = useState(false);
+
+  // Derived conflict state (drives persistent error display).
+  const conflict = hasConflict(startDate, startTime, endDate, endTime);
+
   function handleStartDateChange(dateStr: string) {
-    // Only update the date; keep existing time (or leave empty if none chosen yet).
     const start = startTime ? `${dateStr}T${startTime}` : dateStr;
-    onChange({ start, end: value?.end ?? '', venue: value?.venue });
+    let end = value?.end ?? '';
+
+    // If new start date is after current end date, clear end entirely.
+    if (endDate && dateStr > endDate) {
+      end = '';
+      setEndTimeError(false);
+    } else if (endDate && dateStr === endDate && startTime && endTime && startTime >= endTime) {
+      // Same day — advance end time to avoid conflict.
+      const bumped = nextSlot(startTime);
+      end = `${endDate}T${bumped}`;
+      setEndTimeError(false);
+    }
+
+    onChange({ start, end, venue: value?.venue });
   }
 
   function handleStartTimeChange(time: string) {
-    if (!startDate) return; // date must be chosen first
+    if (!startDate) return;
     const start = `${startDate}T${time}`;
-    onChange({ start, end: value?.end ?? '', venue: value?.venue });
+    let end = value?.end ?? '';
+
+    // Same day and new start time would conflict → advance end time.
+    if (endDate && startDate === endDate && endTime && time >= endTime) {
+      const bumped = nextSlot(time);
+      end = `${endDate}T${bumped}`;
+      setEndTimeError(false);
+    }
+
+    onChange({ start, end, venue: value?.venue });
   }
 
   function handleEndDateChange(dateStr: string) {
     const end = endTime ? `${dateStr}T${endTime}` : dateStr;
     const start = value?.start ?? '';
+    // Clear any lingering end-time error since date changed.
+    setEndTimeError(false);
     onChange({ start: start || end, end, venue: value?.venue });
   }
 
@@ -108,6 +153,8 @@ function EventScheduleSection({ value, onChange }: EventScheduleSectionProps) {
     if (!endDate) return;
     const end = `${endDate}T${time}`;
     const start = value?.start ?? '';
+    // Flag conflict — don't auto-correct here so user sees their pick.
+    setEndTimeError(hasConflict(startDate, startTime, endDate, time));
     onChange({ start: start || end, end, venue: value?.venue });
   }
 
@@ -199,7 +246,10 @@ function EventScheduleSection({ value, onChange }: EventScheduleSectionProps) {
               }}
               disabled={!startDate}
             >
-              <SelectTrigger className="w-[120px] shrink-0">
+              <SelectTrigger
+                className="w-[120px] shrink-0"
+                aria-invalid={endTimeError || conflict ? true : undefined}
+              >
                 <SelectValue placeholder="Time" />
               </SelectTrigger>
               <SelectContent>
@@ -213,6 +263,12 @@ function EventScheduleSection({ value, onChange }: EventScheduleSectionProps) {
           </div>
         </div>
       </div>
+
+      {conflict && (
+        <p role="alert" className="text-sm text-destructive">
+          End date &amp; time must be after the start.
+        </p>
+      )}
     </div>
   );
 }

--- a/web/components/posts/PostPreview.tsx
+++ b/web/components/posts/PostPreview.tsx
@@ -216,6 +216,9 @@ const PostPreview = React.memo(function PostPreview({
   // chevron. Reset to false whenever focusSection transitions *into* 'questions'
   // from a different section so re-focusing the builder brings the view back.
   const [questionViewDismissed, setQuestionViewDismissed] = useState(false);
+  // True when the parent-side "Yes" button was tapped in the preview — triggers
+  // the question flow independently of the teacher's current focus section.
+  const [yesClicked, setYesClicked] = useState(false);
   // Which question the preview is currently showing (can diverge from
   // focusQuestionIndex when the teacher navigates with the chrome arrows).
   const [activeQuestionIndex, setActiveQuestionIndex] = useState(focusQuestionIndex);
@@ -231,10 +234,19 @@ const PostPreview = React.memo(function PostPreview({
     setActiveQuestionIndex(focusQuestionIndex);
   }, [focusQuestionIndex]);
 
-  // True when the teacher is focused on the custom-questions builder, at least
-  // one question exists, and they haven't tapped the back chevron to dismiss.
+  // Shared dismiss helper — clears both dismiss paths.
+  const dismissQuestionView = () => {
+    setQuestionViewDismissed(true);
+    setYesClicked(false);
+  };
+
+  // True when: (a) teacher is focused on the questions builder and hasn't
+  // dismissed, OR (b) the preview "Yes" button was tapped. Both paths require
+  // at least one question to exist.
   const showQuestionView =
-    isForm && focusSection === 'questions' && questions.length > 0 && !questionViewDismissed;
+    isForm &&
+    questions.length > 0 &&
+    ((focusSection === 'questions' && !questionViewDismissed) || yesClicked);
 
   // Scroll the preview pane to the relevant section whenever the teacher's
   // focus moves to a different part of the form.
@@ -257,7 +269,7 @@ const PostPreview = React.memo(function PostPreview({
               type="button"
               aria-label="Back to post"
               className="flex items-center justify-center"
-              onClick={() => setQuestionViewDismissed(true)}
+              onClick={dismissQuestionView}
             >
               <ChevronLeft className="h-4 w-4 text-foreground" strokeWidth={2} />
             </button>
@@ -278,7 +290,7 @@ const PostPreview = React.memo(function PostPreview({
                     if (activeQuestionIndex > 0) {
                       setActiveQuestionIndex((i) => i - 1);
                     } else {
-                      setQuestionViewDismissed(true);
+                      dismissQuestionView();
                     }
                   }}
                 >
@@ -521,8 +533,18 @@ const PostPreview = React.memo(function PostPreview({
                 {responseType === 'yes-no' && (
                   <div className="flex shrink-0 gap-1.5">
                     <button
-                      disabled
-                      className="rounded-full bg-muted px-3 py-1.5 text-[11px] font-medium text-foreground"
+                      type="button"
+                      className={cn(
+                        'rounded-full bg-muted px-3 py-1.5 text-[11px] font-medium text-foreground',
+                        questions.length > 0 ? 'cursor-pointer' : 'cursor-default',
+                      )}
+                      onClick={() => {
+                        if (questions.length > 0) {
+                          setYesClicked(true);
+                          setQuestionViewDismissed(false);
+                          setActiveQuestionIndex(0);
+                        }
+                      }}
                     >
                       Yes
                     </button>

--- a/web/components/posts/PostPreview.tsx
+++ b/web/components/posts/PostPreview.tsx
@@ -537,7 +537,6 @@ const PostPreview = React.memo(function PostPreview({
                       onClick={() => {
                         if (questions.length > 0) {
                           setYesClicked(true);
-                          setQuestionViewDismissed(false);
                           setActiveQuestionIndex(0);
                         }
                       }}

--- a/web/components/posts/PostPreview.tsx
+++ b/web/components/posts/PostPreview.tsx
@@ -125,14 +125,14 @@ function QuestionScreen({
         )}
       </div>
 
-      {/* Submit button */}
+      {/* Next / Submit button */}
       <div className="shrink-0 px-5 pt-3 pb-5">
         <button
           disabled
           type="button"
           className="w-full rounded-full bg-foreground py-3 text-sm font-semibold text-background"
         >
-          Submit
+          {current < total ? 'Next' : 'Submit'}
         </button>
       </div>
     </div>
@@ -263,9 +263,15 @@ const PostPreview = React.memo(function PostPreview({
           {showQuestionView ? (
             <button
               type="button"
-              aria-label="Back to post"
+              aria-label={activeQuestionIndex > 0 ? 'Previous question' : 'Back to post'}
               className="flex items-center justify-center"
-              onClick={dismissQuestionView}
+              onClick={() => {
+                if (activeQuestionIndex > 0) {
+                  setActiveQuestionIndex((i) => i - 1);
+                } else {
+                  dismissQuestionView();
+                }
+              }}
             >
               <ChevronLeft className="h-4 w-4 text-foreground" strokeWidth={2} />
             </button>

--- a/web/components/posts/PostPreview.tsx
+++ b/web/components/posts/PostPreview.tsx
@@ -17,6 +17,7 @@ import {
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
 import type { PostFormState, UploadingFile } from '~/containers/CreatePostView';
+import type { FormQuestion } from '~/data/mock-pg-announcements';
 import { formatFileSize } from '~/helpers/attachments';
 import { formatDateTime, formatLocalDate, formatLocalDateTimeRange } from '~/helpers/dateTime';
 import { createRichTextExtensions, extractTextFromTiptap } from '~/helpers/tiptap';
@@ -47,6 +48,88 @@ interface PostPreviewProps {
   currentUserName?: string;
   defaultEnquiryEmail?: string;
   focusSection?: PreviewFocusSection;
+  /** 0-based index of the question card currently being edited. */
+  focusQuestionIndex?: number;
+}
+
+/**
+ * Full-screen question-answer view shown inside the phone chrome when the
+ * teacher's focus is on the Custom Questions builder. Matches the PG app's
+ * parent-facing answer UI: progress bar, question text, answer area, submit.
+ */
+function QuestionScreen({
+  questions,
+  activeIndex,
+}: {
+  questions: FormQuestion[];
+  activeIndex: number;
+}) {
+  const safeIndex = Math.max(0, Math.min(activeIndex, questions.length - 1));
+  const q = questions[safeIndex]!;
+  const total = questions.length;
+  const current = safeIndex + 1;
+
+  return (
+    <div className="flex flex-1 flex-col bg-white pt-10">
+      {/* Progress + label */}
+      <div className="px-5 pt-4">
+        <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted">
+          <div className="h-full bg-foreground" style={{ width: `${(current / total) * 100}%` }} />
+        </div>
+        <p className="mt-1.5 text-[10px] text-muted-foreground">
+          Q{current} of {total}
+        </p>
+      </div>
+
+      {/* Question text + optional helper */}
+      <div className="mt-5 space-y-1 px-5">
+        <p className="text-sm leading-snug font-semibold">{q.text || 'Untitled question'}</p>
+        {q.description && (
+          <p className="text-xs leading-snug text-muted-foreground">{q.description}</p>
+        )}
+      </div>
+
+      {/* Answer area */}
+      <div className="mt-4 flex-1 overflow-y-auto px-5">
+        {q.type === 'free-text' ? (
+          <div className="relative min-h-[120px] rounded-xl border bg-background p-3">
+            <p className="text-xs text-muted-foreground/50">Type your answer here...</p>
+            <p className="absolute right-3 bottom-2 text-[10px] text-muted-foreground">
+              500 characters left
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {q.options.map((opt, oi) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <li
+                key={oi}
+                className="flex items-center gap-3 rounded-xl border bg-background px-4 py-3"
+              >
+                <span className="h-4 w-4 shrink-0 rounded-full border border-muted-foreground/40" />
+                <span
+                  className={cn('text-sm', opt ? 'text-foreground' : 'text-muted-foreground/50')}
+                >
+                  {opt || `Option ${oi + 1}`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Submit button */}
+      <div className="shrink-0 px-5 pt-3 pb-5">
+        <button
+          disabled
+          type="button"
+          className="w-full rounded-full bg-foreground py-3 text-sm font-semibold text-background"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  );
 }
 
 const PostPreview = React.memo(function PostPreview({
@@ -54,6 +137,7 @@ const PostPreview = React.memo(function PostPreview({
   currentUserName = 'Daniel Tan',
   defaultEnquiryEmail = 'enquiry@school.edu.sg',
   focusSection,
+  focusQuestionIndex = 0,
 }: PostPreviewProps) {
   const {
     kind,
@@ -128,6 +212,30 @@ const PostPreview = React.memo(function PostPreview({
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
+  // Tracks whether the teacher dismissed the question view by tapping the back
+  // chevron. Reset to false whenever focusSection transitions *into* 'questions'
+  // from a different section so re-focusing the builder brings the view back.
+  const [questionViewDismissed, setQuestionViewDismissed] = useState(false);
+  // Which question the preview is currently showing (can diverge from
+  // focusQuestionIndex when the teacher navigates with the chrome arrows).
+  const [activeQuestionIndex, setActiveQuestionIndex] = useState(focusQuestionIndex);
+  const prevFocusRef = useRef(focusSection);
+  useEffect(() => {
+    if (prevFocusRef.current !== 'questions' && focusSection === 'questions') {
+      setQuestionViewDismissed(false);
+    }
+    prevFocusRef.current = focusSection;
+  }, [focusSection]);
+  // Sync preview to whichever question card the teacher just focused.
+  useEffect(() => {
+    setActiveQuestionIndex(focusQuestionIndex);
+  }, [focusQuestionIndex]);
+
+  // True when the teacher is focused on the custom-questions builder, at least
+  // one question exists, and they haven't tapped the back chevron to dismiss.
+  const showQuestionView =
+    isForm && focusSection === 'questions' && questions.length > 0 && !questionViewDismissed;
+
   // Scroll the preview pane to the relevant section whenever the teacher's
   // focus moves to a different part of the form.
   useEffect(() => {
@@ -144,271 +252,299 @@ const PostPreview = React.memo(function PostPreview({
       <div className="relative flex h-[580px] flex-col overflow-hidden rounded-[1.75rem] border-[7px] border-[#1a1f2e] bg-white">
         {/* Mobile chrome — always a frosted white bar so icons stay readable over any content */}
         <div className="absolute inset-x-0 top-0 z-10 flex shrink-0 items-center justify-between rounded-t-[1.3rem] bg-white px-4 py-2.5">
-          <ChevronLeft className="h-4 w-4 text-foreground" strokeWidth={2} />
+          {showQuestionView ? (
+            <button
+              type="button"
+              aria-label="Back to post"
+              className="flex items-center justify-center"
+              onClick={() => setQuestionViewDismissed(true)}
+            >
+              <ChevronLeft className="h-4 w-4 text-foreground" strokeWidth={2} />
+            </button>
+          ) : (
+            <ChevronLeft className="h-4 w-4 text-foreground" strokeWidth={2} />
+          )}
           <div className="flex items-center gap-3 text-foreground">
-            <ArrowUp className="h-4 w-4" strokeWidth={2} />
-            <ArrowDown className="h-4 w-4" strokeWidth={2} />
+            {showQuestionView ? (
+              <>
+                <button
+                  type="button"
+                  aria-label="Previous question"
+                  className={cn(
+                    'flex items-center justify-center',
+                    activeQuestionIndex === 0 ? 'opacity-30' : 'cursor-pointer',
+                  )}
+                  onClick={() => {
+                    if (activeQuestionIndex > 0) {
+                      setActiveQuestionIndex((i) => i - 1);
+                    } else {
+                      setQuestionViewDismissed(true);
+                    }
+                  }}
+                >
+                  <ArrowUp className="h-4 w-4" strokeWidth={2} />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next question"
+                  className={cn(
+                    'flex items-center justify-center',
+                    activeQuestionIndex >= questions.length - 1
+                      ? 'cursor-not-allowed opacity-30'
+                      : 'cursor-pointer',
+                  )}
+                  disabled={activeQuestionIndex >= questions.length - 1}
+                  onClick={() => setActiveQuestionIndex((i) => i + 1)}
+                >
+                  <ArrowDown className="h-4 w-4" strokeWidth={2} />
+                </button>
+              </>
+            ) : (
+              <>
+                <ArrowUp className="h-4 w-4" strokeWidth={2} />
+                <ArrowDown className="h-4 w-4" strokeWidth={2} />
+              </>
+            )}
             <MoreHorizontal className="h-4 w-4" strokeWidth={2} />
           </div>
         </div>
 
-        {/* pt-10 reserves space for the absolute chrome bar when there's no hero photo overlay */}
-        <div
-          ref={scrollContainerRef}
-          className={cn('flex flex-1 flex-col overflow-y-auto', !heroPhoto && 'pt-10')}
-        >
-          {/* Hero photo — full width, overlapped by chrome above, click to open gallery */}
-          {heroPhoto && (
-            <button
-              type="button"
-              className="group relative shrink-0 cursor-pointer overflow-hidden border-0 p-0"
-              onClick={() => {
-                setGalleryOpen(true);
-                setGalleryIndex(0);
-              }}
-              aria-label="Open photo gallery"
-            >
-              <PreviewPhoto photo={heroPhoto} large />
-              {/* Badge: bottom-right, zoom-in icon + count */}
-              {readyPhotos.length > 1 && (
-                <div className="absolute right-3 bottom-3 flex items-center gap-1.5 rounded-full bg-black/65 px-3 py-1.5 text-[13px] font-semibold text-white backdrop-blur-sm">
-                  <ZoomIn className="h-4 w-4" strokeWidth={2} />
-                  {readyPhotos.length} photos
-                </div>
-              )}
-            </button>
-          )}
-
-          {/* Padded content below the photo */}
-          <div className="flex flex-1 flex-col px-5 pb-5">
-            <div data-section="header" className="space-y-0.5 pt-4">
-              <p className={`text-lg leading-tight font-semibold ${dimmedWhenEmpty}`}>
-                {title || titlePlaceholder}
-              </p>
-              <p className="text-[11px] text-muted-foreground">
-                {timestamp} · {currentUserName.toUpperCase()}
-              </p>
-            </div>
-
+        {/* ── Question-answer view (replaces scroll area when questions section is focused) ── */}
+        {showQuestionView ? (
+          <QuestionScreen questions={questions} activeIndex={activeQuestionIndex} />
+        ) : (
+          <>
+            {/* pt-10 reserves space for the absolute chrome bar when there's no hero photo overlay */}
             <div
-              className={`mt-2 flex items-center gap-1.5 text-[11px] font-medium tracking-wider uppercase ${
-                recipientSummary ? 'text-foreground' : 'text-muted-foreground/60'
-              }`}
+              ref={scrollContainerRef}
+              className={cn('flex flex-1 flex-col overflow-y-auto', !heroPhoto && 'pt-10')}
             >
-              <User className="h-3 w-3" strokeWidth={2.25} />
-              {recipientSummary ?? 'STUDENT NAME'}
-            </div>
-
-            {/* Venue + event range — inline rows directly under student name, matching PG app */}
-            {isForm && venue && (
-              <div className="mt-1 flex items-start gap-1.5 text-[11px] text-foreground">
-                <MapPin className="mt-px h-3 w-3 shrink-0 text-muted-foreground" strokeWidth={2} />
-                <span>{venue}</span>
-              </div>
-            )}
-            {isForm && eventRange && (
-              <div className="mt-1 flex items-start gap-1.5 text-[11px] font-medium text-primary">
-                <CalendarClock className="mt-px h-3 w-3 shrink-0 text-primary" strokeWidth={2} />
-                <span>{eventRange}</span>
-              </div>
-            )}
-
-            <div className="mt-4 border-t border-border/40" />
-
-            <div data-section="content" className="mt-4 space-y-2">
-              <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
-                Details
-              </p>
-              {descriptionHtml ? (
-                <div
-                  className="rich-content"
-                  // `generateHTML` serializes a trusted Tiptap schema; Link is
-                  // constrained to http/https/mailto via createRichTextExtensions.
-                  dangerouslySetInnerHTML={{ __html: descriptionHtml }}
-                />
-              ) : description ? (
-                <p className="text-sm whitespace-pre-wrap text-foreground">{description}</p>
-              ) : (
-                <p className="text-sm text-muted-foreground/60">{descriptionPlaceholder}</p>
-              )}
-            </div>
-
-            {/* Shortcuts — divider + tall button rows with trailing chevron, matching PG app */}
-            {enabledShortcuts.length > 0 && (
-              <>
-                <div className="mt-4 border-t border-border/40" />
-                <div data-section="shortcuts" className="mt-4 space-y-2.5">
-                  <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
-                    Shortcuts
-                  </p>
-                  <ul className="space-y-2">
-                    {enabledShortcuts.map((key) => {
-                      const meta = SHORTCUT_PREVIEW[key]!;
-                      return (
-                        <li
-                          key={key}
-                          className="flex items-center gap-3 rounded-2xl border bg-background px-4 py-3.5"
-                        >
-                          <span className="text-lg leading-none">{meta.emoji}</span>
-                          <span className="flex-1 text-sm font-medium">{meta.label}</span>
-                          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              </>
-            )}
-
-            {/* Links — divider + tall button rows: title bold + URL below in blue */}
-            {validLinks.length > 0 && (
-              <>
-                <div className="mt-4 border-t border-border/40" />
-                <div data-section="links" className="mt-4 space-y-2.5">
-                  <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
-                    Links
-                  </p>
-                  <ul className="space-y-2">
-                    {validLinks.map((link, i) => (
-                      // eslint-disable-next-line react/no-array-index-key
-                      <li
-                        key={i}
-                        className="flex items-center gap-3 rounded-2xl border bg-background px-4 py-3.5"
-                      >
-                        <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-medium">
-                            {link.title.trim() || link.url.trim() || 'Untitled link'}
-                          </p>
-                          {link.url.trim() && link.title.trim() && (
-                            <p className="truncate text-xs text-primary">{link.url.trim()}</p>
-                          )}
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </>
-            )}
-
-            {/* Attachments — divider + tall button rows: filename bold + size below */}
-            {readyAttachments.length > 0 && (
-              <>
-                <div className="mt-4 border-t border-border/40" />
-                <div data-section="attachments" className="mt-4 space-y-2.5">
-                  <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
-                    Attachments
-                  </p>
-                  <ul className="space-y-2">
-                    {readyAttachments.map((f) => (
-                      <li
-                        key={f.localId}
-                        className="flex items-center gap-3 rounded-2xl border bg-background px-4 py-3.5"
-                      >
-                        <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-medium">{f.name}</p>
-                          <p className="text-xs text-muted-foreground">{formatFileSize(f.size)}</p>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              </>
-            )}
-
-            {questions.length > 0 && (
-              <div data-section="questions" className="mt-5 space-y-4 border-t pt-4">
-                {questions.map((q, i) => (
-                  <div key={q.id} className="space-y-2">
-                    {/* Question label */}
-                    <div>
-                      <p className="text-sm font-semibold">
-                        <span className="text-destructive">* </span>
-                        {i + 1}. {q.text || 'Untitled question'}
-                      </p>
-                      {q.description && (
-                        <p className="mt-0.5 text-xs text-muted-foreground">{q.description}</p>
-                      )}
+              {/* Hero photo — full width, overlapped by chrome above, click to open gallery */}
+              {heroPhoto && (
+                <button
+                  type="button"
+                  className="group relative shrink-0 cursor-pointer overflow-hidden border-0 p-0"
+                  onClick={() => {
+                    setGalleryOpen(true);
+                    setGalleryIndex(0);
+                  }}
+                  aria-label="Open photo gallery"
+                >
+                  <PreviewPhoto photo={heroPhoto} large />
+                  {/* Badge: bottom-right, zoom-in icon + count */}
+                  {readyPhotos.length > 1 && (
+                    <div className="absolute right-3 bottom-3 flex items-center gap-1.5 rounded-full bg-black/65 px-3 py-1.5 text-[13px] font-semibold text-white backdrop-blur-sm">
+                      <ZoomIn className="h-4 w-4" strokeWidth={2} />
+                      {readyPhotos.length} photos
                     </div>
-                    {/* MCQ options */}
-                    {q.type === 'mcq' && q.options.length > 0 && (
-                      <ul className="space-y-1.5">
-                        {q.options.map((opt, oi) => (
+                  )}
+                </button>
+              )}
+
+              {/* Padded content below the photo */}
+              <div className="flex flex-1 flex-col px-5 pb-5">
+                <div data-section="header" className="space-y-0.5 pt-4">
+                  <p className={`text-lg leading-tight font-semibold ${dimmedWhenEmpty}`}>
+                    {title || titlePlaceholder}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {timestamp} · {currentUserName.toUpperCase()}
+                  </p>
+                </div>
+
+                <div
+                  className={`mt-2 flex items-center gap-1.5 text-[11px] font-medium tracking-wider uppercase ${
+                    recipientSummary ? 'text-foreground' : 'text-muted-foreground/60'
+                  }`}
+                >
+                  <User className="h-3 w-3" strokeWidth={2.25} />
+                  {recipientSummary ?? 'STUDENT NAME'}
+                </div>
+
+                {/* Venue + event range — inline rows directly under student name, matching PG app */}
+                {isForm && venue && (
+                  <div className="mt-1 flex items-start gap-1.5 text-[11px] text-foreground">
+                    <MapPin
+                      className="mt-px h-3 w-3 shrink-0 text-muted-foreground"
+                      strokeWidth={2}
+                    />
+                    <span>{venue}</span>
+                  </div>
+                )}
+                {isForm && eventRange && (
+                  <div className="mt-1 flex items-start gap-1.5 text-[11px] font-medium text-primary">
+                    <CalendarClock
+                      className="mt-px h-3 w-3 shrink-0 text-primary"
+                      strokeWidth={2}
+                    />
+                    <span>{eventRange}</span>
+                  </div>
+                )}
+
+                <div className="mt-4 border-t border-border/40" />
+
+                <div data-section="content" className="mt-4 space-y-2">
+                  <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
+                    Details
+                  </p>
+                  {descriptionHtml ? (
+                    <div
+                      className="rich-content"
+                      // `generateHTML` serializes a trusted Tiptap schema; Link is
+                      // constrained to http/https/mailto via createRichTextExtensions.
+                      dangerouslySetInnerHTML={{ __html: descriptionHtml }}
+                    />
+                  ) : description ? (
+                    <p className="text-sm whitespace-pre-wrap text-foreground">{description}</p>
+                  ) : (
+                    <p className="text-sm text-muted-foreground/60">{descriptionPlaceholder}</p>
+                  )}
+                </div>
+
+                {/* Shortcuts — divider + tall button rows with trailing chevron, matching PG app */}
+                {enabledShortcuts.length > 0 && (
+                  <>
+                    <div className="mt-4 border-t border-border/40" />
+                    <div data-section="shortcuts" className="mt-4 space-y-2.5">
+                      <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
+                        Shortcuts
+                      </p>
+                      <ul className="space-y-2">
+                        {enabledShortcuts.map((key) => {
+                          const meta = SHORTCUT_PREVIEW[key]!;
+                          return (
+                            <li
+                              key={key}
+                              className="flex items-center gap-3 rounded-2xl border bg-background px-4 py-3.5"
+                            >
+                              <span className="text-lg leading-none">{meta.emoji}</span>
+                              <span className="flex-1 text-sm font-medium">{meta.label}</span>
+                              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  </>
+                )}
+
+                {/* Links — divider + tall button rows: title bold + URL below in blue */}
+                {validLinks.length > 0 && (
+                  <>
+                    <div className="mt-4 border-t border-border/40" />
+                    <div data-section="links" className="mt-4 space-y-2.5">
+                      <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
+                        Links
+                      </p>
+                      <ul className="space-y-2">
+                        {validLinks.map((link, i) => (
+                          // eslint-disable-next-line react/no-array-index-key
                           <li
-                            key={oi}
-                            className="flex items-center gap-2.5 rounded-lg border bg-background px-3 py-2 text-xs"
+                            key={i}
+                            className="flex items-center gap-3 rounded-2xl border bg-background px-4 py-3.5"
                           >
-                            <span className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border border-muted-foreground/40" />
-                            <span className={opt ? 'text-foreground' : 'text-muted-foreground/50'}>
-                              {opt || `Option ${oi + 1}`}
-                            </span>
+                            <ExternalLink className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate text-sm font-medium">
+                                {link.title.trim() || link.url.trim() || 'Untitled link'}
+                              </p>
+                              {link.url.trim() && link.title.trim() && (
+                                <p className="truncate text-xs text-primary">{link.url.trim()}</p>
+                              )}
+                            </div>
                           </li>
                         ))}
                       </ul>
-                    )}
-                    {/* Free-text answer area */}
-                    {q.type === 'free-text' && (
-                      <div className="rounded-lg border bg-muted/30 px-3 py-2 text-xs text-muted-foreground/60">
-                        Your answer here…
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
+                    </div>
+                  </>
+                )}
 
-            {/* Enquiry contact */}
-            <div className="mt-auto pt-6 text-center">
-              <p className="text-[11px] text-muted-foreground italic">
-                For enquiries on this post, please contact
-              </p>
-              <p className="text-[11px] text-primary italic">{enquiryContact}</p>
-            </div>
-          </div>
-          {/* /px-5 pb-5 */}
-        </div>
-        {/* /overflow-y-auto */}
+                {/* Attachments — divider + tall button rows: filename bold + size below */}
+                {readyAttachments.length > 0 && (
+                  <>
+                    <div className="mt-4 border-t border-border/40" />
+                    <div data-section="attachments" className="mt-4 space-y-2.5">
+                      <p className="text-[11px] font-medium tracking-widest text-muted-foreground uppercase">
+                        Attachments
+                      </p>
+                      <ul className="space-y-2">
+                        {readyAttachments.map((f) => (
+                          <li
+                            key={f.localId}
+                            className="flex items-center gap-3 rounded-2xl border bg-background px-4 py-3.5"
+                          >
+                            <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate text-sm font-medium">{f.name}</p>
+                              <p className="text-xs text-muted-foreground">
+                                {formatFileSize(f.size)}
+                              </p>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </>
+                )}
 
-        {/* Response bar — sticky to bottom of phone frame, outside the scroll area */}
-        {isForm && (responseType === 'acknowledge' || responseType === 'yes-no') && (
-          <div
-            data-section="response"
-            className="flex shrink-0 items-center justify-between gap-3 border-t border-border/40 bg-white px-5 py-3"
-          >
-            {/* Left: label + due date */}
-            <div className="min-w-0">
-              <p className="text-[10px] text-muted-foreground">
-                {responseType === 'acknowledge' ? 'Please acknowledge by' : 'Please respond by'}
-              </p>
-              <p className="text-xs font-semibold text-foreground">{dueDateLabel ?? '—'}</p>
-            </div>
-            {/* Right: action buttons */}
-            {responseType === 'yes-no' && (
-              <div className="flex shrink-0 gap-1.5">
-                <button
-                  disabled
-                  className="rounded-full bg-muted px-3 py-1.5 text-[11px] font-medium text-foreground"
-                >
-                  Yes
-                </button>
-                <button
-                  disabled
-                  className="rounded-full border border-border px-3 py-1.5 text-[11px] font-medium text-foreground"
-                >
-                  No
-                </button>
+                {/* Questions are NOT shown inline — they appear after the parent taps Yes.
+                    The QuestionScreen overlay handles the preview when focusSection='questions'. */}
+                {/* Anchor so the scroll-to logic can still jump here */}
+                {questions.length > 0 && <div data-section="questions" />}
+
+                {/* Enquiry contact */}
+                <div className="mt-auto pt-6 text-center">
+                  <p className="text-[11px] text-muted-foreground italic">
+                    For enquiries on this post, please contact
+                  </p>
+                  <p className="text-[11px] text-primary italic">{enquiryContact}</p>
+                </div>
               </div>
-            )}
-            {responseType === 'acknowledge' && (
-              <button
-                disabled
-                className="shrink-0 rounded-full bg-[#c9826b] px-4 py-1.5 text-[11px] font-medium text-white"
+              {/* /px-5 pb-5 */}
+            </div>
+            {/* /overflow-y-auto */}
+
+            {/* Response bar — sticky to bottom of phone frame, outside the scroll area */}
+            {isForm && (responseType === 'acknowledge' || responseType === 'yes-no') && (
+              <div
+                data-section="response"
+                className="flex shrink-0 items-center justify-between gap-3 border-t border-border/40 bg-white px-5 py-3"
               >
-                Acknowledge
-              </button>
+                {/* Left: label + due date */}
+                <div className="min-w-0">
+                  <p className="text-[10px] text-muted-foreground">
+                    {responseType === 'acknowledge' ? 'Please acknowledge by' : 'Please respond by'}
+                  </p>
+                  <p className="text-xs font-semibold text-foreground">{dueDateLabel ?? '—'}</p>
+                </div>
+                {/* Right: action buttons */}
+                {responseType === 'yes-no' && (
+                  <div className="flex shrink-0 gap-1.5">
+                    <button
+                      disabled
+                      className="rounded-full bg-muted px-3 py-1.5 text-[11px] font-medium text-foreground"
+                    >
+                      Yes
+                    </button>
+                    <button
+                      disabled
+                      className="rounded-full border border-border px-3 py-1.5 text-[11px] font-medium text-foreground"
+                    >
+                      No
+                    </button>
+                  </div>
+                )}
+                {responseType === 'acknowledge' && (
+                  <button
+                    disabled
+                    className="shrink-0 rounded-full bg-[#c9826b] px-4 py-1.5 text-[11px] font-medium text-white"
+                  >
+                    Acknowledge
+                  </button>
+                )}
+              </div>
             )}
-          </div>
+          </>
         )}
 
         {/* ── Gallery overlay ─────────────────────────────────────────────── */}

--- a/web/components/posts/PostPreview.tsx
+++ b/web/components/posts/PostPreview.tsx
@@ -50,6 +50,13 @@ interface PostPreviewProps {
   focusSection?: PreviewFocusSection;
   /** 0-based index of the question card currently being edited. */
   focusQuestionIndex?: number;
+  /**
+   * Called when the teacher taps the back chevron (or navigates before Q1)
+   * inside the question-answer preview. The parent should set `focusSection`
+   * to something other than `'questions'` so re-entering the questions builder
+   * correctly re-triggers the question view.
+   */
+  onDismissQuestions?: () => void;
 }
 
 /**
@@ -138,6 +145,7 @@ const PostPreview = React.memo(function PostPreview({
   defaultEnquiryEmail = 'enquiry@school.edu.sg',
   focusSection,
   focusQuestionIndex = 0,
+  onDismissQuestions,
 }: PostPreviewProps) {
   const {
     kind,
@@ -212,41 +220,29 @@ const PostPreview = React.memo(function PostPreview({
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
-  // Tracks whether the teacher dismissed the question view by tapping the back
-  // chevron. Reset to false whenever focusSection transitions *into* 'questions'
-  // from a different section so re-focusing the builder brings the view back.
-  const [questionViewDismissed, setQuestionViewDismissed] = useState(false);
   // True when the parent-side "Yes" button was tapped in the preview — triggers
   // the question flow independently of the teacher's current focus section.
   const [yesClicked, setYesClicked] = useState(false);
   // Which question the preview is currently showing (can diverge from
   // focusQuestionIndex when the teacher navigates with the chrome arrows).
   const [activeQuestionIndex, setActiveQuestionIndex] = useState(focusQuestionIndex);
-  const prevFocusRef = useRef(focusSection);
-  useEffect(() => {
-    if (prevFocusRef.current !== 'questions' && focusSection === 'questions') {
-      setQuestionViewDismissed(false);
-    }
-    prevFocusRef.current = focusSection;
-  }, [focusSection]);
   // Sync preview to whichever question card the teacher just focused.
   useEffect(() => {
     setActiveQuestionIndex(focusQuestionIndex);
   }, [focusQuestionIndex]);
 
-  // Shared dismiss helper — clears both dismiss paths.
+  // Dismiss: tell the parent to move focusSection away from 'questions' so that
+  // the next time the teacher interacts with the builder it triggers a real prop
+  // change and the question view correctly re-appears.
   const dismissQuestionView = () => {
-    setQuestionViewDismissed(true);
+    onDismissQuestions?.();
     setYesClicked(false);
   };
 
-  // True when: (a) teacher is focused on the questions builder and hasn't
-  // dismissed, OR (b) the preview "Yes" button was tapped. Both paths require
-  // at least one question to exist.
+  // True when: (a) teacher is focused on the questions builder, OR (b) the
+  // preview "Yes" button was tapped. Both paths require at least one question.
   const showQuestionView =
-    isForm &&
-    questions.length > 0 &&
-    ((focusSection === 'questions' && !questionViewDismissed) || yesClicked);
+    isForm && questions.length > 0 && (focusSection === 'questions' || yesClicked);
 
   // Scroll the preview pane to the relevant section whenever the teacher's
   // focus moves to a different part of the form.

--- a/web/components/posts/QuestionBuilder.tsx
+++ b/web/components/posts/QuestionBuilder.tsx
@@ -12,9 +12,11 @@ const MAX_MCQ_OPTIONS = 6;
 interface QuestionBuilderProps {
   questions: FormQuestion[];
   dispatch: React.Dispatch<PostFormAction>;
+  /** Called with the 0-based index of whichever question card just received focus. */
+  onQuestionFocus?: (index: number) => void;
 }
 
-function QuestionBuilder({ questions, dispatch }: QuestionBuilderProps) {
+function QuestionBuilder({ questions, dispatch, onQuestionFocus }: QuestionBuilderProps) {
   if (questions.length === 0) {
     return (
       <button
@@ -37,7 +39,12 @@ function QuestionBuilder({ questions, dispatch }: QuestionBuilderProps) {
   return (
     <div className="space-y-4">
       {questions.map((question, index) => (
-        <div key={question.id} className="space-y-3 rounded-xl border p-4">
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <div
+          key={question.id}
+          className="space-y-3 rounded-xl border p-4"
+          onFocus={() => onQuestionFocus?.(index)}
+        >
           <div className="flex items-start gap-2">
             <div className="flex-1 space-y-2">
               <Input

--- a/web/components/posts/SchedulePickerDialog.tsx
+++ b/web/components/posts/SchedulePickerDialog.tsx
@@ -129,6 +129,11 @@ export interface SchedulePickerDialogProps {
    * `configs.configs.schedule_window` once PG ships the real flag.
    */
   scheduleWindow?: ScheduleWindow;
+  /**
+   * YYYY-MM-DD string in SGT. When set, the scheduled send must be at least
+   * 1 day before this date (i.e. before midnight SGT on the due date).
+   */
+  dueDate?: string;
 }
 
 export function SchedulePickerDialog({
@@ -137,6 +142,7 @@ export function SchedulePickerDialog({
   onConfirm,
   busy,
   scheduleWindow = DEFAULT_SCHEDULE_WINDOW,
+  dueDate,
 }: SchedulePickerDialogProps) {
   const [date, setDate] = useState<Date | undefined>(undefined);
   const [time, setTime] = useState<string>(DEFAULT_TIME);
@@ -198,8 +204,23 @@ export function SchedulePickerDialog({
     if (diff > MAX_LEAD_MS) {
       return { ok: false as const, reason: 'Scheduled time cannot be more than 30 days away.' };
     }
+    if (dueDate) {
+      // Require at least 1 full day gap: scheduledSendAt must be before midnight SGT on the due date.
+      const dueMidnightSgt = new Date(`${dueDate}T00:00:00+08:00`);
+      if (new Date(scheduledSendAt) >= dueMidnightSgt) {
+        const formatted = new Date(`${dueDate}T12:00:00+08:00`).toLocaleDateString('en-SG', {
+          day: 'numeric',
+          month: 'short',
+          year: 'numeric',
+        });
+        return {
+          ok: false as const,
+          reason: `Scheduled send must be at least 1 day before the due date (${formatted}).`,
+        };
+      }
+    }
     return { ok: true as const };
-  }, [scheduledSendAt, time, scheduleWindow]);
+  }, [scheduledSendAt, time, scheduleWindow, dueDate]);
 
   function handleConfirm() {
     if (!scheduledSendAt || !validation.ok) return;

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -1410,19 +1410,23 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                             variant="secondary"
                             size="sm"
                             disabled={state.questions.length >= MAX_QUESTIONS}
-                            onClick={() => dispatch({ type: 'ADD_QUESTION' })}
+                            onClick={() => {
+                              dispatch({ type: 'ADD_QUESTION' });
+                              setFocusSection('questions');
+                            }}
                           >
                             <Plus className="h-4 w-4" />
                             Add a Question
                           </Button>
                         </div>
-                        <div onFocus={() => setFocusSection('questions')}>
-                          <QuestionBuilder
-                            questions={state.questions}
-                            dispatch={dispatch}
-                            onQuestionFocus={setFocusedQuestionIndex}
-                          />
-                        </div>
+                        <QuestionBuilder
+                          questions={state.questions}
+                          dispatch={dispatch}
+                          onQuestionFocus={(index) => {
+                            setFocusedQuestionIndex(index);
+                            setFocusSection('questions');
+                          }}
+                        />
                       </div>
                     </>
                   )}
@@ -1477,6 +1481,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   defaultEnquiryEmail={session.schoolEmailAddress ?? 'enquiry@school.edu.sg'}
                   focusSection={focusSection}
                   focusQuestionIndex={focusedQuestionIndex}
+                  onDismissQuestions={() => setFocusSection('response')}
                 />
               </CardContent>
             </Card>

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -785,6 +785,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
   const [focusSection, setFocusSection] = useState<
     'header' | 'content' | 'attachments' | 'links' | 'questions' | 'response'
   >('header');
+  // 0-based index of the question card the teacher is currently editing.
+  const [focusedQuestionIndex, setFocusedQuestionIndex] = useState(0);
   // `submitted` lives until the browser unmounts us on navigate — that's what
   // debounces a rapid double-tap on the Post button without a setTimeout race.
   const [saveState, setSaveState] = useState<'idle' | 'submitting' | 'submitted'>('idle');
@@ -1396,7 +1398,11 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                         </Button>
                       </div>
                       <div onFocus={() => setFocusSection('questions')}>
-                        <QuestionBuilder questions={state.questions} dispatch={dispatch} />
+                        <QuestionBuilder
+                          questions={state.questions}
+                          dispatch={dispatch}
+                          onQuestionFocus={setFocusedQuestionIndex}
+                        />
                       </div>
                     </div>
                   )}
@@ -1446,6 +1452,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   currentUserName={session.staffName ?? 'Daniel Tan'}
                   defaultEnquiryEmail={session.schoolEmailAddress ?? 'enquiry@school.edu.sg'}
                   focusSection={focusSection}
+                  focusQuestionIndex={focusedQuestionIndex}
                 />
               </CardContent>
             </Card>

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -74,7 +74,7 @@ import { VenueSection } from '~/components/posts/VenueSection';
 import { MAX_WEBSITE_LINKS, WebsiteLinksSection } from '~/components/posts/WebsiteLinksSection';
 import type { WebsiteLink } from '~/components/posts/WebsiteLinksSection';
 import { useSidebarContext } from '~/components/Sidebar/context';
-import { Button, Card, CardContent, Input, Label } from '~/components/ui';
+import { Button, Card, CardContent, Input, Label, Separator } from '~/components/ui';
 import {
   describeScheduledSendFailure,
   isAnnouncementDraftId,
@@ -1204,6 +1204,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                 </div>
               </div>
 
+              <Separator />
+
               {/* Staff in charge */}
               <div className="space-y-1.5">
                 <Label>
@@ -1218,6 +1220,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                 />
                 <p className="text-sm text-muted-foreground">{staffHelperText(state.kind)}</p>
               </div>
+
+              <Separator />
 
               {/* Enquiry email */}
               <div className="space-y-1.5">
@@ -1282,6 +1286,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   )}
                 </div>
 
+                <Separator />
+
                 {/* Description with counter and toolbar */}
                 <div className="space-y-1.5" onFocus={() => setFocusSection('content')}>
                   <div className="flex items-center justify-between">
@@ -1314,18 +1320,23 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
 
                 {/* Event schedule and venue — right after description, consent-form only. */}
                 {selectedType === 'post-with-response' && (
-                  <div className="space-y-5" onFocus={() => setFocusSection('header')}>
-                    <EventScheduleSection
-                      value={state.event}
-                      onChange={(value) => dispatch({ type: 'SET_EVENT', payload: value })}
-                    />
+                  <>
+                    <Separator />
+                    <div className="space-y-5" onFocus={() => setFocusSection('header')}>
+                      <EventScheduleSection
+                        value={state.event}
+                        onChange={(value) => dispatch({ type: 'SET_EVENT', payload: value })}
+                      />
 
-                    <VenueSection
-                      value={state.venue}
-                      onChange={(value) => dispatch({ type: 'SET_VENUE', payload: value })}
-                    />
-                  </div>
+                      <VenueSection
+                        value={state.venue}
+                        onChange={(value) => dispatch({ type: 'SET_VENUE', payload: value })}
+                      />
+                    </div>
+                  </>
                 )}
+
+                <Separator />
 
                 {/* Shortcuts — per-key flag-gated. Renders null when both
                   shortcuts are gated off, so there's no empty subsection. */}
@@ -1336,10 +1347,14 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   editContactEnabled={editContactEnabled}
                 />
 
+                <Separator />
+
                 {/* Website links — available on both kinds. */}
                 <div onFocus={() => setFocusSection('links')}>
                   <WebsiteLinksSection value={state.websiteLinks} dispatch={dispatch} />
                 </div>
+
+                <Separator />
 
                 {/* Attachments */}
                 <div onFocus={() => setFocusSection('attachments')}>
@@ -1366,6 +1381,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                     </p>
                   </div>
 
+                  <Separator />
+
                   <div onFocus={() => setFocusSection('response')}>
                     <ResponseTypeSelector
                       value={state.responseType}
@@ -1376,35 +1393,38 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
 
                   {/* Questions — Yes/No only */}
                   {state.responseType === 'yes-no' && (
-                    <div className="space-y-4">
-                      <div className="flex items-start justify-between gap-4">
-                        <div className="space-y-1">
-                          <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
-                            Questions
-                          </p>
-                          <p className="text-sm text-muted-foreground">
-                            Custom questions (optional). You may add up to {MAX_QUESTIONS}{' '}
-                            questions.
-                          </p>
+                    <>
+                      <Separator />
+                      <div className="space-y-4">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="space-y-1">
+                            <p className="text-xs font-medium tracking-widest text-muted-foreground uppercase">
+                              Questions
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              Custom questions (optional). You may add up to {MAX_QUESTIONS}{' '}
+                              questions.
+                            </p>
+                          </div>
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            disabled={state.questions.length >= MAX_QUESTIONS}
+                            onClick={() => dispatch({ type: 'ADD_QUESTION' })}
+                          >
+                            <Plus className="h-4 w-4" />
+                            Add a Question
+                          </Button>
                         </div>
-                        <Button
-                          variant="secondary"
-                          size="sm"
-                          disabled={state.questions.length >= MAX_QUESTIONS}
-                          onClick={() => dispatch({ type: 'ADD_QUESTION' })}
-                        >
-                          <Plus className="h-4 w-4" />
-                          Add a Question
-                        </Button>
+                        <div onFocus={() => setFocusSection('questions')}>
+                          <QuestionBuilder
+                            questions={state.questions}
+                            dispatch={dispatch}
+                            onQuestionFocus={setFocusedQuestionIndex}
+                          />
+                        </div>
                       </div>
-                      <div onFocus={() => setFocusSection('questions')}>
-                        <QuestionBuilder
-                          questions={state.questions}
-                          dispatch={dispatch}
-                          onQuestionFocus={setFocusedQuestionIndex}
-                        />
-                      </div>
-                    </div>
+                    </>
                   )}
                 </CardContent>
               </Card>
@@ -1421,6 +1441,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                     Due Date &amp; Reminder
                   </p>
 
+                  <Separator />
+
                   <div onFocus={() => setFocusSection('response')}>
                     <DueDateSection
                       value={state.dueDate}
@@ -1428,6 +1450,8 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                       required
                     />
                   </div>
+
+                  <Separator />
 
                   <ReminderSection
                     value={state.reminder}

--- a/web/containers/CreatePostView.tsx
+++ b/web/containers/CreatePostView.tsx
@@ -74,7 +74,17 @@ import { VenueSection } from '~/components/posts/VenueSection';
 import { MAX_WEBSITE_LINKS, WebsiteLinksSection } from '~/components/posts/WebsiteLinksSection';
 import type { WebsiteLink } from '~/components/posts/WebsiteLinksSection';
 import { useSidebarContext } from '~/components/Sidebar/context';
-import { Button, Card, CardContent, Input, Label, Separator } from '~/components/ui';
+import {
+  Button,
+  Card,
+  CardContent,
+  Input,
+  Label,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Separator,
+} from '~/components/ui';
 import {
   describeScheduledSendFailure,
   isAnnouncementDraftId,
@@ -102,7 +112,11 @@ import {
   type PostFormField,
 } from '~/lib/validation-errors';
 
-import { hasPendingUploads, isCreatePostFormValid } from './createPostValidation';
+import {
+  computeInlineErrors,
+  hasPendingUploads,
+  isCreatePostFormValid,
+} from './createPostValidation';
 
 // ─── Route loader ───────────────────────────────────────────────────────────
 
@@ -849,6 +863,19 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
   // the form-state matches what Phase 2 expects.
   const isFormValid = isCreatePostFormValid(state, selectedType);
   const uploadsPending = hasPendingUploads(state);
+
+  const [showValidationPopover, setShowValidationPopover] = useState(false);
+  const FIELD_LABELS: Record<PostFormField, string> = {
+    title: 'Add a title',
+    description: 'Write the post details',
+    enquiryEmail: 'Select an enquiry email',
+    recipients: 'Select at least one recipient',
+    dueDate: 'Set a due date for responses',
+  };
+  const missingFieldLabels = (Object.keys(fieldErrors) as PostFormField[]).map(
+    (k) => FIELD_LABELS[k],
+  );
+
   const recipientCount = state.selectedRecipients.reduce((sum, r) => sum + (r.count ?? 1), 0);
   const isEditing = Boolean(editId);
   // True when editing a post that has already been sent — only staff in charge
@@ -902,6 +929,24 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
 
   if (editId && !editData) {
     return <Navigate to="/posts" replace />;
+  }
+
+  function handlePostClick() {
+    if (!isFormValid) {
+      setFieldErrors(computeInlineErrors(state, selectedType));
+      setShowValidationPopover(true);
+      return;
+    }
+    setShowSendDialog(true);
+  }
+
+  function handleScheduleClick() {
+    if (!isFormValid) {
+      setFieldErrors(computeInlineErrors(state, selectedType));
+      setShowValidationPopover(true);
+      return;
+    }
+    setShowScheduleDialog(true);
   }
 
   function handleTypeSelect(type: PostKind) {
@@ -1114,22 +1159,46 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   <Button
                     variant="secondary"
                     size="sm"
-                    disabled={!isFormValid || isSaving}
-                    onClick={() => setShowScheduleDialog(true)}
+                    disabled={isSaving}
+                    onClick={handleScheduleClick}
+                    className={cn(
+                      !isFormValid && '!bg-muted !text-muted-foreground/40 hover:!bg-muted',
+                    )}
                   >
                     <CalendarClock className="mr-1.5 h-4 w-4" />
                     Schedule
                   </Button>
                 )}
-                <Button
-                  variant="default"
-                  size="sm"
-                  disabled={!isFormValid || isSaving}
-                  onClick={() => setShowSendDialog(true)}
-                >
-                  <Send className="mr-1.5 h-4 w-4" />
-                  Post
-                </Button>
+                <Popover open={showValidationPopover} onOpenChange={setShowValidationPopover}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      variant="default"
+                      size="sm"
+                      disabled={isSaving}
+                      onClick={handlePostClick}
+                      className={cn(
+                        !isFormValid && '!bg-muted !text-muted-foreground/40 hover:!bg-muted',
+                      )}
+                    >
+                      <Send className="mr-1.5 h-4 w-4" />
+                      Post
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent side="top" align="end" className="w-64 space-y-2 p-4">
+                    <p className="text-sm font-semibold">Complete these fields before posting</p>
+                    <ul className="space-y-1">
+                      {missingFieldLabels.map((label) => (
+                        <li
+                          key={label}
+                          className="flex items-center gap-2 text-sm text-destructive"
+                        >
+                          <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-destructive" />
+                          {label}
+                        </li>
+                      ))}
+                    </ul>
+                  </PopoverContent>
+                </Popover>
                 {uploadsPending && (
                   <span className="text-xs text-muted-foreground">Attachments uploading…</span>
                 )}
@@ -1174,7 +1243,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
       {/* Body */}
       <div className="flex justify-center gap-8 px-6 py-6">
         {/* Form column */}
-        <div className="w-full max-w-2xl flex-1 space-y-6">
+        <div className="flex w-full max-w-2xl flex-1 flex-col gap-6">
           {/* RECIPIENTS Card */}
           <Card>
             <CardContent className="space-y-5 p-6">
@@ -1193,14 +1262,20 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   </p>
                   <StudentRecipientSelector
                     value={state.selectedRecipients}
-                    onChange={(recipients) =>
-                      dispatch({ type: 'SET_RECIPIENTS', payload: recipients })
-                    }
+                    onChange={(recipients) => {
+                      clearFieldError('recipients');
+                      dispatch({ type: 'SET_RECIPIENTS', payload: recipients });
+                    }}
                     classes={classes}
                     students={students}
                     groupsAssigned={groupsAssigned}
                     customGroups={customGroups}
                   />
+                  {fieldErrors.recipients && (
+                    <p role="alert" className="text-sm text-destructive">
+                      {fieldErrors.recipients}
+                    </p>
+                  )}
                 </div>
               </div>
 
@@ -1450,9 +1525,17 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
                   <div onFocus={() => setFocusSection('response')}>
                     <DueDateSection
                       value={state.dueDate}
-                      onChange={(value) => dispatch({ type: 'SET_DUE_DATE', payload: value })}
+                      onChange={(value) => {
+                        clearFieldError('dueDate');
+                        dispatch({ type: 'SET_DUE_DATE', payload: value });
+                      }}
                       required
                     />
+                    {fieldErrors.dueDate && (
+                      <p role="alert" className="mt-1.5 text-sm text-destructive">
+                        {fieldErrors.dueDate}
+                      </p>
+                    )}
                   </div>
 
                   <Separator />
@@ -1535,6 +1618,7 @@ function CreatePostViewInner({ editId }: { editId?: string }) {
         onConfirm={handleScheduleConfirm}
         busy={isSaving}
         scheduleWindow={scheduleWindow}
+        dueDate={selectedType === 'post-with-response' ? state.dueDate : undefined}
       />
     </div>
   );

--- a/web/containers/createPostValidation.ts
+++ b/web/containers/createPostValidation.ts
@@ -1,4 +1,5 @@
 import type { PostKind } from '~/components/posts/PostTypePicker';
+import type { PostFormField } from '~/lib/validation-errors';
 
 import type { PostFormState } from './CreatePostView';
 
@@ -58,6 +59,27 @@ export function isCreatePostFormValid(
   }
 
   return true;
+}
+
+/**
+ * Returns field-level error messages for every required field that is
+ * currently empty. Used to stamp errors on the form when Post/Schedule
+ * is clicked while the form is invalid.
+ */
+export function computeInlineErrors(
+  state: PostFormState,
+  selectedType: PostKind | null,
+): Partial<Record<PostFormField, string>> {
+  const errors: Partial<Record<PostFormField, string>> = {};
+  if (!state.title.trim()) errors.title = 'Please enter a title.';
+  if (!state.description.trim() || state.description.length > 2000)
+    errors.description = 'Please write the post details.';
+  if (!state.enquiryEmail.trim()) errors.enquiryEmail = 'Please select an enquiry email.';
+  if (state.selectedRecipients.length === 0)
+    errors.recipients = 'Please select at least one recipient.';
+  if (selectedType === 'post-with-response' && !state.dueDate.trim())
+    errors.dueDate = 'Please set a due date for responses.';
+  return errors;
 }
 
 export function hasPendingUploads(state: PostFormState): boolean {

--- a/web/lib/validation-errors.ts
+++ b/web/lib/validation-errors.ts
@@ -1,7 +1,7 @@
 import { PGValidationError } from '~/api/errors';
 
 /** Logical form field identifiers the container stamps inline validation errors against. */
-export type PostFormField = 'title' | 'description' | 'enquiryEmail';
+export type PostFormField = 'title' | 'description' | 'enquiryEmail' | 'recipients' | 'dueDate';
 
 /**
  * Map PGW validation error codes to a user-facing message. Falls back to the


### PR DESCRIPTION
## Summary

- **Question-answer preview** — phone frame shows the full question-answer flow when the teacher is editing custom questions; switches question as focus moves between cards
- **Interactive Yes button** — tapping Yes in the preview enters the question flow independently
- **Card spacing fix** — switched form column wrapper from `space-y-6` to `flex flex-col gap-6` so all inter-card gaps are uniform
- **Submit-time field validation** — Post/Schedule buttons show a muted disabled appearance when form is incomplete; clicking stamps inline red errors on missing fields and opens a "Complete these fields before posting" popover
- **Schedule ↔ due date conflict** — `SchedulePickerDialog` rejects a scheduled send on or after the consent form's due date, with an inline explanation
- **Compact dropzones** — Files and Photos drop areas are shorter
- **Event start/end validation** — auto-advances end time on same-day conflict; shows red error when end ≤ start; clears end when start date leaps past it
- **Question preview back-nav** — `<` chevron navigates to the previous question; dismisses to post details only from Q1
- **Question preview CTA** — reads "Next" on all questions except the last ("Submit")

## Test plan

- [ ] Editing custom questions → preview shows the current question; switching question cards updates the preview
- [ ] Yes button in preview opens question flow
- [ ] Gap between Response Type and Due Date cards matches all other inter-card gaps
- [ ] Click Post/Schedule with empty form → grey buttons, popover lists missing fields, inline errors on each field; filling fields clears errors; popover auto-closes when form is valid
- [ ] Set due date → open Schedule picker → pick a date on or after due date → Confirm stays disabled with conflict message
- [ ] Files / Photos drop zones are visibly more compact
- [ ] Set event start + end to same day/time → red error; change start time later → end auto-advances 30 min
- [ ] With 2 questions, focus Q2 → click `<` → shows Q1; click `<` → returns to post details
- [ ] CTA reads "Next" on Q1 of 2, "Submit" on Q2 of 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)