### PR TITLE
docs: PG↔TW reverse-engineered requirement specs

### DIFF
--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,0 +1,93 @@
+# PG ↔ TW Integration — Business Requirements
+
+> **Source of truth: the GitHub epics.** These files mirror the issue bodies for in-repo reference, review and diffing. Edit the issue first, then re-sync the matching file here. Mirrors parent tracker [#116](https://github.com/String-sg/teacher-workspace/issues/116).
+
+> **Terminology note.** These reverse-engineered specs use **PG's real code terms** (Announcements, Consent Forms) so they stay accurate to the source. In the **TW product** these are rebranded: **Announcements → Posts**, **Forms / Consent Forms → Posts with responses**. The TW epics/issues use the new names; the underlying feature is the same.
+
+## Epics
+
+| #   | Epic                              | Requirements doc                                                                    | Issue                                                             |
+| --- | --------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| 1   | Announcements: Create & Send      | [epic-1-announcements-create-send](./epic-1-announcements-create-send.md)           | [#118](https://github.com/String-sg/teacher-workspace/issues/118) |
+| 2   | Announcements: Tracking & Chasing | [epic-2-announcements-tracking-chasing](./epic-2-announcements-tracking-chasing.md) | [#119](https://github.com/String-sg/teacher-workspace/issues/119) |
+| 3   | Forms / Consent Collection        | [epic-3-forms-consent](./epic-3-forms-consent.md)                                   | [#120](https://github.com/String-sg/teacher-workspace/issues/120) |
+| 4   | Custom Student Groups             | [epic-4-custom-student-groups](./epic-4-custom-student-groups.md)                   | [#121](https://github.com/String-sg/teacher-workspace/issues/121) |
+| 5   | Parent-Teacher Meeting Scheduling | [epic-5-ptm-scheduling](./epic-5-ptm-scheduling.md)                                 | [#122](https://github.com/String-sg/teacher-workspace/issues/122) |
+| 6   | Reports                           | [epic-6-reports](./epic-6-reports.md)                                               | [#123](https://github.com/String-sg/teacher-workspace/issues/123) |
+| 7   | HeyTalia (AI Drafting Assistant)  | [epic-7-heytalia](./epic-7-heytalia.md)                                             | [#124](https://github.com/String-sg/teacher-workspace/issues/124) |
+
+## How these requirements were derived (read first)
+
+The original TW ↔ PG parity work was built **directly against the PG (Parents Gateway) frontend** and was deliberately under-documented in Jira — the parity behaviour lived in the code. These epics have now been **reverse-engineered from two ground-truth sources in this repo**, so PG's team can break them down and re-implement in the new structure without re-reading the originals:
+
+1. **The TW frontend** (`web/`) — working React/TS code for the features already built (Announcements, Forms/Consent, Custom Groups). These are _liftable_.
+2. **The PG API contract** captured as Go-BFF fixtures (`server/internal/pg/fixtures/*.json`) and the mock router (`server/internal/pg/mock.go`). This is the closest thing to an executable parity spec and covers **every** domain — including the ones with no TW UI yet (PTM, HeyTalia, Reports).
+
+Each feature in the child epics carries a **build-status flag**:
+
+- ✅ **Built** — working FE code exists in this repo; can be lifted into the new structure.
+- 🟡 **Contract-only** — PG API shape + BFF route exist, but no TW UI yet; start from the route contract.
+- ⚪ **Not built / inferred** — epic or scraped-spec only; constraints are inferred and **must be confirmed with PG** before sizing.
+
+Exact limits (char counts, file caps, enums) cite the source file/constant so they can be verified rather than trusted.
+
+> **Phase-1 constraint:** the PGW backend is untouchable. All parity divergence is absorbed in the TW FE + Go BFF. No requirement below should be read as a request for a PGW backend change.
+
+---
+
+## Platform contract reference (shared by all epics)
+
+### Two run modes
+
+Toggled by `TW_PG_MOCK`. **Mock mode** (`server/internal/pg/mock.go`) serves fixtures and stubs writes — no DB/Redis/PGW creds needed. **Proxy mode** (`server/internal/pg/proxy.go`) reverse-proxies `GET|POST|PUT|DELETE /api/{path...}` verbatim to PGW. In proxy mode the BFF does **not** enumerate routes, so **`mock.go` is the de-facto route contract**. Note: the mock is _ahead_ of the FE on PTM/HeyTalia/Reports — those routes exist with no FE consumer yet.
+
+### Endpoint inventory (base `/api/web/2/staff`, config/files at `/api/*`)
+
+**Auth / session / config**
+
+- `GET /session/current` — staff identity, school context, 2FA, `heyTaliaAccess`, session TTL
+- `GET /users/me` — profile + recent logins
+- `GET /api/configs` — feature flags + configs; `GET /api/feature/2/flags` — platform flags
+- `PUT /{staffId}/updateDisplayName`, `PUT /{staffId}/updateDisplayEmail`
+
+**Announcements** — `GET /announcements`, `/announcements/shared`, `/announcements/{id}`, `/announcements/drafts/{id}`, `/announcements/prefilled/{id}`; `POST /announcements` (send), `/announcements/drafts` (save), `/announcements/drafts/schedule` (schedule new), `/announcements/duplicate`, `/announcements/drafts/duplicate`, `/announcements/{id}/addStaffInCharge`, `/announcements/drafts/{id}/cancelSchedule`; `PUT /announcements/drafts/{id}`, `/announcements/{id}/enquiryEmailAddress`, `/announcements/{id}/removeAccess`, `/announcements/drafts/schedule/{id}` (schedule existing), `/announcements/drafts/{id}/rescheduleSchedule`; `DELETE /announcements/{id}`, `/announcements/drafts/{id}`.
+
+**Consent forms** — mirror of announcements under `/consentForms*`, plus `PUT /consentForms/{id}/updateDueDate` and `PUT /consentForms/{id}/student/{studentId}/reply` (teacher-proxy YES/NO).
+
+**Groups** — `GET /groups/assigned`, `/groups/custom`, `/groups/custom/{id}`, `/groups/classes/{classId}`, `/groups/cca/students/{ccaId}`; `POST /groups/custom` (create), `/groups/custom/validateStudents` + `/validateStudents/results` (Excel upload 2-step), `/groups/student/count`; `PUT /groups/custom/{id}`, `/groups/custom/{id}/share`, `/groups/custom/{id}/removeAccess`; `DELETE /groups/custom/{id}`.
+
+**School data** — `GET /school/staff`, `/school/students`, `/school/groups` (classes), `/school/studentGroups`, `/school/staffGroups`, `/school/students/retrieveReport`; `POST /school/travelDeclaration`.
+
+**PTM** — `GET /ptm`, `/ptm/serverdatetime`, `/ptm/{eventId}`, `/ptm/timeslots/{id}`, `/ptm/bookings/{id}`, `/ptm/schedule/{id}`, `/ptm/booking/{id}`, `/ptm/{eventId}/targetStudents`; `POST /ptm` (create), `/ptm/booking/{block|unblock|add|change|remove}`, `/ptm/booking/validate`, `/ptm/{eventId}/addStaffInCharge`; `PUT /ptm/{eventId}/removeAccess`, `/ptm/{eventId}/updateEnquiryEmail`; `DELETE /ptm/{eventId}`.
+
+**HeyTalia** — `POST /heytalia/chat`, `/heytalia/feedback`, `/heytalia/email`, `/heytalia/upload-file`, `/heytalia/metrics`, `/heytalia/conversations/delete`, `/heytalia/conversations/system-message`; `GET /heytalia/email/recipients/history`, `/heytalia/conversations`, `/heytalia/conversations/{id}`.
+
+**Notifications / misc** — `GET|PUT /notificationPreference`; `GET /api/web/2/webNotification`; `GET|POST|DELETE /messageGroups*`; `GET /hq-announcement-downloads/{code}`.
+
+**Files (3-step upload, all domains)** — `POST /api/files/2/preUploadValidation` → presigned S3 POST → `GET /api/files/2/postUploadVerification?attachmentId=` (AV-scan poll); `GET /api/files/2/handleDownloadAttachment?attachmentId=`.
+
+### Core data model
+
+- **Session** (`session_current.json`): `staffId`, `staffName`, `isA` (admin), `staffSchoolId` (school context — one school per session, no switcher), `staffEmailAdd`, `schoolEmailAddress`, `is2FAAuthorized`, `sessionTimeLeft`, `displayName/displayEmail`, `isIhl`, `heyTaliaAccess`.
+- **Post** (unified): the FE collapses announcements + consent forms into one `PGPost` discriminated on `kind: 'announcement' | 'form'`. Wire types stay separate; mappers converge them (`web/api/mappers.ts`). Enums: announcement status `POSTED|SCHEDULED|DRAFT|POSTING`; consent status `OPEN|CLOSED|DRAFT|POSTING|SCHEDULED`; response type `VIEW_ONLY|ACKNOWLEDGE|YES_NO` (**write-side asymmetry: acknowledge is sent as singular `ACKNOWLEDGEMENT`**); reminder type `NONE|ONE_TIME|DAILY`.
+- **Targeting** — write payload sends `studentGroups[]`/`staffGroups[]` of `{type,label,value}`. PGW `ETargetType` = `school | level | class | group | cca | student`. FE→wire: `class→class, level→level, school→school, cca→cca, custom/teaching→group`. **Whole-school** = `type:'school'`; **custom group** = `type:'group'` with `customGroupId` as `value`.
+- **Student** (`school_students.json`): `studentId, studentName, uinFinNo, classSerialNo, classCode, className, levelCode, levelDescription, cca[]`.
+- **Staff** (`school_staff.json`): `staffId, name, email, className?`.
+- **Custom group**: summary `{customGroupId, name, studentCount, createdByName, isShared, createdAt}` (mapped from raw `{id, groupName, owners[], studentsList[]}`); detail adds `sharedWith[]` + `students[]`.
+
+### Auth / identity
+
+Staff identity flows via `context.Context` (`identity.go`) and is re-stamped as `X-TW-Staff-ID` by the proxy director (which strips inbound spoofed values). Currently a **stub** pending TW auth middleware. PGW must whitelist TW's server IP and trust the header. OTPaaS/MIMS 2FA is validated only in proxy mode. CSRF: `-4013` triggers a one-shot token refresh + replay. Session expiry: `-401`/`-4012` → redirect `/session-expired`.
+
+### Feature flags / config
+
+`/api/configs` → `{flags, configs}`. Flags gating UI: `absence_submission`, `duplicate_announcement_form_post`, `heytalia_chat`, `schedule_announcement_form_post`. Configs block: `two_way_comms` (beta + school whitelist), `web_notification` (banner window), `absence_notification.blacklist`. Per-user HeyTalia entitlement is **not** a flag — it's `session.heyTaliaAccess`. Client memoises configs for 15 min; fetch failure falls back to all-off (no toast).
+
+### Cross-cutting conventions
+
+- **Timezone:** every teacher-entered date is anchored to **SGT (+08:00)**; bare dates (due date, reminder) become end-of-day `T23:59:59+08:00`. Load-bearing for Forms + Scheduling.
+- **Error model:** PGW envelope `{resultCode, message, error:{errorReason, fieldPath, subCode}}`. Validation errors (`-400/-4001/-4003/-4004`) render **inline/silent** (no toast); `-429` toasts; `-404` not-found page.
+- **Envelope:** real PGW wraps `{body, resultCode, message}`; detail endpoints return `body:[detail]` single-element arrays. Mock fixtures are raw.
+- **No pagination** anywhere — lists return full arrays; own + shared lists are merged with own-wins dedup. At cohort scale this likely needs server pagination (flagged across epics).
+- **Timeouts:** writes 30s, uploads 60s, AV-scan poll capped 30s/500ms.
+- **Wire allowlist:** write mappers `satisfies PGWritePayload` — PGW rejects unknown keys (no `allowUnknown`), so every wire field must mirror PGW exactly.

--- a/docs/requirements/announcements-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/announcements-1-pg-reverse-engineer-specs.md
@@ -1,0 +1,318 @@
+# Feature Specification: Announcements
+
+**Feature Branch**: `001-announcements`
+**Created**: 2026-06-09
+**Status**: Reverse-Engineered
+**Input**: Reverse-engineered from existing codebase (`pgw-web`)
+
+---
+
+## Overview
+
+Announcements is a one-way communication feature in Parents Gateway Web that lets school staff broadcast information to parents. Unlike Consent Forms, announcements collect **no parental response** — they track only whether each recipient parent has **read** the post. Staff create announcements targeting student groups (and individual students), assign co-owning staff-in-charge, attach rich-text content, web links, file attachments, and a photo gallery, optionally add in-app shortcuts, and either post immediately, save as a draft (with autosave), or schedule for future sending. After posting, staff track read status per student, filter the recipient table, export to Excel, and duplicate or delete the post. School admins get a read-only oversight list. The feature is a React frontend backed by a Node/Express BFF (`src/server/apiv2/staff/...` and `.../school-admin/...`) using Sequelize models from `@pgw/db-migration`.
+
+---
+
+## User Scenarios & Testing
+
+### US-1: Create and Post an Announcement (Staff)
+
+**As a** school staff member,
+**I want to** create a new announcement with all required fields and post it,
+**So that** I can keep parents informed.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/announcements/new` (page `CreateAnnouncementPage.tsx`).
+- The form is organized into sections (`FormDivider`): **Recipients (PARENTS)**, **Recipients (SCHOOL STAFF)**, **Enquiry Details**, **Content**, **Gallery**, **Settings**.
+- Staff selects target recipients via `IndividualStudentGroupsComboBoxDirty` — by **class, level, school, CCA, custom group, or individual student**. When >1 unique student is selected, a summary line shows "This announcement will be sent to the parents of N students."
+- Staff selects **staff-in-charge** via `StaffGroupsComboBoxDirty` (co-owners). Sub-label: "These staff will be able to view read status, and delete the announcement". **There is NO editor/viewer access-type distinction** (see note below).
+- Staff selects an **enquiry email** (`EmailSelectorDirty`) from staff email, school email, or a custom "Other" address.
+- Staff enters **title** (max 120 chars — error "Exceeded by N characters") and **description** (rich text, max 2000 chars).
+- Staff optionally adds **in-app shortcuts** (`MultipleSelectCheckboxDirty`, hidden when `isIhl`).
+- Staff adds **web links** (up to 3, URL + optional description), **file attachments** (up to 3, ≤5 MB each), and **photo gallery** images (up to 12, with up to 3 cover photos).
+- Staff optionally fills a **schedule post date/time** under Settings.
+- Staff clicks **Preview** (`AnnouncementPreview`), then **Post Now**. A confirmation modal reads "You are about to post the announcement "<title>" to N students."
+- On confirm, `useSubmitForm` → `AnnouncementManager.postAnnouncement` → `AnnouncementService.post` → `POST /api/web/v2/staff/announcements`.
+- On success: redirect to `/announcements` with success notification linking to `/announcements/details/:id`; analytics `AnnouncementCreated` fired.
+- Targets are sent only as `{ targetType, targetId }` (acad year omitted; resolved server-side at send time).
+
+> **Difference from Consent Forms:** Announcements have **no response type** (no Yes/No or Acknowledgement), **no custom questions**, **no event date range / venue**, **no consent due date / reminders**. The recipient summary stats and table are about **Read / Unread**, not replies.
+
+> **Note on staff-in-charge access type (verified):** The Consent Forms request mentions EDITOR vs VIEWER. Announcements do **not** implement any such enum. `AnnouncementOwner` carries only `pgStaffId` + `isDeleted` (no `accessType`); `grep` for `accessType|EDITOR|VIEWER` yields only the unrelated email-template variable `editor` (the creator's display name). All staff-in-charge are equal co-owners who can view read status and delete.
+
+### US-2: Save Announcement as Draft
+
+**As a** school staff member,
+**I want to** save an incomplete announcement as a draft,
+**So that** I can finish it later.
+
+**Acceptance Criteria:**
+
+- Staff clicks "Save as Draft" (`SaveAsDraftStickyBar`).
+- New draft → `POST /api/web/v2/staff/announcements/drafts`; existing → `PUT /api/web/v2/staff/announcements/drafts/:announcementDraftId` (`AnnouncementDraftManager.saveAsDraft`).
+- After first save, URL replaces to `/announcements/drafts/:announcementDraftId`.
+- Toast: "Your draft announcement has been saved successfully."
+- Draft body persists `studentGroups`, `staffGroups`, `title`, `content`, `enquiryEmailAddress`, `urls`, `shortcuts`, `attachments`/`images` (by `fileToken`), and `scheduledDateTime`.
+- Save is **blocked** if title >120 or description >2000.
+- If exactly one of schedule date / time is filled, save is blocked (`incompleteScheduleSendDatetime`).
+
+### US-3: Autosave on Session Timeout
+
+**As a** school staff member,
+**I want** my in-progress announcement to be autosaved before my session expires,
+**So that** I don't lose work.
+
+**Acceptance Criteria:**
+
+- `useAutoSaveStates` (`AutoSaveStatesContext`) drives a `PENDING → TRIGGER → SUCCESS/FAILED` cycle.
+- On `TRIGGER`, if the form is dirty, `processSaveAsDraft(true)` runs with `isAutosave=true`, sending the `pg-no-extend` header so the session is **not** extended.
+- Autosave updates `updatedAt` silently (no toast); on failure sets state `FAILED`.
+
+### US-4: Edit a Draft Announcement
+
+**As a** school staff member,
+**I want to** reopen and continue editing a draft,
+**So that** I can finalize and post it.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/announcements/drafts/:id`.
+- `useDraftGetter` → `AnnouncementDraftManager.getAnnouncementDraftById` → `GET /api/web/v2/staff/announcements/drafts/:announcementDraftId`.
+- All fields pre-populate (student groups, staff groups, title, `richTextContent`/`content`, email, shortcuts, urls, attachments, images, `scheduledDateTime`).
+- Attachment/photo state derived: `fail → ERROR`, past `expiryDate → EXPIRED`, else `SUCCESS`; expired uploads surface a `NotificationExpiryAlert` via `useDraftUploadExpiryNotifier`.
+
+### US-5: Schedule, Reschedule, and Cancel an Announcement
+
+**As a** school staff member,
+**I want to** schedule an announcement for a future date/time and manage that schedule,
+**So that** I can prepare posts in advance.
+
+**Acceptance Criteria:**
+
+- Staff fills the `SchedulePostDateTimePicker`; on Preview the sticky bar exposes **Schedule Post**.
+- Confirmation modal states students and staff-in-charge are resolved **at send time**, and PG sends a reminder before the scheduled time "unless it's scheduled under the next 24 hours."
+- Schedule new → `POST /api/web/v2/staff/announcements/drafts/schedule`; schedule existing draft → `PUT /api/web/v2/staff/announcements/drafts/schedule/:announcementDraftId`.
+- Scheduled posts appear in **Created by you** with status SCHEDULED; their rows are click-disabled (also for POSTING).
+- **Reschedule** (row action) → `PUT /api/web/v2/staff/announcements/drafts/:announcementDraftId/rescheduleSchedule`.
+- **Cancel** (row action) → modal "Cancel sending this post?" ("the post will be moved to Drafts") → `POST /api/web/v2/staff/announcements/drafts/:announcementDraftId/cancelSchedule`.
+- A failed scheduled send surfaces `scheduledSendFailureCode`; the row expands to show the mapped error message.
+- WOGAA transaction is started on Preview when schedule-eligible and completed on success.
+
+### US-6: View Announcements List (Staff)
+
+**As a** school staff member,
+**I want to** see announcements I created and those shared with me,
+**So that** I can manage them and track reads.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/announcements` (`StaffAnnouncementList.tsx`). Mantine `Tabs`: **Created by you** / **Shared with you**, synced to URL query `tab`.
+- "Create New" page action → `/announcements/new`.
+- **Created by you** (`GET /api/web/v2/staff/announcements`) columns: **Title**, **Date** (sortable), **Status**, **To Parents Of** (filterable), **# Read** (`readPerStudent / totalStudents` + progress bar, shown only for POSTED), and an action menu. Status values from `EAnnouncementAPIResponseStatus` = DRAFT, POSTED, SCHEDULED, POSTING.
+  - Action menu by status: DRAFT → Edit / Duplicate / Delete; POSTED → Duplicate; SCHEDULED → Reschedule / Cancel.
+  - Row click: DRAFT → `/announcements/drafts/:id`; POSTED → `/announcements/details/:id`; SCHEDULED/POSTING disabled.
+  - Search by title (min 3 chars, debounced); filter modal for Date range + Status; table/filter state persisted in URL.
+- **Shared with you** (`GET /api/web/v2/staff/announcements/shared`) columns add **Created By**; action menu only offers **Duplicate** for POSTED rows.
+
+### US-7: View Announcement Details and Read Status (Staff)
+
+**As a** school staff member,
+**I want to** see who has read a posted announcement,
+**So that** I can follow up with parents who haven't.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/announcements/details/:id`; data via `GET /api/web/v2/staff/announcements/:id`.
+- Header shows title, target groups, and individual student targets.
+- Two tabs: **Read Status** (default) and **Details**.
+- **Read Status tab** (`ResponseScreen.tsx`):
+  - Summary stats (`StatsGroup`) showing **Total / Read / Unread**; clicking a stat filters the table by read state.
+  - Filter row: **Status** dropdown (onboarding status), **Class** dropdown, **Show Columns** multi-select.
+  - Data table columns: **Name** (fixed), **Class/Index**, **Read Status** (Read/Unread), **Read Time**, **First Read By** (parent identity/name/contact), **Status** (onboarding). IHL variant swaps Class/Index for **Class** + **Student ID**.
+  - **Export to Excel** button (desktop only; mobile shows "not supported on mobile devices.") → `AnnouncementDetailManager.exportToExcel`. Excel columns ordered per `EXCEL_DATA_COLUMNS`.
+- **Details tab** (`DetailsScreen.tsx`): posting details, **Staff-in-charge** (with **Add**, self-**Remove**), **Enquiry Email** (with **Edit**), Description, Shortcuts, Web Link, File attachments, Photo Gallery, and **Other Actions** (Duplicate + Delete).
+
+> **Difference from Consent Forms:** No "Edit Response" per student, no reply-audit history modal, no due-date editing, no "Custodians may edit till due date" banner. There is no per-student write path beyond read tracking.
+
+### US-8: Manage Staff-in-Charge
+
+**As a** school staff member,
+**I want to** add or remove staff-in-charge on a posted announcement,
+**So that** the right staff can oversee it.
+
+**Acceptance Criteria:**
+
+- Details tab → **Add** opens `AddStaffInChargeOverlay` → `POST /api/web/v2/staff/announcements/:id/addStaffInCharge` (body `{ announcementId, staffIDs }`). New staff receive an email notification.
+- A staff-in-charge can **Remove** themselves → confirmation → `PUT /api/web/v2/staff/announcements/:id/removeAccess`; on success redirect to `/announcements`.
+
+### US-9: Edit Enquiry Email (Posted Announcement)
+
+**As a** school staff member,
+**I want to** update the enquiry email on a posted announcement,
+**So that** parents contact the right person.
+
+**Acceptance Criteria:**
+
+- Details tab → **Edit** (enquiry email) opens `EditEmailAddressOverlay` (staff/school/custom).
+- `PUT /api/web/v2/staff/announcements/:id/enquiryEmailAddress` (body includes `enquiryEmailAddress` + `prevEnquiryEmailAddress` for the application log).
+
+> **Difference from Consent Forms:** There is **no Edit Due Date** flow (announcements have no due date).
+
+### US-10: Delete an Announcement
+
+**As a** school staff member,
+**I want to** permanently delete an announcement,
+**So that** obsolete posts are removed.
+
+**Acceptance Criteria:**
+
+- Details tab → tick "I am sure I want to delete this announcement." then **Delete Forever**, confirmation modal.
+- Staff path → `DELETE /api/web/v2/staff/announcements/:id`; admin path → `DELETE /api/web/v2/schoolAdmins/announcements/:id`.
+- Notification `delete_announcement_success`; redirect to `/announcements` (or `/admin/announcements` for admin).
+- A DRAFT can also be deleted from the Created-by-you list → `DELETE /api/web/v2/staff/announcements/drafts/:announcementDraftId`; the row is optimistically removed from the cache.
+
+### US-11: Duplicate an Announcement (Draft or Posted)
+
+**As a** school staff member,
+**I want to** duplicate an existing announcement,
+**So that** I can reuse it.
+
+**Acceptance Criteria:**
+
+- Draft duplication → `POST /api/web/v2/staff/announcements/drafts/duplicate` (body `{ announcementDraftId }`).
+- Posted duplication → `POST /api/web/v2/staff/announcements/duplicate` (body `{ announcementId }`); the server guards ownership.
+- Both return a new `announcementDraftId`; staff is redirected to `/announcements/drafts/:newId` with a success toast.
+
+### US-12: Create from a Prefilled Magic Link
+
+**As a** school staff member,
+**I want to** open a pre-populated announcement from a deep link,
+**So that** I can quickly post content prepared elsewhere (e.g. an AI-drafted post).
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/announcements/prefilled/:magicLinkId`.
+- `usePrefilledGetter` → `GET /api/web/v2/staff/announcements/prefilled/:announcementPrefilledId`.
+- Status is `EPrefilledAnnProcessStatus` (`PROCESSING` / `COMPLETED`); while `PROCESSING` the combo boxes show a loading state and the hook **polls** until `COMPLETED` or surfaces a load error.
+- Title, content, urls, student groups, and staff groups are pre-filled; the form is marked dirty.
+
+### US-13: View Announcements List (School Admin)
+
+**As a** school admin,
+**I want to** oversee all announcements in my school,
+**So that** I can monitor communications.
+
+**Acceptance Criteria:**
+
+- Admin navigates to `/admin/announcements` (legacy `R12` list).
+- List rows show title, "Created by <staff name>", "on <postedDate>", and a recipient `total` indicator; clicking → `/admin/announcements/details/:id`.
+- Admin endpoints under `schoolAdminAnnouncementRouter`: legacy `GET /api/web/v2/schoolAdmins/announcements`; reskin `GET /api/web/v2/schoolAdmins/r12/announcements`; `GET …/:id`; `DELETE …/:id`.
+- Admin details view hides **Add staff-in-charge**, **Edit enquiry email**, and **Duplicate**; admin can still **Delete**.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Announcement Creation
+
+- One-way post: **no** response type, custom questions, event dates, venue, or due date.
+- Recipients selectable by class, level, school, CCA, custom group, and/or individual student; targets serialized as `{ targetType, targetId }` only.
+- Staff-in-charge are equal co-owners (no editor/viewer enum); creator is excluded from the submitted staff-in-charge list.
+- Enquiry email from staff email, school email, or custom.
+- Title **max 120 chars**; description rich text **max 2000 chars**.
+- Rich text via Tiptap — supported marks/nodes: **Document, Paragraph, Text, Bold, Italic, Underline, TextAlign (paragraph/orderedList/bulletList), ListItem, OrderedList, BulletList, HardBreak**, plus History, CharacterCount, Placeholder. Stored as `richTextContent` (JSON) with `content` plain-text fallback.
+- Web links: **up to 3**, URL + optional description.
+- File attachments: **up to 3**, **≤5 MB each**, uploaded by `fileToken`.
+- Photo gallery: **up to 12**, **up to 3 cover photos**.
+- In-app shortcuts: `DECLARE_TRAVELS`, `EDIT_CONTACT_DETAILS` (`EAnnouncementShortcutType`). **Hidden entirely when `isIhl`** (no separate SPED hide found — IHL is the variant the code encodes).
+
+#### FR-2: Draft Management
+
+- Manual save and autosave to the drafts endpoints; new vs existing chosen by presence of `:id`.
+- Autosave sends `pg-no-extend` header so the session is not extended; states driven by `AutoSaveStatesContext`.
+- Drafts persist all fields incl. `scheduledDateTime`; attachment/photo expiry tracked (`expiryDate` → EXPIRED state).
+- Save blocked on title/description over-limit and on partially-filled schedule date/time.
+- Drafts can be edited, duplicated, or deleted.
+
+#### FR-3: Scheduled Posting
+
+- Schedule on create or from an existing draft; reschedule and cancel from the Created-by-you list.
+- Recipients and staff-in-charge are resolved at send time, not at scheduling.
+- Creator reminded before send unless within 24 hours.
+- `scheduledSendFailureCode` tracked; failure message shown in an expandable row.
+- Cancel moves the post back to Drafts.
+
+#### FR-4: Read Tracking
+
+- Per recipient, track **Read / Unread** (`readStatus`/`readDate`); no reply values.
+- Summary stats Total / Read / Unread; clicking filters the table.
+- Filter by onboarding **Status**, **Class**, and interactive **Read summary**; configurable **Show Columns**.
+- `# Read` progress = `readPerStudent / totalStudents`, surfaced only for POSTED.
+- "First Read By" shows the parent identity/name/contact of the first read.
+
+#### FR-5: Export
+
+- Export the filtered read-status table to Excel (`.xlsx`).
+- Export respects column visibility and current filters; columns ordered per `EXCEL_DATA_COLUMNS`.
+- Disabled on mobile.
+
+#### FR-6: Roles and Access
+
+- **Staff (creator/owner):** full CRUD, manage staff-in-charge, edit enquiry email, export, duplicate, schedule.
+- **Staff (shared / co-owner):** see in "Shared with you"; can view read status and **Duplicate** posted; staff-in-charge can self-remove and delete the announcement.
+- **School Admin:** read-only oversight list + delete; no staff management, enquiry-email edit, or duplicate. Uses `/schoolAdmins/` API path.
+- **IHL (Institute of Higher Learning):** in-app shortcuts hidden; response table uses Class + Student ID columns instead of Class/Index.
+- **SPED:** Not separately encoded in the announcement code paths reviewed — the only school-type branch is `isIhl`. _(Consent Forms' SPED shortcut-hiding was not found for announcements; flagged rather than invented.)_
+
+#### FR-7: Navigation Prevention
+
+- Unsaved changes trigger a React-Router `Prompt` ("…Any unsaved changes will be lost.") and `useUnloadEvent` guards browser unload while dirty and not posting.
+
+#### FR-8: Listing, Search, and URL State
+
+- Created-by-you / Shared-with-you tabs persisted via `tab` query param.
+- Per-tab table state (pagination, sorting, filters, search) persisted in the URL; title search ≥3 chars with debounce.
+
+### Key Entities
+
+| Entity                                         | Description                                                                                           |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `Announcement`                                 | A posted announcement with content, targets, owners, students (with read status), images, attachments |
+| `AnnouncementDraft`                            | A pre-post draft holding all form fields incl. `scheduledDateTime`, by `fileToken` uploads            |
+| `AnnouncementPrefilled`                        | A magic-link pre-population payload with `EPrefilledAnnProcessStatus` (PROCESSING/COMPLETED)          |
+| `AnnouncementRecipient`                        | A targeted student + parent with `readDate`, parent name/phone/relationship, `onBoardedCategory`      |
+| `AnnouncementTarget`                           | A target group: school/level/class/cca/custom (`ETargetType`), acad year resolved server-side         |
+| `AnnouncementOwner`                            | A staff co-owner (`pgStaffId`, `isDeleted`) — **no access-type field**                                |
+| `AnnouncementShortcut`                         | In-app shortcut: `DECLARE_TRAVELS`, `EDIT_CONTACT_DETAILS`                                            |
+| `AnnouncementUrl`                              | A web link (`webLink` + `linkDescription`)                                                            |
+| `AnnouncementAttachment` / `AnnouncementImage` | File attachment / gallery image (name, size, sequence, `isCover`, downloadUrl)                        |
+| `EAnnouncementAPIResponseStatus`               | List row status (DRAFT, POSTED, SCHEDULED, POSTING — mapped from `EResourceStatus`)                   |
+
+---
+
+## Success Criteria
+
+1. **Creation**: Staff can create and post an announcement with recipients, staff-in-charge, rich text, links, attachments, and gallery, receiving confirmation and the post appearing in the list.
+2. **Draft Persistence**: Drafts save/restore all fields incl. schedule and expiry-aware uploads; autosave fires on session-timeout trigger without extending the session.
+3. **Scheduled Posting**: Schedule, reschedule, and cancel work; failure codes render; recipients resolve at send time.
+4. **Read Tracking**: Summary stats (Total/Read/Unread) are accurate; Status/Class/Read filters and Show-Columns combine correctly; IHL column variant renders.
+5. **Export Accuracy**: Excel export matches the filtered table and column order; unavailable on mobile.
+6. **Role-Based Access**: Admin list/details correctly hide add-staff, edit-email, and duplicate; shared-with-you offers only duplicate of posted; IHL hides shortcuts and reskins columns.
+7. **Duplication & Deletion**: Draft and posted duplication both yield a new editable draft; deletion (staff and admin paths) removes the post and redirects with success notice.
+8. **Navigation Safety**: Dirty-state prompt and unload guard prevent accidental loss.
+
+---
+
+## Assumptions
+
+1. The backend is a Node/Express BFF alongside the React frontend, using Sequelize models from `@pgw/db-migration`; staff routes mount under `/api/web/v2/staff` and admin under `/api/web/v2/schoolAdmins`.
+2. File uploads (attachments/photos) use a token flow — files uploaded separately and referenced by `fileToken`.
+3. The Parents Gateway mobile app handles the parent reading flow; this spec covers the staff web portal. Announcements are one-way (read tracking only, no parental responses).
+4. Rich text is Tiptap JSON in `richTextContent` with a `content` plain-text fallback; supported nodes/marks are exactly those registered in `getSupportedExtensions`.
+5. `isIhl` derives from school config in Redux `indexPage`. SPED-specific behavior was **not** found in announcement code paths (only IHL branches); this is flagged, not assumed.
+6. WOGAA tracking is a Singapore-government analytics requirement; used for schedule-post transactions and search/filter.
+7. `EResourceStatus` (DRAFT, POSTED, POSTING, SCHEDULED) is the canonical status enum; `EAnnouncementAPIResponseStatus` maps it for list rows.
+8. The `R12` admin routes (`/schoolAdmins/r12/announcements`) are a transitional reskin coexisting with the legacy admin list.

--- a/docs/requirements/custom-groups-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/custom-groups-1-pg-reverse-engineer-specs.md
@@ -1,0 +1,282 @@
+# Feature Specification: Custom Student Groups
+
+**Feature Branch**: `004-custom-groups`
+**Created**: 2026-06-09
+**Status**: Reverse-Engineered
+**Input**: Reverse-engineered from existing codebase (pgw-web)
+
+---
+
+## Overview
+
+Custom Student Groups is a roster-management feature in Parents Gateway Web that lets school staff assemble ad-hoc groups of students that cut across class/level/CCA boundaries. Staff create a group by manually selecting students from the school roster or by bulk-uploading an Excel (`.xlsx`) file, then reuse the saved group as a recipient target when creating Posts/Consent Forms/Announcements. Groups support co-ownership-style sharing (any staff a group is shared with gets full edit/share/send rights), edit (rename, add/remove students), deletion by the last remaining owner, and self-removal by non-last owners. The feature has two roster variants: a mainstream-school (MS) variant keyed on student Name + Class, and an Institute-of-Higher-Learning (IHL) variant keyed on Student ID, with a hard cap of 5,000 students per group. File-upload validation runs as an asynchronous, token-and-polling job on the BFF and returns a valid/invalid breakdown with per-row error reasons.
+
+---
+
+## User Scenarios & Testing
+
+### US-1: Create a Custom Group by Manual Student Selection (Staff)
+
+**As a** school staff member,
+**I want to** create a custom group by hand-picking students from my school roster,
+**So that** I can target a bespoke set of students in future posts.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/groups` and clicks "Create New" (links to `/groups/customGroups/new`), firing analytics `NewCustomGroupButtonPressed`.
+- The Create page (`CustomGroupPage`, `pageType === 'create'`) shows title "Create new group", a mandatory `Title` field (max 120 chars, placeholder "What would you like to call your group?"), and a Students section.
+- Clicking "Add Students" opens a dropdown (`AddStudentDropdownComponent`) with two options: "Add manually" and "Upload via Excel".
+- "Add manually" opens the "Add students" overlay (`AddStudentsComponent`) populated from `StudentService.getStudents()` → `GET /api/web/v2/staff/school/students`.
+- Selected students render in `StudentTable`, sorted by class description then index. Each row has a delete action; deleting with `studentId === null` opens a "Delete all?" modal ("All **N** student(s) will be removed.").
+- The "Create Now" button is enabled only when `groupName.trim().length > 0 && selectedStudentIds.length > 0` (and, for IHL, `selectedStudentIds.length <= 5000`). Label flips to "Creating..." while posting.
+- On submit (analytics `CustomGroupCreateButtonPressed`), the FE dedupes IDs (`_.uniq`) and calls `actions.createGroup` → `POST /api/web/v2/staff/groups/custom` with `{ groupName, selectedSchoolStudents }`.
+- On success: analytics `CustomGroupCreated`, success notification `create_group_success`, redirect to `/groups`.
+- Duplicate-name error (`error.errorReason === 'customGroup name duplicated'`) renders inline: "The title you entered already exists. Please use a different title." (Server enforces uniqueness only for IHL — see FR-7.)
+- A `Prompt` / `beforeunload` guard ("You are about to leave this page. Any unsaved changes will be lost.") fires if the form is edited and not yet posted.
+
+### US-2: Create a Custom Group by Excel File Upload (Staff)
+
+**As a** school staff member,
+**I want to** bulk-add students by uploading an Excel file,
+**So that** I can build large groups without selecting students one by one.
+
+**Acceptance Criteria:**
+
+- From the "Add Students" dropdown, staff clicks "Upload via Excel" (analytics `CustomGroupUploadViaExcelPressed`; on create, starts WOGAA transaction `CREATE_CUSTOM_GROUP_FILE_UPLOAD`). This opens the upload overlay (`UploadStudentsComponent`).
+- "Upload via Excel" is **disabled when the list already has students**; conversely the manual "Add Students" button is disabled once a file-upload result is displayed. The two paths are mutually exclusive.
+- **Accepted file type**: `.xlsx` only (`CUSTOM_GROUP_ACCEPTED_MIME_TYPES`). Wrong type toast: "Only .xlsx file type is allowed." (CSV is **not** accepted.)
+- **Max file size**: 5 MB (`MAX_UPLOAD_FILE_SIZE`). Oversize toast: "You may only add files up to 5 MB." **Max files**: 1.
+- **Max students**: `CUSTOM_GROUP_MAX_STUDENTS_COUNT = 5000`.
+- **Expected columns**:
+  - **MS** (`isIhl === false`): two columns `Name` and `Class`. Copy: "Upload an Excel file (.xlsx) with two columns: 'Name' and 'Class'. The columns can be in any order and any position, as long as they are named correctly." Header matching is case-insensitive and whitespace-trimmed.
+  - **IHL** (`isIhl === true`): one column `Student ID` (`CUSTOM_GROUP_FILE_UPLOAD_COLUMN_HEADER`).
+- First worksheet parsed client-side (`XLSX.read`); user-facing row numbers are `index + 2` (header is row 1).
+- **Client-side validation order & exact messages** (`ValidationMessages`):
+  - Blank file → "The file is empty. Please check it and re-upload."
+  - IHL missing/duplicate header → "The column header must be \"Student ID\". Please amend and re-upload." / "We found duplicate columns with the header \"Student ID\". Please amend and re-upload."
+  - IHL over cap → "You may only upload up to 5000 Student IDs. Please amend and re-upload."
+  - IHL duplicate IDs → "We found N duplicate Student ID(s). Please amend and re-upload."
+  - MS duplicate headers → "The column 'Name' and/or 'Class' appears more than once. Please remove the duplicate(s) and re-upload."
+  - MS missing headers → "The columns 'Name' and/or 'Class' are missing. Please add them and re-upload."
+  - MS missing values → "Your file is missing 'Name' or 'Class' entries in row(s): {rows}{ and N more}. Please update these rows and re-upload." (first 5 rows listed)
+  - MS over cap → "You may only upload up to 5000 students. Please reduce the number and re-upload."
+  - MS duplicate Name+Class → "We found duplicate entries with the same 'Name' and 'Class': • {name in rows …}{ and N more}. Please remove the duplicates and re-upload." (case-insensitive; first 5)
+  - Generic parse failure → "There was an error processing your file. Please check the format and try again." Server failure → "Sorry, an unexpected error occurred on our side. Please try again later."
+- On passing client validation, rows go to the BFF for **server-side roster matching**:
+  - `POST /api/web/v2/staff/groups/custom/validateStudents` with `[{ studentId }]` (IHL) or `[{ name, className }]` (MS). **Asynchronous**: BFF stores a `pending` result in Redis (10-min TTL) and returns a signed `token`.
+  - FE polls `POST /api/web/v2/staff/groups/custom/validateStudents/results` with `{ token }` every 3 s, up to 100 attempts, until `status === 'success'` (throws on `error`).
+- The result (`{ validStudents, invalidStudents }`) renders in collapsible accordions "Valid students (N)" / "Invalid students (N)" with per-row reasons. Header shows filename + size + "Total unique students".
+- Only `validStudents.pgStudentId` become the group's students; the group can be created from the valid subset while invalid rows are reported.
+- Removing the file opens a "Remove file?" modal which clears students and the validation result.
+
+### US-3: View Custom Groups List (Staff)
+
+**As a** school staff member,
+**I want to** see all custom groups I own or that are shared with me,
+**So that** I can manage them.
+
+**Acceptance Criteria:**
+
+- `/groups` (`GroupsPage`) renders an "Assigned Groups" section (US-9) above a "Custom Groups" section.
+- `getGroupsStaffOwns()` → `GET /api/web/v2/staff/groups/custom?type=summary` returns `IGroupSummaryDetails[]` (`id`, `groupName`, `numberOfStaff`, `numberOfStudents`).
+- Each row shows the name + student count; a shared icon prefixes the name when `numberOfStaff > 1`.
+- Empty state: "You have not created any groups yet." / "Try creating one now!"
+- Only groups with `numberOfStudents > 0` are returned. Clicking a row → `/groups/customGroups/{id}`.
+
+### US-4: View Custom Group Details (Staff)
+
+**As a** school staff member,
+**I want to** open a custom group and review its members and metadata,
+**So that** I can verify the roster and decide on actions.
+
+**Acceptance Criteria:**
+
+- `/groups/customGroups/:id` (`CustomGroupDetails`); `getSingleGroupWithStudents(id)` → `GET /api/web/v2/staff/groups/custom/:id` (analytics `CustomGroupViewed`).
+- Header shows name + "Custom Group" label. Two tabs: "Students (N)" (default) and "Details".
+- **Students tab**: members grouped by class (sorted by `classSerialNo`); each row shows name, index/UIN (MS) or Student ID (IHL), gender, and an "Onboarded & Can Respond" status icon. `-404` redirect if the group isn't in the owned list.
+- **Details tab**: "Created on {date} by {createdBy}." and "Group shared with" = owner names. "OTHER ACTIONS" exposes Edit / Share / Delete-or-Remove.
+- **IHL only**: an "Export to Excel" button on the Students tab (desktop). Columns: Student ID, Name, Class, Course.
+
+### US-5: Edit a Custom Group (Staff)
+
+**As a** staff member with access to a group,
+**I want to** rename it and add/remove students,
+**So that** I can keep the roster current.
+
+**Acceptance Criteria:**
+
+- Details → "Edit Group" → `/groups/customGroups/:id/edit` (`CustomGroupPage`, `pageType === 'edit'`).
+- `getGroupData(id)` → `GET /api/web/v2/staff/groups/custom/:id` pre-populates `groupName` + `selectedStudentIds`.
+- Both manual add and Excel upload available. "Save" enabled only when changed (`isFormEdited`) and valid → `PUT /api/web/v2/staff/groups/custom/:id` with `{ groupName, selectedSchoolStudents }`.
+- On success: notification `edit_group_success`, redirect to `/groups/customGroups/:id`.
+
+### US-6: Share a Custom Group with Other Staff (Staff)
+
+**As a** staff member who owns/has access to a group,
+**I want to** share it with other staff,
+**So that** they can also send to and manage the group.
+
+**Acceptance Criteria:**
+
+- Details → "Share this custom group" (body: "You will be granting access to edit this group. Please be certain.") → `ShareGroupOverlay`.
+- Pick staff via `ShareStaffComboBox`. "Share group" disabled until ≥1 selected.
+- **Permissions model is co-ownership, not editor/viewer.** The overlay states verbatim the granted rights: **View and send to the group**, **Edit the group name**, **Add or delete students**, **Share the group with other staff**. Shared staff become `owners` with the full action set.
+- On confirm → `PUT /api/web/v2/staff/groups/custom/:id/share` with `{ selectedStaff }`. Server validates same-school, not-already-owner, and emails the added staff.
+
+### US-7: Delete a Custom Group (Last Owner) (Staff)
+
+**As a** staff member who is the sole owner of a group,
+**I want to** delete it permanently,
+**So that** obsolete groups are removed.
+
+**Acceptance Criteria:**
+
+- The Delete action appears **only when `owners.length === 1`** and the current staff is that owner. Surfaces an `isPartOfMessageGroup` warning when used by a message group.
+- Confirm → `DELETE /api/web/v2/staff/groups/custom/:id`. On success: redirect to `/groups`, notification `delete_group_success`.
+- Server guard: deletion only proceeds when the requester is the **last** remaining owner; else `{ success: false, reason: 'Invalid custom group or Staff not last owner' }`.
+- **Multi-select / bulk delete is NOT implemented in pgw-web.** Deletion is per-group from the detail page only. (See Assumptions #6.)
+
+### US-8: Remove Own Access from a Shared Group (Non-Last Owner) (Staff)
+
+**As a** staff member sharing a group with others,
+**I want to** remove my own access,
+**So that** I stop seeing/sending to a group I no longer need, without affecting other owners.
+
+**Acceptance Criteria:**
+
+- The Remove action appears **only when `owners.length > 1`** and the current staff is among them (body: "You will no longer be able to select this group when creating new posts.").
+- Confirm → `PUT /api/web/v2/staff/groups/custom/:id/removeAccess`. On success: redirect `/groups`, notification `remove_access_group_success`.
+- Server guard: only proceeds when more than one owner exists and the requester is one of them (the last owner must Delete instead).
+
+### US-9: View Assigned (Auto-Provisioned School Cockpit) Groups (Staff)
+
+**As a** school staff member,
+**I want to** see the class and CCA groups assigned to me by School Cockpit,
+**So that** I can deep-link into them without creating anything.
+
+**Acceptance Criteria:**
+
+- On `/groups`, `getAssignedGroups()` → `GET /api/web/v2/staff/groups/assigned?type=summary` populates an "Assigned Groups" section (shown only when classes or CCA groups exist).
+- For MS the title includes the academic year; for IHL it is just "Assigned Groups".
+- Assigned **class** → `/groups/class/details/:id`; assigned **CCA** → `/groups/cca/details/:id`.
+- These are derived from SC staff allocations (read-only) — not custom groups, no create/edit/share/delete. There is **no separate "SC custom group" entity** — PGTW-15's "SC custom group" maps to this assigned grouping.
+
+### US-10: Reuse a Custom Group as a Post Recipient (Staff)
+
+**As a** staff member composing a post/consent form/announcement,
+**I want to** select a saved custom group as a recipient target,
+**So that** I don't re-select students each time.
+
+**Acceptance Criteria:**
+
+- The recipient picker (`StudentGroupsComboBox`) exposes a "Group" tab alongside Class / Level / School / CCA / Individual; custom groups surface there (`GroupTypes.GROUP = 'group'`), with an inline "+ Create Custom Group" link.
+- A selected group resolves to its current members at send time; recipient counts via `POST .../groups/student/count`. Self-removal (US-8) and deletion (US-7) make the group unavailable as a future recipient.
+
+### US-11: IHL Variant (Student ID vs Index) (Staff)
+
+**As a** staff member at an Institute of Higher Learning,
+**I want to** identify students by Student ID rather than class index,
+**So that** rosters match my institution's records.
+
+**Acceptance Criteria:**
+
+- `isIhl` (Redux `indexPage.isIhl`, server-derived via `IHL_SCHOOL_IDS`) switches all identity displays (Student ID vs index/UIN), the upload schema (Student ID vs Name+Class), the valid/invalid result tables, and IHL-only Excel export on the detail Students tab.
+- The 5,000 cap is gated for IHL at the UI submit, on upload validation, and server-side; MS create/edit don't gate the cap in the button but the BFF still rejects > 5000 on upload.
+- IHL additionally enforces **unique group names** server-side on create/edit; MS does not.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Group Creation (manual)
+
+- A group requires a non-empty `groupName` (UI max 120 chars) and at least one student.
+- Manual selection sources the roster from `GET /api/web/v2/staff/school/students` and submits deduped `selectedSchoolStudents` to `POST /api/web/v2/staff/groups/custom`.
+- Server validates each student exists, is in the school, has an active allocation and a level; else `'custom group has invalid student'`. Duplicate IDs → `'customGroups has duplicate elements'`. Empty target → `'customGroups targets cannot be empty'`.
+
+#### FR-2: File Upload + Validation
+
+- **Accepted type**: `.xlsx` only. **Max size**: 5 MB. **Max files**: 1. **Max students**: 5,000.
+- **MS columns**: `Name`, `Class` (any order, case-insensitive, trimmed). **IHL column**: `Student ID`.
+- Two-stage validation: (1) client-side structural checks with the exact `ValidationMessages` strings; (2) server-side roster matching via an async token + Redis + 3 s polling job.
+- Per-row invalid reasons (`CUSTOM_GROUP_FILE_UPLOAD_INVALID_MESSAGES`): IHL `Not found` / `Currently inactive` / `No level`; MS `Name not found…` / `Class not found…` / `Name and class do not match…` / `Student is marked as inactive…`. Row numbers are `excel index + 2`.
+- Only valid students are added; the group may be created with the valid subset. Manual and upload paths are mutually exclusive within one editing session.
+
+#### FR-3: Sharing / Permissions
+
+- Sharing is **co-ownership**: every shared staff becomes an `owner` with rights to view, send to, rename, add/remove students, and re-share. **No editor/viewer distinction.**
+- `PUT .../groups/custom/:id/share` with `{ selectedStaff }`. Server rejects out-of-school or already-owner targets; sends a share-notification email.
+
+#### FR-4: Lifecycle / Edit / Delete / Remove-access
+
+- Edit: `PUT .../groups/custom/:id` (rename + replace student set). Save gated on actual change + validity.
+- Delete (last owner only): `DELETE .../groups/custom/:id` (server "last owner" guard).
+- Remove access (non-last owner only): `PUT .../groups/custom/:id/removeAccess`.
+- Delete vs Remove chosen by owner count in the UI. **No bulk/multi-select delete exists.**
+
+#### FR-5: SC / Assigned Groups Integration
+
+- Assigned class/CCA groups come from `GET .../groups/assigned?type=summary` and deep-link to read-only `/groups/class/details/:id` and `/groups/cca/details/:id`. Auto-provisioned from SC allocations; no CRUD/share. No standalone SC-custom-group entity exists.
+
+#### FR-6: Reuse as Recipients
+
+- Saved custom groups appear under the "Group" tab of `StudentGroupsComboBox` when composing posts/forms/announcements, with an inline "+ Create Custom Group" shortcut. Recipient counts via `POST .../groups/student/count`.
+
+#### FR-7: Roles / IHL / Variants
+
+- **Owner (creator or shared)**: full edit/share/send; delete only if last owner; remove-access only if not last owner. All owners are equal.
+- **IHL**: Student-ID-keyed upload/match/display; IHL-only Excel export; 5,000 cap gated in UI submit; unique group name enforced server-side.
+- **MS**: Name+Class-keyed; UIN/FIN + index display; no UI submit cap (BFF still caps upload at 5,000); group-name uniqueness not enforced.
+
+#### FR-8: Navigation Guard
+
+- Create/Edit pages guard accidental navigation via `Prompt` + `beforeunload` while dirty and not yet posted; Safari bfcache defeated via `onpageshow`.
+
+### Key Entities
+
+| Entity                              | Description                                                                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `CustomGroup`                       | A staff-owned group: `id`, `groupName`, `createdBy`, `createdAt`, `owners[]`, `studentsList[]`, `isPartOfMessageGroup`.                                                  |
+| `IGroupSummaryDetails`              | List-row projection: `id`, `groupName`, `numberOfStaff`, `numberOfStudents` (only groups with > 0 students).                                                             |
+| `CustomGroupMember`                 | A student in a group: `studentId`, `studentName`, `className`, `classSerialNo`, `levelCode/Description`, `gender`, `uinFinNo`, `schoolStudentId` (IHL), onboarding flag. |
+| `CustomGroupOwner`                  | Staff with full access (`staffId`, `staffName`) — the join that encodes co-ownership/sharing.                                                                            |
+| `ValidateStudents…Request/Response` | Upload payload `{ studentId }` (IHL) / `{ name, className }` (MS); response `{ token }`; poll result `{ status, data: { validStudents, invalidStudents } }`.             |
+| Assigned / SC group                 | Auto-provisioned `class`/`cca` targets from SC; read-only deep-links.                                                                                                    |
+| `StudentType` enum                  | `IHL` / `MS` — selects the upload/validation/display variant.                                                                                                            |
+
+---
+
+## Success Criteria
+
+1. **Manual creation**: Staff can create a named group from hand-picked students and see it in the list and as a post recipient.
+2. **Upload creation**: A valid `.xlsx` (≤ 5 MB, correct columns, ≤ 5,000 rows) produces a correct valid/invalid breakdown; a group can be created from the valid subset; every encoded validation message renders verbatim.
+3. **Async validation robustness**: Token issuance, Redis `pending` seeding, and 3-second polling resolve without UI hang; 10-minute TTL / 100-attempt ceiling respected.
+4. **Sharing/co-ownership**: Sharing grants the full action set, triggers the email, and rejects out-of-school or duplicate owners.
+5. **Lifecycle guards**: Delete only for last owner; Remove-access only for non-last owners; the UI shows the correct one based on owner count.
+6. **IHL/MS parity**: Identity columns, upload schema, export availability, name-uniqueness, and the 5,000 cap behave per variant.
+7. **Reuse**: A saved group is selectable under the recipient "Group" tab and resolves to its current membership.
+
+---
+
+## Assumptions
+
+1. The backend is a Node/Express BFF colocated with the React app (Sequelize via `@pgw/db-migration`); routes under `/api/web/v2/staff/groups/custom`.
+2. File parsing happens **client-side** (`xlsx`); only structurally valid rows are sent to the BFF, which performs roster matching against School Cockpit data.
+3. Upload validation is intentionally asynchronous (token + Redis + polling) to tolerate large files (up to 5,000 students).
+4. `isIhl` is derived from school configuration (`IHL_SCHOOL_IDS`), exposed via Redux `indexPage.isIhl`.
+5. CSV is **not** an accepted upload format — only `.xlsx`.
+6. **No multi-select/bulk group deletion exists in pgw-web** (PGTW-20's "multi-select delete" is not present). Deletion is single-group from the detail page, governed by the last-owner guard. Flagged as a gap rather than invented.
+7. "SC custom group" (PGTW-15) corresponds to the read-only Assigned (class/CCA) groups; there is no separate SC-owned custom-group write path.
+8. Group-name uniqueness is enforced only for IHL schools server-side.
+
+---
+
+## Jira Mapping
+
+- **PGTW-13 — Create custom group (manual + file upload)**: US-1 (manual), US-2 (Excel upload), US-11 (IHL); FR-1, FR-2, FR-7, FR-8.
+- **PGTW-14 — Share + edit custom group**: US-5 (edit), US-6 (share); FR-3, FR-4.
+- **PGTW-15 — SC custom group / auto-provisioned groups**: US-9 (Assigned/SC groups); FR-5. (No standalone SC-custom-group write path exists.)
+- **PGTW-20 — Delete (single + multi-select)**: US-7 (single delete, last-owner guard), US-8 (remove access); FR-4. **Multi-select delete is NOT implemented in pgw-web — net-new for TW.**
+- **Cross-cutting — Reuse as recipients**: US-10; FR-6.

--- a/docs/requirements/forms-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/forms-1-pg-reverse-engineer-specs.md
@@ -1,0 +1,326 @@
+# Feature Specification: Consent Forms
+
+**Feature Branch**: `003-consent-forms`
+**Created**: 2026-05-12
+**Status**: Reverse-Engineered
+**Input**: Reverse-engineered from existing codebase
+
+---
+
+## Overview
+
+Consent Forms is a core communication feature in Parents Gateway Web that allows school staff to create, publish, and manage consent/acknowledgement forms sent to parents. Parents respond via the PG mobile app; staff track responses, filter data, edit responses on behalf of parents, and export results to Excel. The feature supports two response types (Yes/No and Acknowledgement), custom follow-up questions, scheduled posting, draft management, and duplication of both drafts and posted forms.
+
+---
+
+## User Scenarios & Testing
+
+### US-1: Create a New Consent Form (Staff)
+
+**As a** school staff member,
+**I want to** create a new consent form with all required fields,
+**So that** I can collect consent from parents for school activities.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/consentForms/new`.
+- Staff selects target student groups (by class, level, school, CCA, or custom group) and optionally individual students.
+- Staff selects staff-in-charge (co-owners who can view responses).
+- Staff enters enquiry email address (from staff email, school email, or custom).
+- Staff enters title (max 120 characters) and description (rich text, max 2000 characters).
+- Staff optionally adds in-app shortcuts (e.g., Declare Travels, Edit Contact Details -- hidden for SPED schools).
+- Staff adds web links (URL + optional description), file attachments (up to limit), and photo gallery images (with cover photo designation).
+- Staff selects response type: **Yes/No** or **Acknowledgement**.
+- If Yes/No is selected, staff can optionally add custom questions (text, single selection, or multi selection).
+- Staff enters event details: start date/time, end date/time, venue.
+- Staff enters consent due date (mandatory) and configures reminders (none, one-time, or daily).
+- Staff can optionally set a scheduled post date/time for future publishing.
+- A preview is shown before posting.
+- On post, a confirmation modal shows the form title and number of target students.
+- Successful post redirects to the consent forms list with a success notification.
+- WOGAA transaction tracking is fired for scheduled posts.
+
+### US-2: Save Form as Draft
+
+**As a** school staff member,
+**I want to** save an incomplete consent form as a draft,
+**So that** I can continue editing it later.
+
+**Acceptance Criteria:**
+
+- Staff can click "Save as Draft" at any point during creation.
+- Draft is saved via `POST /staff/consentForms/drafts` (new) or `PUT /staff/consentForms/drafts/:id` (existing).
+- After first save, the URL updates to `/consentForms/drafts/:id`.
+- Auto-save triggers on session timeout countdown (auto-save state context).
+- Toast notification confirms successful save.
+- Draft upload expiry is tracked for attachments and photos.
+- If title or description exceeds character limits, save is blocked with inline error.
+- Incomplete schedule date/time (only date or only time filled) blocks save with error.
+
+### US-3: Edit a Draft Consent Form
+
+**As a** school staff member,
+**I want to** open an existing draft and continue editing,
+**So that** I can finalize and post the form.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/consentForms/drafts/:id`.
+- The `useDraftGetter` hook fetches the draft via `ConsentFormDraftManager.getConsentFormDraftById`.
+- All fields are pre-populated from the draft data (student groups, staff groups, title, content, email, shortcuts, URLs, attachments, photos, response type, custom questions, event dates, venue, due date, reminder, schedule).
+- Expired attachments/photos show an expiry alert notification.
+- Staff can edit any field and save again as draft or post.
+
+### US-4: Schedule a Consent Form Post
+
+**As a** school staff member,
+**I want to** schedule a consent form to be posted at a future date/time,
+**So that** I can prepare forms in advance.
+
+**Acceptance Criteria:**
+
+- Staff fills in the schedule date/time picker.
+- On preview, staff clicks "Schedule Post" which opens a confirmation modal showing the scheduled date, time, and a note that student/staff assignments are evaluated at send time.
+- On confirm, the form is saved via `ConsentFormScheduleService.post` (new) or `.put` (existing draft).
+- Scheduled forms appear in the "Created by you" list with status SCHEDULED.
+- Staff can reschedule or cancel scheduled forms from the list action menu.
+- Rescheduling calls `ConsentFormScheduleService.rescheduleScheduledConsentForm`.
+- Cancellation calls `ConsentFormScheduleService.cancelScheduledConsentForm`.
+- Scheduled send failure codes are tracked and displayed.
+
+### US-5: View Consent Forms List (Staff)
+
+**As a** school staff member,
+**I want to** see all consent forms I created or that are shared with me,
+**So that** I can manage and track responses.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/consentForms`.
+- Page shows two tabs: "Created by you" and "Shared with you" (Mantine Tabs, URL query param `tab`).
+- **Created by you** tab: shows forms with columns Title, Date, Status, To Parents Of, # Responded, and an action menu.
+  - Statuses: DRAFT, OPEN, CLOSED, SCHEDULED, POSTING.
+  - Action menu varies by status: Draft (Edit, Duplicate, Delete), Open/Closed (Duplicate), Scheduled (Reschedule, Cancel).
+  - Response progress bar shows `respondedPerStudent / totalStudents`.
+  - Date column is sortable. Status, To Parents Of columns are filterable.
+- **Shared with you** tab: shows forms shared by other staff with columns Title, Date, Status, Created By, To Parents Of, # Responded, and action menu (Duplicate for Open/Closed only).
+- "Create New" button navigates to `/consentForms/new`.
+
+### US-6: View Consent Form Details and Responses (Staff)
+
+**As a** school staff member,
+**I want to** view detailed responses for a posted consent form,
+**So that** I can track parent consent and take action.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/consentForms/details/:id`.
+- Page shows a header with title, event date range, and target groups.
+- Two tabs: "Responses" and "Details".
+- **Responses tab:**
+  - Summary stats at top showing Total, Yes, No, Pending counts (or Total, Yes, Pending for Acknowledgement type).
+  - Clicking a stat filters the response table by that reply value.
+  - Filter section with dropdowns for Status (Onboarded/Not Onboarded), Class, and Show Columns (multi-select).
+  - Response data table with configurable columns: Name (fixed), Class/Index, Gender, Response, Custom Questions (dynamic per question), Comments, Last Responded By, Last Responded On, Status.
+  - IHL schools have alternative column layout (IHL Class, Student ID instead of Class/Index).
+  - "Edit Response" link per student (restricted for onboarded custodians before due date for Yes/No forms).
+  - "Export to Excel" button (desktop only) exports filtered data to .xlsx.
+  - "View more" link on Last Responded By shows reply audit history modal.
+  - For Yes/No response type, a reminder banner is displayed: "Custodians may edit their responses till the due date."
+- **Details tab:**
+  - Shows posting details (date, staff name), staff-in-charge (with Add button), enquiry email (with Edit button), description, shortcuts, venue, web links, file attachments, photo gallery, type of response, custom questions with choices, due date and reminder info (with Edit button), view history (accordion), and Other Actions (Duplicate, Delete).
+
+### US-7: Edit a Student's Response (Staff)
+
+**As a** school staff member,
+**I want to** edit a parent's response on behalf of them,
+**So that** I can correct or update consent information.
+
+**Acceptance Criteria:**
+
+- Staff clicks "Edit Response" for a student in the Responses tab.
+- An overlay opens showing the student name, submitted-by info, and editable fields.
+- Staff can change the reply (Yes/No or Yes for Acknowledgement).
+- If Yes is selected and custom questions exist, staff can edit custom question answers (text input, radio buttons for single selection, checkboxes for multi selection).
+- Staff can edit optional comments (max 500 characters).
+- On save, a confirmation modal appears. On confirm, the response is updated via `PUT /staff/consentForms/:id/student/:studentId/reply`.
+- Custom question replies are only sent when reply is YES.
+- Success notification shown; response table refreshes.
+
+### US-8: Manage Staff-in-Charge
+
+**As a** school staff member,
+**I want to** add or remove staff-in-charge for a consent form,
+**So that** the right staff can manage responses.
+
+**Acceptance Criteria:**
+
+- From the Details tab, staff clicks "Add" next to Staff-in-charge.
+- An overlay shows a staff selector; selected staff are added via `POST /staff/consentForms/:id/addStaffInCharge`.
+- Staff can remove themselves via "Remove" link, which calls `PUT /staff/consentForms/:id/removeAccess` and redirects to the list.
+
+### US-9: Edit Enquiry Email and Due Date
+
+**As a** school staff member,
+**I want to** update the enquiry email or extend the due date of a posted form,
+**So that** parents have the correct contact information and enough time to respond.
+
+**Acceptance Criteria:**
+
+- Edit Enquiry Email overlay allows selecting from staff email, school email, or custom. Calls `PUT /staff/consentForms/:id/updateEnquiryEmail`.
+- Edit Due Date overlay allows changing due date and reminder. Calls `PUT /staff/consentForms/:id/updateDueDate`.
+- History records are created for due date changes and shown in the View History section.
+
+### US-10: Delete a Consent Form
+
+**As a** school staff member,
+**I want to** permanently delete a consent form,
+**So that** obsolete forms are removed.
+
+**Acceptance Criteria:**
+
+- From the Details tab, staff checks a disclaimer checkbox and clicks "Delete Forever".
+- A confirmation modal appears.
+- On confirm, the form is deleted via `DELETE /staff/consentForms/:id` (or `/schoolAdmins/consentForms/:id` for admins).
+- Redirects to the consent forms list with a success notification.
+
+### US-11: Duplicate a Consent Form
+
+**As a** school staff member,
+**I want to** duplicate an existing consent form (draft or posted),
+**So that** I can reuse it with modifications.
+
+**Acceptance Criteria:**
+
+- From the list action menu or Details tab, staff can duplicate.
+- Draft duplication calls `POST /staff/consentForms/drafts/duplicate`.
+- Posted form duplication calls `POST /staff/consentForms/duplicate`.
+- Both return a new draft ID; staff is redirected to `/consentForms/drafts/:newId` with a success toast.
+- Analytics events are tracked for duplication.
+
+### US-12: View Consent Forms List (School Admin)
+
+**As a** school admin,
+**I want to** view all consent forms across my school,
+**So that** I can oversee school communications.
+
+**Acceptance Criteria:**
+
+- Admin navigates to `/admin/consentForms`.
+- Legacy list view showing all posted forms with title, event dates, due date indicator, creator name, posted date, and total recipient count.
+- Clicking navigates to `/admin/consentForms/details/:id`.
+- Admin has `isAdmin=true` flag which maps to `/schoolAdmins/consentForms` API endpoint.
+- Admin can delete forms but cannot add/remove staff or edit email/due date.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+#### FR-1: Form Creation
+
+- Support two response types: `YES_NO` and `ACKNOWLEDGEMENT`.
+- Support custom questions with types: `text`, `single_selection`, `multi_selection`.
+- Custom questions are only applicable when response type is `YES_NO`.
+- Each custom question has a title, optional description, and for selection types, a list of choices with id/label.
+- Support event date range (start date/time, end date/time), venue, consent due date.
+- Support three reminder types: `NONE` (default due-date reminder only), `ONE_TIME` (additional reminder on specific date), `DAILY` (daily reminders from date until due date).
+- Support rich text content (JSON format via `richTextContent` field).
+- Support file attachments and photo gallery with file token-based upload.
+- Support in-app shortcuts selection.
+- Support web links with optional descriptions.
+- Support staff groups selection for co-ownership.
+- Title max length: 120 characters. Description max length: 2000 characters.
+
+#### FR-2: Draft Management
+
+- Auto-save on session timeout trigger.
+- Manual save as draft at any time.
+- Draft persists all form fields including scheduled post date/time.
+- Draft upload expiry tracking for attachments and photos.
+- Drafts can be edited, deleted, or duplicated.
+
+#### FR-3: Scheduled Posting
+
+- Forms can be scheduled for future posting with a specific date and time.
+- Scheduled forms can be rescheduled or cancelled.
+- Students and staff assignments are evaluated at the time of actual sending, not scheduling.
+- A reminder is sent to the creator before the scheduled time (unless within 24 hours).
+- Scheduled send failure codes are tracked and displayed.
+
+#### FR-4: Response Tracking
+
+- Track responses per student: YES, NO, or Pending (for YES_NO); YES or Pending (for ACKNOWLEDGEMENT).
+- Display response summary stats with interactive filtering.
+- Support filtering by class, onboarding status, and reply type.
+- Support configurable column visibility.
+- Custom question responses displayed inline in the data table.
+- Reply audit trail shows history of response changes (by custodian or teacher).
+
+#### FR-5: Response Editing
+
+- Staff can edit responses on behalf of parents.
+- For Yes/No forms, editing is restricted for onboarded custodians until after the due date.
+- Custom question replies are mandatory when reply is YES.
+- Comments are optional (max 500 characters).
+
+#### FR-6: Export
+
+- Export filtered response data to Excel (.xlsx).
+- Export respects column visibility and filter settings.
+- Export includes class, index, name, gender, response, custom questions, comments, last responded by/on, status.
+- Export is not available on mobile devices.
+
+#### FR-7: Roles and Access
+
+- **Staff**: Full CRUD on own forms, edit responses, manage staff-in-charge, edit email/due date.
+- **Staff (shared)**: View responses, duplicate posted forms. No edit/delete.
+- **School Admin**: View all school forms, delete forms. No staff management or field editing. Uses `/schoolAdmins/` API path.
+- **IHL (Institute of Higher Learning)**: Alternative column layout with Student ID instead of index number.
+- **SPED (Special Education)**: In-app shortcut "Edit Contact Details" is hidden.
+
+#### FR-8: Navigation Prevention
+
+- Unsaved changes trigger a browser navigation prompt ("You are about to leave this page. Any unsaved changes will be lost.").
+- `useUnloadEvent` hook prevents accidental page close.
+
+### Key Entities
+
+| Entity                  | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `ConsentForm`           | A posted consent form with full response data             |
+| `ConsentFormDraft`      | A draft consent form (pre-posting)                        |
+| `ConsentFormRecipient`  | A student-parent pair targeted by a form, with reply data |
+| `CustomQuestion`        | A follow-up question attached to a Yes/No form            |
+| `CustomQuestionReply`   | A parent's answer to a custom question                    |
+| `ConsentFormTarget`     | Target group (class, level, school, CCA, custom group)    |
+| `ConsentFormOwner`      | Staff member who owns/co-owns the form                    |
+| `ConsentFormHistory`    | Audit trail of form changes (creation, due date edits)    |
+| `ConsentFormReplyAudit` | Audit trail of individual reply changes                   |
+
+---
+
+## Success Criteria
+
+1. **Form Creation**: Staff can successfully create and post a consent form with all field types, receiving confirmation and seeing it in the list.
+2. **Draft Persistence**: Drafts save all fields and restore correctly on reload, including auto-save on timeout.
+3. **Scheduled Posting**: Scheduled forms are sent at the correct time; reschedule and cancel work without data loss.
+4. **Response Tracking**: Response summary stats are accurate; filters work correctly across all combinations; data table displays all columns including dynamic custom question columns.
+5. **Response Editing**: Staff can edit responses with all custom question types; validation enforces mandatory fields; confirmation modal prevents accidental changes.
+6. **Export Accuracy**: Excel export matches the filtered data table exactly, including custom question columns.
+7. **Role-Based Access**: Admin and staff views correctly restrict/enable actions based on role; IHL and SPED variants render correctly.
+8. **Data Integrity**: Optimistic concurrency via `updatedAt` field; file upload state tracking (success/fail/expired).
+
+---
+
+## Assumptions
+
+1. The backend API is a Node.js BFF (Backend-For-Frontend) running alongside the React frontend, using Sequelize ORM (`@pgw/db-migration`).
+2. File uploads (attachments, photos) use a token-based upload flow where files are uploaded separately and referenced by `fileToken`.
+3. The mobile app (Parents Gateway) handles the parent-side response flow; this spec covers only the staff web portal.
+4. Rich text content is stored as JSON (`richTextContent`) with a plain-text fallback (`content`).
+5. The `isIhl` and `isSped` flags are derived from school configuration and stored in the Redux `indexPage` state.
+6. WOGAA (Whole-of-Government Application Analytics) tracking is a Singapore government requirement for public-facing applications.
+7. The `EResourceStatus` enum (DRAFT, POSTED, SCHEDULED, POSTING) comes from a shared status type; the frontend maps POSTED to OPEN/CLOSED based on the consent-by date.
+8. Session timeout auto-save uses the `AutoSaveStatesContext` (PENDING -> TRIGGER -> SUCCESS/FAILED).

--- a/docs/requirements/heytalia-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/heytalia-1-pg-reverse-engineer-specs.md
@@ -1,0 +1,141 @@
+# Feature Specification: HeyTalia (AI Assistant)
+
+**Feature Branch**: `007-heytalia`
+**Created**: 2026-06-09
+**Status**: Reverse-Engineered (brief)
+**Input**: Reverse-engineered from existing codebase (`src/shared/components/HeyTalia/`, `src/app/actions/heyTalia*.ts`)
+
+---
+
+> ⚠️ **Out of Phase-1 scope.** **HeyTalia is NOT in the PGTW Phase-1 backlog — there is no PGTW story for it.** In `pgw-web` it is beta-gated behind a feature flag plus an explicit `heyTaliaAccess` allowlist, with `TODO: Remove … when HeyTalia is generally available` comments — i.e. a not-yet-GA pilot, not a parity baseline. Treat this spec as reference for later, not current parity work.
+
+---
+
+## Overview
+
+HeyTalia ("Talia") is an in-app AI assistant for school staff, mounted as a header widget (`HeyTaliaHeaderWidget` in `NavBar`) that opens a resizable right-hand chat sidebar (`ChatSidebar`). It helps staff **draft announcements and consent forms** through chat, then either **insert the AI draft into the real creation flow** (creating a draft and navigating to it) or **send the draft by email for human vetting**. It supports file upload (PDF/DOCX) for summarisation, RAG-style knowledge answers with sources, persistent conversation history, and per-message + general feedback. Access is **beta-gated**: rendered only when `flags.heytalia_chat.enabled` AND the user has `heyTaliaAccess`. All endpoints sit under `POST/GET /api/web/2/staff/heytalia/*`.
+
+---
+
+## User Scenarios & Testing
+
+### US-1: Open Talia and start a drafting session
+
+**As a** school staff member with beta access,
+**I want to** open the Talia sidebar and pick a quick action,
+**So that** I can begin drafting with AI help.
+
+**Acceptance Criteria:**
+
+- A "HeyTalia" button appears in the nav header (gated by `heytalia_chat` flag + `heyTaliaAccess`); a preview bubble shows on load for ~5s.
+- Opening the sidebar restores prior state from `localStorage` and fetches history (`GET /api/web/2/staff/heytalia/conversations?limit=100`).
+- **Quick actions**: "Create announcement" and "Create form" (`ActionType = 'announcement' | 'form'`) seed the conversation intent.
+
+### US-2: Generate an AI draft via chat
+
+**As a** staff member,
+**I want to** describe what I need and have Talia produce a structured draft,
+**So that** I can review it before using it.
+
+**Acceptance Criteria:**
+
+- Sending a message → `POST /api/web/2/staff/heytalia/chat` (handles conversation append + metrics).
+- Responses carry `structuredData.type` of `announcement_draft`, `form_draft`, `knowledge_response`, `chat_response`, or `clarification_request`.
+- Drafts can include `placeholderFields` (`[For input]` blanks), a detected `dateFormat`, and `validation_status` / `validation_error`.
+- Knowledge responses render `sources` (filename + S3 URI) via a Reference modal.
+- Optional **file upload** (PDF/DOCX, with char-count metadata) via `POST /api/web/2/staff/heytalia/upload-file`.
+
+### US-3: Use the AI draft in the real creation flow (integration seam)
+
+**As a** staff member,
+**I want to** turn a generated draft into a real PG draft,
+**So that** I can finish and post it in the normal editor.
+
+**Acceptance Criteria:**
+
+- "Use draft" (`handleUseDraft`) parses the message JSON and:
+  - `announcement_draft` → `transformAnnouncementDraft` → `AnnouncementDraftService.post` → navigates to `/announcements/drafts/{id}`.
+  - `form_draft` → `transformConsentFormDraft` → `ConsentFormDraftService.post` → navigates to `/consentForms/drafts/{id}`.
+- A `prefill` metric is logged on success/failure.
+- If required `[For input]` placeholders are unfilled, draft creation fails with a prompt to fill them.
+
+### US-4: Send a draft by email for vetting
+
+**As a** staff member,
+**I want to** email a draft to a colleague for approval,
+**So that** it can be vetted before going out to parents.
+
+**Acceptance Criteria:**
+
+- "Send email" opens `AddRecipientsModal` (recipient history pre-fetched: `GET /api/web/2/staff/heytalia/email/recipients/history?limit=5`), then an `EmailPreviewModal` with editable rich-text (TipTap) subject/body.
+- Sending → `POST /api/web/2/staff/heytalia/email` with recipients, `draftContentJson`, attribution, subject, `ccEmail` (sender), `senderName`.
+- On success an in-chat **email receipt** message records per-recipient `success`/`failed` status.
+
+### US-5: Conversation history and feedback
+
+**As a** staff member,
+**I want** my chats saved and a way to rate responses,
+**So that** I can resume work and help improve Talia.
+
+**Acceptance Criteria:**
+
+- History list + load + delete: `GET .../conversations`, `GET .../conversations/{id}`, `POST .../conversations/delete`.
+- Per-message thumbs feedback (`responseGood`, optional `feedbackTag`, `feedbackText`) and general feedback (`feedbackText`, `rating`) → `POST /api/web/2/staff/heytalia/feedback`.
+- Engagement metrics → `POST /api/web/2/staff/heytalia/metrics`; session tracked client-side via `sessionManager`.
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-1**: Beta-gate rendering behind `flags.heytalia_chat.enabled` + `heyTaliaAccess`.
+- **FR-2**: Chat through `POST .../heytalia/chat`; classify responses by `structuredData.type`.
+- **FR-3**: Two entry intents — announcement and form (`QuickActions`).
+- **FR-4**: "Use draft" creates a real Announcement/Consent-Form draft and navigates to its editor URL (the integration seam).
+- **FR-5**: "Send email" routes a draft for human vetting with editable preview and per-recipient receipt.
+- **FR-6**: Persist + restore session/messages in `localStorage`; persist conversations server-side (list/load/delete).
+- **FR-7**: Support PDF/DOCX upload for summarisation with char-count metadata.
+- **FR-8**: Capture per-message and general feedback; log engagement metrics.
+- **FR-9**: Surface RAG sources, draft validation errors, and `[For input]` placeholder fields.
+
+### Key Entities
+
+| Entity            | Description                                                                                                           |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `ChatMessage`     | A message (`user`/`assistant`/`system`) with optional `structuredData`, `fileAttachment`, `emailReceipt`              |
+| `structuredData`  | Typed payload: `announcement_draft` / `form_draft` / `knowledge_response` / `chat_response` / `clarification_request` |
+| `FileAttachment`  | Uploaded PDF/DOCX metadata (name, size, charCount, type)                                                              |
+| Conversation      | Server-persisted chat thread (list/load/delete)                                                                       |
+| `emailReceipt`    | Per-recipient send result for the vetting email                                                                       |
+| Session / metrics | Client `sessionManager` tracking active/idle time                                                                     |
+
+---
+
+## Success Criteria
+
+1. Beta-eligible staff can open Talia, draft an announcement or form via chat, and review structured output.
+2. "Use draft" reliably creates the corresponding PG draft and lands the user in the real editor.
+3. "Send email" delivers the draft for vetting and reports per-recipient status.
+4. Conversations persist and reload; feedback and metrics are recorded.
+
+---
+
+## Assumptions
+
+1. The chat/email/metrics endpoints are BFF proxies fronting an LLM service (chat handles conversation persistence + metrics server-side; email generates final HTML Lambda-side).
+2. `senderName`/`staffEmailAdd` come from Redux `indexPage`; `ccEmail` is the sender's own email.
+3. Draft transforms (`transformAnnouncementDraft`, `transformConsentFormDraft`) map AI JSON onto the existing Announcement/Consent-Form draft schemas.
+4. The S3 source URIs in knowledge responses point at an internal document store for RAG.
+
+---
+
+## Integration Seam (if PG ever pulls it into scope)
+
+The load-bearing coupling is `handleUseDraft` in `ChatSidebar.tsx` — it POSTs an AI-generated payload to `AnnouncementDraftService` / `ConsentFormDraftService` and then navigates to `/announcements/drafts/{id}` or `/consentForms/drafts/{id}`. This is a **prefilled-draft handoff** into the existing creation flows (it creates a real server-side draft, then deep-links to that draft's editor — no magic-link token). The parallel email path (`POST .../heytalia/email`) is the vetting handoff. Any future TW adoption needs those draft-service transforms and the draft editor routes to exist on the TW side.
+
+---
+
+## Jira Mapping
+
+**No PGTW story exists for HeyTalia** — out of Phase-1 scope. This spec is forward-looking reference only.

--- a/docs/requirements/ptm-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/ptm-1-pg-reverse-engineer-specs.md
@@ -1,0 +1,168 @@
+# Feature Specification: Parent-Teacher Meetings (PTM)
+
+**Feature Branch**: `005-ptm`
+**Created**: 2026-06-09
+**Status**: Reverse-Engineered (brief)
+**Input**: Reverse-engineered from existing codebase (pgw-web)
+
+---
+
+## Overview
+
+Parent-Teacher Meetings (PTM) lets school staff create a slot-based meeting event for parents of selected students. A staff member configures basic info (targets, staff-in-charge, enquiry email, web links, attachments), meeting day/time ranges with a per-slot duration and slots-per-timing capacity, and a single booking window during which parents self-book a slot via the PG mobile app. Staff track booking progress on a Meetings dashboard (Ongoing / Upcoming / Past, each meeting showing Available / Booked / Pending counts) and drill into a per-meeting details page with a Schedule view, where they can block slots, add/change/remove a student in a slot on a parent's behalf, manage staff-in-charge, edit the enquiry email, export the schedule, and delete the event. All PTM endpoints are served under the staff v2 base (`{STAFF_BASE_URL_V2}/ptm`).
+
+---
+
+## User Scenarios & Testing
+
+### US-1: Create a Meeting Event (Staff)
+
+**As a** school staff member,
+**I want to** create a meeting event with target students, meeting days/times, slot duration/capacity, and a booking window,
+**So that** parents can book a meeting slot with me.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/meetings/new`; a 4-step `Stepper` (Basic Info → Meeting Details → Booking Window → Booking Preview).
+- **Step 1**: target student groups, staff-in-charge (co-owners), title, description, venue, enquiry email, web links, file attachments (token-based via `fileToken`).
+- **Step 2**: `durationPerSlot` (minutes), `bookingsPerSlot` (slots per timing), one or more meeting day/time ranges (`meetingDateTimes`).
+- **Step 3**: one booking window (start/end date-time) — "5.0 initial will support one booking window".
+- **Step 4**: preview, then submit.
+- On submit, `PtmService.createPtmEvent` → `POST {STAFF_BASE_URL_V2}/ptm` with `staffsInCharge`, `targets`, `title`, `description`, `venue`, `enquiryEmailAddress`, `eventDates`, `durationPerSlot`, `bookingsPerSlot`, `bookingWindows`, `webLinkList`, `attachments`.
+- Server validates date ranges against duration (`validateDateRange`); meetings created today must be ≥ `DEFAULT_EARLIEST_MEETING_DATE_DAYS_AFTER_TODAY` days out.
+- Success returns `{ eventId }`, fires `MeetingCreated`, redirects to `/meetings`.
+
+### US-2: Meetings Dashboard (Staff)
+
+**As a** school staff member,
+**I want to** see all my meeting events grouped by status with booking progress,
+**So that** I can monitor responses at a glance.
+
+**Acceptance Criteria:**
+
+- `/meetings`; `usePtmList` → `GET {STAFF_BASE_URL_V2}/ptm` returns `{ events, serverDateTime }`.
+- Events categorised by server time into **Ongoing**, **Upcoming**, **Past**.
+- Each row shows meeting-day count, `{durationPerSlot} min per slot`, `{bookingsPerSlot} slot(s) per timing`, booking-window status, and stats **Available / Booked / Pending** + target count.
+- Rows sortable (`EarliestStart / LatestEnd / LatestCreated`); each links to `/meetings/details/{eventId}`. "Create New" → `/meetings/new`.
+
+### US-3: View Meeting Details & Per-Slot Booking Status (Staff)
+
+**As a** school staff member,
+**I want to** open a meeting and see each day's slots and who has booked,
+**So that** I can review and manage the schedule.
+
+**Acceptance Criteria:**
+
+- `/meetings/details/:id`; two tabs: **Schedule** and **Details**.
+- Loads details (`GET .../ptm/:id`), time slots (`GET .../ptm/timeslots/:id`), and bookings for the selected day (`GET .../ptm/bookings/:id?scheduleDate=...` with `bookedCount`/`availableCount`/`blockedCount`).
+- Schedule grouped by day; each slot shows status `available` / `booked` / `blocked` and, when booked, the student/comment. Per-booking detail via `GET .../ptm/booking/:timeslotBookingId`.
+- Schedule exportable (`ScheduleExportManager`, desktop).
+
+### US-4: Manage Slots — Block / Unblock and Help a Parent Book (Staff)
+
+**As a** school staff member,
+**I want to** block slots and add/change/remove a student in a slot on a parent's behalf,
+**So that** I can manage availability and assist parents who cannot self-book.
+
+**Acceptance Criteria:**
+
+- **Block (booked slot)**: "Block and remove student?" → `POST .../ptm/booking/block` (`{ bookingId, currEventStudentId? }`).
+- **Unblock**: `POST .../ptm/booking/unblock` (`{ bookingId }`).
+- **Help-book / Add student**: Add/Edit overlay with eligible students from `GET .../ptm/:eventId/targetStudents`. Add → `POST .../ptm/booking/add`; change → `POST .../ptm/booking/change`; remove → `POST .../ptm/booking/remove`.
+- Server guardrails surfaced as error reasons: `hasExistingResponse`, `slotAlreadyBooked`, `remarksMismatch`, `eventStudentMismatch`.
+
+### US-5: Manage Staff-in-Charge & Enquiry Email (Staff)
+
+**As a** school staff member,
+**I want to** add co-owners and update the enquiry email,
+**So that** the right staff can manage the meeting and parents have correct contact info.
+
+**Acceptance Criteria:**
+
+- Add staff-in-charge → `POST .../ptm/:eventId/addStaffInCharge`; new staff emailed.
+- Remove self → `PUT .../ptm/:eventId/removeAccess`; redirects to `/meetings`.
+- Edit enquiry email → `PUT .../ptm/:eventId/updateEnquiryEmail`.
+
+### US-6: Delete a Meeting Event (Staff)
+
+**As a** school staff member,
+**I want to** delete a meeting event,
+**So that** obsolete events are removed.
+
+**Acceptance Criteria:**
+
+- "Delete meeting event now?" confirmation → `DELETE .../ptm/:id`; redirects to `/meetings`.
+
+> **Not found / flagged:** No edit-event flow exists — routes are only `/meetings`, `/meetings/new`, `/meetings/details/:id`. Post-creation changes are limited to staff-in-charge, enquiry email, and per-slot booking management; core event fields (dates, duration, capacity, booking window) are not editable. Whole-slot block (`blockPtmTimeSlot`) is stubbed (`TODO`, not API-ready).
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-1 (Event creation):** Create a PTM event with targets, staff-in-charge, title, description, venue, enquiry email, web links, attachments. `POST {STAFF_BASE_URL_V2}/ptm` → `{ eventId }`.
+- **FR-2 (Slot model):** An event has one or more `eventDates` (day + start/end range); slots are generated from each range using `durationPerSlot`. Each timing supports `bookingsPerSlot` parallel bookings (capacity).
+- **FR-3 (Booking window):** Exactly one booking window governs parent self-booking; status `NOT_STARTED` / `OPEN` / `CLOSED` (`EBookingWindowStatus`).
+- **FR-4 (Date guardrail):** Dates validate against duration and respect a minimum lead time (`DEFAULT_EARLIEST_MEETING_DATE_DAYS_AFTER_TODAY`).
+- **FR-5 (Dashboard):** List events with server-time Ongoing/Upcoming/Past categorisation and per-event booking summary + target count; sortable.
+- **FR-6 (Schedule view):** Per-day slot grid with booking detail and `booked/available/blocked` counts; per-booking lookup by `timeslotBookingId`.
+- **FR-7 (Block/unblock):** `/ptm/booking/block`, `/ptm/booking/unblock`; blocked slots aren't bookable by parents.
+- **FR-8 (Help-book management):** Add/change/remove a student in a slot (`/ptm/booking/add|change|remove`) from eligible `targetStudents`, with conflict guards.
+- **FR-9 (Staff-in-charge):** Add staff-in-charge and remove self; notify added staff by email.
+- **FR-10 (Enquiry email):** Update enquiry email post-creation.
+- **FR-11 (Delete):** `DELETE /ptm/:id`.
+- **FR-12 (Export & server time):** Export schedule to Excel; expose server date-time (`/ptm/serverdatetime`) for categorisation/booking-window math.
+- **FR-13 (Parent side, out of web scope):** Parents view/book/change via mobile; reply enum `ESchoolEventReply` = YES/NO.
+
+### Roles
+
+- **Owner / staff-in-charge:** full management (block, help-book, staff-in-charge, enquiry email, delete) on events they own/co-own.
+- **Parent (custodian):** self-books within the booking window via mobile; permission via `EParentPermission` (`''` / `r` / `rw`).
+
+---
+
+## Key Entities
+
+| Entity                                           | Description                                                                              |
+| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `IPTMEventSummary` / `IPTMEventDetails`          | A meeting event (targets, dates, `durationPerSlot`, `bookingsPerSlot`, booking summary). |
+| `ISchoolEventDate`                               | A start/end date-time range; used for both `eventDates` and `bookingWindows`.            |
+| `IPTMEventSlot` / `…WithBookings`                | A generated time slot with start/end and availability/bookings.                          |
+| `ISchoolEventTimeSlotBooking`                    | A booking of a slot (status `available`/`unavailable`; UI also surfaces `blocked`).      |
+| `ISchoolEventBookingSummary`                     | `{ available, booked, pending }` rollup per event.                                       |
+| `IEventStudentDetails` / `ITargetStudentDetails` | A targeted/eligible student for a booking.                                               |
+| `ICustodianDetails`                              | Parent linked to a student, with `EParentPermission`.                                    |
+| `IEventReply`                                    | A parent's reply (`ESchoolEventReply` YES/NO) + booked slot + remarks.                   |
+
+---
+
+## Success Criteria
+
+1. **Creation:** Staff complete the 4-step flow; slots generate from day/time ranges using duration + capacity; the event appears in the correct dashboard section.
+2. **Tracking:** Dashboard and details counts (Available / Booked / Pending / Blocked) accurately reflect bookings against server time.
+3. **Management:** Block/unblock and add/change/remove-student actions persist and enforce conflict guardrails.
+4. **Lifecycle:** Staff-in-charge, enquiry email, and delete actions succeed with correct redirects/notifications.
+
+---
+
+## Assumptions
+
+1. PTM is built on the shared school-event/booking model; it's the only school-event type wired to this slot/booking-window flow here.
+2. Backend is the Node BFF (Sequelize via `@pgw/db-migration`); all routes under `{STAFF_BASE_URL_V2}/ptm`.
+3. Parent-side booking happens on the PG mobile app; this spec covers the staff web portal only.
+4. Exactly one booking window per event in this version; multi-window is a future extension.
+5. Attachments use the token-based (`fileToken`) flow shared with Consent Forms.
+6. No event-edit or scheduled-post flow exists for PTM; whole-time-slot block is stubbed and not yet API-backed.
+
+---
+
+## Jira Mapping
+
+| Ticket      | Scope                                | Spec coverage                 |
+| ----------- | ------------------------------------ | ----------------------------- |
+| **PGTW-21** | Create meeting event                 | US-1, FR-1..FR-4              |
+| **PGTW-22** | Dashboard + responses/booking status | US-2, US-3, FR-5, FR-6, FR-12 |
+| **PGTW-23** | Management: block slots / help book  | US-4, US-5, US-6, FR-7..FR-11 |
+
+**Notes:** Edit-event and scheduled-posting (present in Consent Forms) are absent in PTM. `removeSelfFromStaffInCharge` / `updateEnquiryEmail` could split into a separate lifecycle ticket if PGTW-23 is scoped purely to slot management.

--- a/docs/requirements/reports-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/reports-1-pg-reverse-engineer-specs.md
@@ -1,0 +1,138 @@
+# Feature Specification: Reports
+
+**Feature Branch**: `006-reports`
+**Created**: 2026-06-09
+**Status**: Reverse-Engineered (brief)
+**Input**: Reverse-engineered from existing codebase (`src/app/pages/StaffReports/`, `src/app/pages/AdminReports/`)
+
+---
+
+## Overview
+
+Reports is a self-service export feature in Parents Gateway Web that lets school staff generate Excel (`.xlsx`) reports about their students. The real codebase exposes exactly **two report types**, surfaced as sub-nav tabs on a single Reports page:
+
+1. **Onboarding** — custodian (parent) PG onboarding status.
+2. **Travel Declaration** — declaration status over a chosen date range.
+
+There are two parallel pages with near-identical UX, differing only in scope and API path:
+
+- **Staff Reports** (`/staff/reports`) — Form Teacher (FT) / Co-Form Teacher: scoped to the staff member's assigned **form class**.
+- **Admin Reports** (`/admin/reports`, gated by `AdminRoute`) — Staff with Admin rights: scoped to the **whole school**.
+
+For **IHL** schools the Travel Declaration tab is hidden (`!isIhl` gates the `SubNav`), so IHL sees only the Onboarding report with IHL-specific copy. Both reports are **desktop-only** — on mobile a "This report can only be exported on desktop" notice replaces the export controls.
+
+> **Important:** there is **no in-app drill-down or paginated data table** — the "view" of a report _is_ the downloaded Excel file. Exports are generated **client-side** from JSON rows the API returns.
+
+---
+
+## User Scenarios & Testing
+
+### US-1: Generate Onboarding report for my form class (Staff)
+
+**As a** Form / Co-Form Teacher,
+**I want to** export my form class's custodian onboarding status,
+**So that** I can see which parents have/haven't onboarded onto PG.
+
+**Acceptance Criteria:**
+
+- Staff navigates to `/staff/reports`; the **Onboarding** tab is selected by default.
+- On mount, the page calls `GroupsService.getAssignedGroups()` and renders the staff member's `formClass`.
+- If no form class is assigned, the page shows guidance ("you need a form class… approach Staff with Admin rights") instead of an export button (IHL gets school-info-system worded copy).
+- "Export to Excel" → `downloadStudentOnboardingReport(formClass)` → `GET /api/web/2/staff/school/students/retrieveReport?action=onboardReport`.
+- The workbook has two sheets: **Students** and **Onboarding Status Breakdown**; filename `{schoolCode}-{formClass}-onboarding-report-{timestamp}.xlsx`.
+
+### US-2: Generate Travel Declaration report for my form class (Staff)
+
+**As a** Form / Co-Form Teacher,
+**I want to** export who did/did not declare travel over a date range,
+**So that** I can follow up with non-declaring families.
+
+**Acceptance Criteria:**
+
+- Staff selects the **Travel Declaration** tab (hidden for IHL).
+- Filters: a **declaration status** radio (`Declared (Include travelling and not travelling)` / `Did Not Declare (No declarations made)`) and a **date range** picker.
+- Export is disabled until the date range passes validation (`dateTimeValidationHasError`).
+- "Export to Excel" → `downloadFormClassTravelDeclarationReport(...)` → `POST /api/web/2/staff/school/travelDeclaration` with `{ reportType, startDate, endDate }`; fires `ExportToExcelButtonPressed`.
+- For the "Did Not Declare" case a second **Onboarding Status Breakdown** sheet is appended; otherwise a single **Students** sheet. Empty results yield a placeholder row.
+
+### US-3: Generate school-wide reports (Admin)
+
+**As a** Staff member with Admin rights,
+**I want to** generate Onboarding and Travel Declaration reports for the whole school,
+**So that** I can oversee onboarding and travel compliance across all classes.
+
+**Acceptance Criteria:**
+
+- Admin navigates to `/admin/reports` (route protected by `AdminRoute`).
+- Same two tabs and filters as staff, but scoped to `schoolName` (no form-class lookup; no "without form class" guidance).
+- Onboarding export → `downloadStudentOnboardingReport()` → `GET /api/web/2/schoolAdmins/students?action=onboardReport`; filename `{schoolCode}-onboarding-report-{timestamp}.xlsx`.
+- Travel Declaration export → `POST /api/web/2/schoolAdmins/travelDeclaration`.
+
+### US-4: Switching tabs resets filters
+
+**As a** staff/admin user,
+**I want** filters to reset when I change report tabs,
+**So that** stale date/status selections aren't carried over.
+
+**Acceptance Criteria:**
+
+- Changing tab via `SubNav` resets state to `INITIAL_STATES` (clears status, dates, re-flags `dateTimeValidationHasError`).
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-1**: Provide exactly two report types — **Onboarding** and **Travel Declaration** — as sub-nav tabs on a single Reports page.
+- **FR-2**: Staff reports scoped to the user's assigned form class (`getAssignedGroups()`); Admin reports scoped to the whole school.
+- **FR-3**: For staff with no assigned form class, suppress export and show guidance copy (IHL variant differs).
+- **FR-4**: Hide the Travel Declaration tab for IHL schools; render IHL-specific descriptions for Onboarding.
+- **FR-5**: Travel Declaration requires two filters: declaration-status radio (Declared / Did Not Declare) and a validated date range; disable export until valid.
+- **FR-6**: All exports produce client-side `.xlsx` (`xlsx` / `xlsx-style` + `file-saver`); the API returns JSON rows that the FE serializes (no server-side file download).
+- **FR-7**: Onboarding exports always include a second **Onboarding Status Breakdown** sheet; Travel Declaration includes it only for "Did Not Declare".
+- **FR-8**: Block all exports on mobile user agents; show a desktop-only notice.
+- **FR-9**: Filenames embed `schoolCode`, scope (form class for staff), report identity, and a timestamp.
+- **FR-10**: Route protection — `/admin/reports` requires admin (`AdminRoute`); `/staff/reports` is a standard staff route.
+
+### Key Entities
+
+| Entity                         | Description                                              |
+| ------------------------------ | -------------------------------------------------------- |
+| Onboarding report row          | Per-student custodian onboarding status (Students sheet) |
+| Travel Declaration report row  | Per-student declaration status over date range           |
+| `ETravelDeclarationReportType` | Enum: `Declared` / `DidNotDeclare` (drives radio + API)  |
+| Onboarding Status Breakdown    | Static explainer sheet appended to certain exports       |
+| `formClass`                    | Staff's assigned form class string (report scope)        |
+
+---
+
+## Success Criteria
+
+1. FT/Co-FT can export both reports scoped to their form class; admins can export both school-wide.
+2. Onboarding and Travel Declaration `.xlsx` files open with the correct sheets and naming.
+3. Travel Declaration export is gated on a valid date range and a selected status.
+4. IHL schools see only the Onboarding tab with IHL copy.
+5. Mobile users are blocked with a clear desktop-only message.
+6. Staff without a form class see guidance instead of broken exports.
+
+---
+
+## Assumptions
+
+1. The BFF report endpoints (`.../retrieveReport?action=onboardReport`, `.../travelDeclaration`) return JSON row arrays plus `metadata.schoolCode`; the FE assembles the workbook.
+2. `isIhl`, `staffSchoolId`, `schoolName` come from Redux `indexPage`.
+3. "Admin" here means a staff member with admin rights (the `AdminRoute` guard), not a separate persona.
+4. The Onboarding Status Breakdown sheet content is static reference data.
+5. Date-range validation limits (3-month window) are enforced by the shared `DateRangePicker`.
+
+---
+
+## Jira Mapping
+
+| Story                                   | Coverage                                                                                                                                                                                                                           |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PGTW-16 — Travel Declaration report** | US-2 (staff/form-class), US-3 (admin/school-wide), FR-5, FR-7. Endpoints: `POST /api/web/2/staff/school/travelDeclaration` (staff), `POST /api/web/2/schoolAdmins/travelDeclaration` (admin).                                      |
+| **PGTW-17 — PG onboarding report**      | US-1 (staff/form-class), US-3 (admin/school-wide), FR-2, FR-7. Endpoints: `GET /api/web/2/staff/school/students/retrieveReport?action=onboardReport` (staff), `GET /api/web/2/schoolAdmins/students?action=onboardReport` (admin). |
+
+**Notes:** access = FT / Co-FT (form-class scope) and Staff-with-Admin (school scope); IHL hides Travel Declaration; both reports are desktop-only; there is **no in-app drill-down table** — the report is the exported Excel file.


### PR DESCRIPTION
Adds `docs/requirements/` to the active branch — detailed, code-grounded **parity specs** for the PG features being re-implemented in TW, reverse-engineered from the real PG frontend (`pgw-web`). Format matches the PG team's original `forms-1` spec.

## Contents
- `README.md` — index + terminology note (PG terms ↔ TW *Posts / Posts with responses* rebrand) + platform-contract reference
- `announcements-1`, `forms-1`, `custom-groups-1`, `ptm-1`, `reports-1`, `heytalia-1` — one spec per feature (User Scenarios → Functional Requirements → Key Entities → Success Criteria), mapped to the PGTW Jira backlog

## Notes
- **Docs only** — no code changes.
- These back the GitHub epics (#116 / String-sg/teacher-workspace-pg-frontend#20–#124 on `teacher-workspace`); the **issues remain the source of truth**.
- Specs intentionally use PG's real code terms (Announcements/Consent Forms) for accuracy; the TW product rebrand (Posts / Posts with responses) is noted in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)