### PR TITLE
docs: update specs to engineering team's Complete Redevelopment Specs

### DIFF
--- a/docs/requirements/README.md
+++ b/docs/requirements/README.md
@@ -1,20 +1,22 @@
 # PG ↔ TW Integration — Business Requirements
 
-> **Source of truth: the GitHub epics.** These files mirror the issue bodies for in-repo reference, review and diffing. Edit the issue first, then re-sync the matching file here. Mirrors parent tracker [#116](https://github.com/String-sg/teacher-workspace/issues/116).
+> **Source of truth: the GitHub epics.** These files mirror the issue bodies for in-repo reference, review and diffing. Edit the issue first, then re-sync the matching file here. Mirrors parent tracker [#1](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/1).
 
 > **Terminology note.** These reverse-engineered specs use **PG's real code terms** (Announcements, Consent Forms) so they stay accurate to the source. In the **TW product** these are rebranded: **Announcements → Posts**, **Forms / Consent Forms → Posts with responses**. The TW epics/issues use the new names; the underlying feature is the same.
+
+> **Specs updated (Jun 2026):** the per-feature specs below are the engineering team's **Complete Redevelopment Specs** (authoritative - business logic, validation, API contracts). The platform-contract reference further down is retained for context.
 
 ## Epics
 
 | #   | Epic                              | Requirements doc                                                                    | Issue                                                             |
 | --- | --------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| 1   | Announcements: Create & Send      | [epic-1-announcements-create-send](./epic-1-announcements-create-send.md)           | [#118](https://github.com/String-sg/teacher-workspace/issues/118) |
-| 2   | Announcements: Tracking & Chasing | [epic-2-announcements-tracking-chasing](./epic-2-announcements-tracking-chasing.md) | [#119](https://github.com/String-sg/teacher-workspace/issues/119) |
-| 3   | Forms / Consent Collection        | [epic-3-forms-consent](./epic-3-forms-consent.md)                                   | [#120](https://github.com/String-sg/teacher-workspace/issues/120) |
-| 4   | Custom Student Groups             | [epic-4-custom-student-groups](./epic-4-custom-student-groups.md)                   | [#121](https://github.com/String-sg/teacher-workspace/issues/121) |
-| 5   | Parent-Teacher Meeting Scheduling | [epic-5-ptm-scheduling](./epic-5-ptm-scheduling.md)                                 | [#122](https://github.com/String-sg/teacher-workspace/issues/122) |
-| 6   | Reports                           | [epic-6-reports](./epic-6-reports.md)                                               | [#123](https://github.com/String-sg/teacher-workspace/issues/123) |
-| 7   | HeyTalia (AI Drafting Assistant)  | [epic-7-heytalia](./epic-7-heytalia.md)                                             | [#124](https://github.com/String-sg/teacher-workspace/issues/124) |
+| 1   | Posts: Create & Send      | [announcements-1](./announcements-1-pg-reverse-engineer-specs.md)           | [#20](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/20) |
+| 2   | Posts: Tracking & Chasing | [announcements-1](./announcements-1-pg-reverse-engineer-specs.md) | [#9](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/9) |
+| 3   | Posts with Responses        | [forms-1](./forms-1-pg-reverse-engineer-specs.md)                                   | [#5](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/5) |
+| 4   | Custom Student Groups             | [custom-groups-1](./custom-groups-1-pg-reverse-engineer-specs.md)                   | [#6](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/6) |
+| 5   | Parent-Teacher Meeting Scheduling | [ptm-1](./ptm-1-pg-reverse-engineer-specs.md)                                 | [#7](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/7) |
+| 6   | Reports                           | [reports-1](./reports-1-pg-reverse-engineer-specs.md)                                               | [#10](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/10) |
+| 7   | HeyTalia (AI Drafting Assistant)  | [heytalia-1](./heytalia-1-pg-reverse-engineer-specs.md)                                             | [#11](https://github.com/String-sg/teacher-workspace-pg-frontend/issues/11) |
 
 ## How these requirements were derived (read first)
 

--- a/docs/requirements/announcements-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/announcements-1-pg-reverse-engineer-specs.md
@@ -1,318 +1,638 @@
-# Feature Specification: Announcements
+# Announcements - Complete Redevelopment Spec (Staff & Admin)
 
-**Feature Branch**: `001-announcements`
 **Created**: 2026-06-09
-**Status**: Reverse-Engineered
-**Input**: Reverse-engineered from existing codebase (`pgw-web`)
+**Purpose**: Comprehensive reference for frontend redevelopment — business logic, validation, functional behavior, and API contracts.
 
 ---
 
-## Overview
+## 1. Constants & Constraints
 
-Announcements is a one-way communication feature in Parents Gateway Web that lets school staff broadcast information to parents. Unlike Consent Forms, announcements collect **no parental response** — they track only whether each recipient parent has **read** the post. Staff create announcements targeting student groups (and individual students), assign co-owning staff-in-charge, attach rich-text content, web links, file attachments, and a photo gallery, optionally add in-app shortcuts, and either post immediately, save as a draft (with autosave), or schedule for future sending. After posting, staff track read status per student, filter the recipient table, export to Excel, and duplicate or delete the post. School admins get a read-only oversight list. The feature is a React frontend backed by a Node/Express BFF (`src/server/apiv2/staff/...` and `.../school-admin/...`) using Sequelize models from `@pgw/db-migration`.
+### 1.1 Character Limits
 
----
+| Field | Max Length |
+|-------|-----------|
+| Title | 120 characters |
+| Description (rich text) | 2,000 characters (plain text count) |
+| Enquiry email | 250 characters |
+| Message to Schools (HQ only) | 2,500 characters |
 
-## User Scenarios & Testing
+### 1.2 File Upload Limits
 
-### US-1: Create and Post an Announcement (Staff)
+| Constraint | Value |
+|-----------|-------|
+| Max attachments | 3 files |
+| Max photos | 12 photos |
+| Max cover photos | 3 |
+| Max file size | 5 MB |
+| Attachment extensions | `.pdf, .csv, .docx, .xlsx, .xls, .pptx, .jpg, .jpeg, .gif, .png, .mp3, .mp4, .m4v` |
+| Photo extensions | `.jpg, .jpeg, .png` |
 
-**As a** school staff member,
-**I want to** create a new announcement with all required fields and post it,
-**So that** I can keep parents informed.
+### 1.3 Other
 
-**Acceptance Criteria:**
-
-- Staff navigates to `/announcements/new` (page `CreateAnnouncementPage.tsx`).
-- The form is organized into sections (`FormDivider`): **Recipients (PARENTS)**, **Recipients (SCHOOL STAFF)**, **Enquiry Details**, **Content**, **Gallery**, **Settings**.
-- Staff selects target recipients via `IndividualStudentGroupsComboBoxDirty` — by **class, level, school, CCA, custom group, or individual student**. When >1 unique student is selected, a summary line shows "This announcement will be sent to the parents of N students."
-- Staff selects **staff-in-charge** via `StaffGroupsComboBoxDirty` (co-owners). Sub-label: "These staff will be able to view read status, and delete the announcement". **There is NO editor/viewer access-type distinction** (see note below).
-- Staff selects an **enquiry email** (`EmailSelectorDirty`) from staff email, school email, or a custom "Other" address.
-- Staff enters **title** (max 120 chars — error "Exceeded by N characters") and **description** (rich text, max 2000 chars).
-- Staff optionally adds **in-app shortcuts** (`MultipleSelectCheckboxDirty`, hidden when `isIhl`).
-- Staff adds **web links** (up to 3, URL + optional description), **file attachments** (up to 3, ≤5 MB each), and **photo gallery** images (up to 12, with up to 3 cover photos).
-- Staff optionally fills a **schedule post date/time** under Settings.
-- Staff clicks **Preview** (`AnnouncementPreview`), then **Post Now**. A confirmation modal reads "You are about to post the announcement "<title>" to N students."
-- On confirm, `useSubmitForm` → `AnnouncementManager.postAnnouncement` → `AnnouncementService.post` → `POST /api/web/v2/staff/announcements`.
-- On success: redirect to `/announcements` with success notification linking to `/announcements/details/:id`; analytics `AnnouncementCreated` fired.
-- Targets are sent only as `{ targetType, targetId }` (acad year omitted; resolved server-side at send time).
-
-> **Difference from Consent Forms:** Announcements have **no response type** (no Yes/No or Acknowledgement), **no custom questions**, **no event date range / venue**, **no consent due date / reminders**. The recipient summary stats and table are about **Read / Unread**, not replies.
-
-> **Note on staff-in-charge access type (verified):** The Consent Forms request mentions EDITOR vs VIEWER. Announcements do **not** implement any such enum. `AnnouncementOwner` carries only `pgStaffId` + `isDeleted` (no `accessType`); `grep` for `accessType|EDITOR|VIEWER` yields only the unrelated email-template variable `editor` (the creator's display name). All staff-in-charge are equal co-owners who can view read status and delete.
-
-### US-2: Save Announcement as Draft
-
-**As a** school staff member,
-**I want to** save an incomplete announcement as a draft,
-**So that** I can finish it later.
-
-**Acceptance Criteria:**
-
-- Staff clicks "Save as Draft" (`SaveAsDraftStickyBar`).
-- New draft → `POST /api/web/v2/staff/announcements/drafts`; existing → `PUT /api/web/v2/staff/announcements/drafts/:announcementDraftId` (`AnnouncementDraftManager.saveAsDraft`).
-- After first save, URL replaces to `/announcements/drafts/:announcementDraftId`.
-- Toast: "Your draft announcement has been saved successfully."
-- Draft body persists `studentGroups`, `staffGroups`, `title`, `content`, `enquiryEmailAddress`, `urls`, `shortcuts`, `attachments`/`images` (by `fileToken`), and `scheduledDateTime`.
-- Save is **blocked** if title >120 or description >2000.
-- If exactly one of schedule date / time is filled, save is blocked (`incompleteScheduleSendDatetime`).
-
-### US-3: Autosave on Session Timeout
-
-**As a** school staff member,
-**I want** my in-progress announcement to be autosaved before my session expires,
-**So that** I don't lose work.
-
-**Acceptance Criteria:**
-
-- `useAutoSaveStates` (`AutoSaveStatesContext`) drives a `PENDING → TRIGGER → SUCCESS/FAILED` cycle.
-- On `TRIGGER`, if the form is dirty, `processSaveAsDraft(true)` runs with `isAutosave=true`, sending the `pg-no-extend` header so the session is **not** extended.
-- Autosave updates `updatedAt` silently (no toast); on failure sets state `FAILED`.
-
-### US-4: Edit a Draft Announcement
-
-**As a** school staff member,
-**I want to** reopen and continue editing a draft,
-**So that** I can finalize and post it.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/announcements/drafts/:id`.
-- `useDraftGetter` → `AnnouncementDraftManager.getAnnouncementDraftById` → `GET /api/web/v2/staff/announcements/drafts/:announcementDraftId`.
-- All fields pre-populate (student groups, staff groups, title, `richTextContent`/`content`, email, shortcuts, urls, attachments, images, `scheduledDateTime`).
-- Attachment/photo state derived: `fail → ERROR`, past `expiryDate → EXPIRED`, else `SUCCESS`; expired uploads surface a `NotificationExpiryAlert` via `useDraftUploadExpiryNotifier`.
-
-### US-5: Schedule, Reschedule, and Cancel an Announcement
-
-**As a** school staff member,
-**I want to** schedule an announcement for a future date/time and manage that schedule,
-**So that** I can prepare posts in advance.
-
-**Acceptance Criteria:**
-
-- Staff fills the `SchedulePostDateTimePicker`; on Preview the sticky bar exposes **Schedule Post**.
-- Confirmation modal states students and staff-in-charge are resolved **at send time**, and PG sends a reminder before the scheduled time "unless it's scheduled under the next 24 hours."
-- Schedule new → `POST /api/web/v2/staff/announcements/drafts/schedule`; schedule existing draft → `PUT /api/web/v2/staff/announcements/drafts/schedule/:announcementDraftId`.
-- Scheduled posts appear in **Created by you** with status SCHEDULED; their rows are click-disabled (also for POSTING).
-- **Reschedule** (row action) → `PUT /api/web/v2/staff/announcements/drafts/:announcementDraftId/rescheduleSchedule`.
-- **Cancel** (row action) → modal "Cancel sending this post?" ("the post will be moved to Drafts") → `POST /api/web/v2/staff/announcements/drafts/:announcementDraftId/cancelSchedule`.
-- A failed scheduled send surfaces `scheduledSendFailureCode`; the row expands to show the mapped error message.
-- WOGAA transaction is started on Preview when schedule-eligible and completed on success.
-
-### US-6: View Announcements List (Staff)
-
-**As a** school staff member,
-**I want to** see announcements I created and those shared with me,
-**So that** I can manage them and track reads.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/announcements` (`StaffAnnouncementList.tsx`). Mantine `Tabs`: **Created by you** / **Shared with you**, synced to URL query `tab`.
-- "Create New" page action → `/announcements/new`.
-- **Created by you** (`GET /api/web/v2/staff/announcements`) columns: **Title**, **Date** (sortable), **Status**, **To Parents Of** (filterable), **# Read** (`readPerStudent / totalStudents` + progress bar, shown only for POSTED), and an action menu. Status values from `EAnnouncementAPIResponseStatus` = DRAFT, POSTED, SCHEDULED, POSTING.
-  - Action menu by status: DRAFT → Edit / Duplicate / Delete; POSTED → Duplicate; SCHEDULED → Reschedule / Cancel.
-  - Row click: DRAFT → `/announcements/drafts/:id`; POSTED → `/announcements/details/:id`; SCHEDULED/POSTING disabled.
-  - Search by title (min 3 chars, debounced); filter modal for Date range + Status; table/filter state persisted in URL.
-- **Shared with you** (`GET /api/web/v2/staff/announcements/shared`) columns add **Created By**; action menu only offers **Duplicate** for POSTED rows.
-
-### US-7: View Announcement Details and Read Status (Staff)
-
-**As a** school staff member,
-**I want to** see who has read a posted announcement,
-**So that** I can follow up with parents who haven't.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/announcements/details/:id`; data via `GET /api/web/v2/staff/announcements/:id`.
-- Header shows title, target groups, and individual student targets.
-- Two tabs: **Read Status** (default) and **Details**.
-- **Read Status tab** (`ResponseScreen.tsx`):
-  - Summary stats (`StatsGroup`) showing **Total / Read / Unread**; clicking a stat filters the table by read state.
-  - Filter row: **Status** dropdown (onboarding status), **Class** dropdown, **Show Columns** multi-select.
-  - Data table columns: **Name** (fixed), **Class/Index**, **Read Status** (Read/Unread), **Read Time**, **First Read By** (parent identity/name/contact), **Status** (onboarding). IHL variant swaps Class/Index for **Class** + **Student ID**.
-  - **Export to Excel** button (desktop only; mobile shows "not supported on mobile devices.") → `AnnouncementDetailManager.exportToExcel`. Excel columns ordered per `EXCEL_DATA_COLUMNS`.
-- **Details tab** (`DetailsScreen.tsx`): posting details, **Staff-in-charge** (with **Add**, self-**Remove**), **Enquiry Email** (with **Edit**), Description, Shortcuts, Web Link, File attachments, Photo Gallery, and **Other Actions** (Duplicate + Delete).
-
-> **Difference from Consent Forms:** No "Edit Response" per student, no reply-audit history modal, no due-date editing, no "Custodians may edit till due date" banner. There is no per-student write path beyond read tracking.
-
-### US-8: Manage Staff-in-Charge
-
-**As a** school staff member,
-**I want to** add or remove staff-in-charge on a posted announcement,
-**So that** the right staff can oversee it.
-
-**Acceptance Criteria:**
-
-- Details tab → **Add** opens `AddStaffInChargeOverlay` → `POST /api/web/v2/staff/announcements/:id/addStaffInCharge` (body `{ announcementId, staffIDs }`). New staff receive an email notification.
-- A staff-in-charge can **Remove** themselves → confirmation → `PUT /api/web/v2/staff/announcements/:id/removeAccess`; on success redirect to `/announcements`.
-
-### US-9: Edit Enquiry Email (Posted Announcement)
-
-**As a** school staff member,
-**I want to** update the enquiry email on a posted announcement,
-**So that** parents contact the right person.
-
-**Acceptance Criteria:**
-
-- Details tab → **Edit** (enquiry email) opens `EditEmailAddressOverlay` (staff/school/custom).
-- `PUT /api/web/v2/staff/announcements/:id/enquiryEmailAddress` (body includes `enquiryEmailAddress` + `prevEnquiryEmailAddress` for the application log).
-
-> **Difference from Consent Forms:** There is **no Edit Due Date** flow (announcements have no due date).
-
-### US-10: Delete an Announcement
-
-**As a** school staff member,
-**I want to** permanently delete an announcement,
-**So that** obsolete posts are removed.
-
-**Acceptance Criteria:**
-
-- Details tab → tick "I am sure I want to delete this announcement." then **Delete Forever**, confirmation modal.
-- Staff path → `DELETE /api/web/v2/staff/announcements/:id`; admin path → `DELETE /api/web/v2/schoolAdmins/announcements/:id`.
-- Notification `delete_announcement_success`; redirect to `/announcements` (or `/admin/announcements` for admin).
-- A DRAFT can also be deleted from the Created-by-you list → `DELETE /api/web/v2/staff/announcements/drafts/:announcementDraftId`; the row is optimistically removed from the cache.
-
-### US-11: Duplicate an Announcement (Draft or Posted)
-
-**As a** school staff member,
-**I want to** duplicate an existing announcement,
-**So that** I can reuse it.
-
-**Acceptance Criteria:**
-
-- Draft duplication → `POST /api/web/v2/staff/announcements/drafts/duplicate` (body `{ announcementDraftId }`).
-- Posted duplication → `POST /api/web/v2/staff/announcements/duplicate` (body `{ announcementId }`); the server guards ownership.
-- Both return a new `announcementDraftId`; staff is redirected to `/announcements/drafts/:newId` with a success toast.
-
-### US-12: Create from a Prefilled Magic Link
-
-**As a** school staff member,
-**I want to** open a pre-populated announcement from a deep link,
-**So that** I can quickly post content prepared elsewhere (e.g. an AI-drafted post).
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/announcements/prefilled/:magicLinkId`.
-- `usePrefilledGetter` → `GET /api/web/v2/staff/announcements/prefilled/:announcementPrefilledId`.
-- Status is `EPrefilledAnnProcessStatus` (`PROCESSING` / `COMPLETED`); while `PROCESSING` the combo boxes show a loading state and the hook **polls** until `COMPLETED` or surfaces a load error.
-- Title, content, urls, student groups, and staff groups are pre-filled; the form is marked dirty.
-
-### US-13: View Announcements List (School Admin)
-
-**As a** school admin,
-**I want to** oversee all announcements in my school,
-**So that** I can monitor communications.
-
-**Acceptance Criteria:**
-
-- Admin navigates to `/admin/announcements` (legacy `R12` list).
-- List rows show title, "Created by <staff name>", "on <postedDate>", and a recipient `total` indicator; clicking → `/admin/announcements/details/:id`.
-- Admin endpoints under `schoolAdminAnnouncementRouter`: legacy `GET /api/web/v2/schoolAdmins/announcements`; reskin `GET /api/web/v2/schoolAdmins/r12/announcements`; `GET …/:id`; `DELETE …/:id`.
-- Admin details view hides **Add staff-in-charge**, **Edit enquiry email**, and **Duplicate**; admin can still **Delete**.
+| Constraint | Value |
+|-----------|-------|
+| Max web links | 3 |
+| Schedule min delay | 5 minutes from now |
+| Schedule max delay | 21 days (configurable via `SCHEDULE_POST_MAX_NUM_DAYS` env) |
+| Schedule interval | 5-minute intervals only |
 
 ---
 
-## Requirements
+## 2. Business Logic Rules
 
-### Functional Requirements
+### 2.1 Status Model
 
-#### FR-1: Announcement Creation
+**Backend** (`EResourceStatus`): `DRAFT`, `POSTED`, `SCHEDULED`, `POSTING`
 
-- One-way post: **no** response type, custom questions, event dates, venue, or due date.
-- Recipients selectable by class, level, school, CCA, custom group, and/or individual student; targets serialized as `{ targetType, targetId }` only.
-- Staff-in-charge are equal co-owners (no editor/viewer enum); creator is excluded from the submitted staff-in-charge list.
-- Enquiry email from staff email, school email, or custom.
-- Title **max 120 chars**; description rich text **max 2000 chars**.
-- Rich text via Tiptap — supported marks/nodes: **Document, Paragraph, Text, Bold, Italic, Underline, TextAlign (paragraph/orderedList/bulletList), ListItem, OrderedList, BulletList, HardBreak**, plus History, CharacterCount, Placeholder. Stored as `richTextContent` (JSON) with `content` plain-text fallback.
-- Web links: **up to 3**, URL + optional description.
-- File attachments: **up to 3**, **≤5 MB each**, uploaded by `fileToken`.
-- Photo gallery: **up to 12**, **up to 3 cover photos**.
-- In-app shortcuts: `DECLARE_TRAVELS`, `EDIT_CONTACT_DETAILS` (`EAnnouncementShortcutType`). **Hidden entirely when `isIhl`** (no separate SPED hide found — IHL is the variant the code encodes).
+**Frontend display** (`EAnnouncementAPIResponseStatus`):
+| Display Status | Derived From |
+|----------------|-------------|
+| `DRAFT` | EResourceStatus.DRAFT |
+| `OPEN` | POSTED (always OPEN for announcements — no due date) |
+| `SCHEDULED` | EResourceStatus.SCHEDULED |
+| `POSTING` | EResourceStatus.POSTING |
 
-#### FR-2: Draft Management
+### 2.2 Access Control
 
-- Manual save and autosave to the drafts endpoints; new vs existing chosen by presence of `:id`.
-- Autosave sends `pg-no-extend` header so the session is not extended; states driven by `AutoSaveStatesContext`.
-- Drafts persist all fields incl. `scheduledDateTime`; attachment/photo expiry tracked (`expiryDate` → EXPIRED state).
-- Save blocked on title/description over-limit and on partially-filled schedule date/time.
-- Drafts can be edited, duplicated, or deleted.
+| Action | Creator | Staff-in-Charge | School Admin |
+|--------|---------|-----------------|--------------|
+| View details | Yes | Yes | Yes |
+| View read status | Yes | Yes | Yes |
+| Add staff-in-charge | Yes | No | No |
+| Remove self as staff | N/A | Yes | N/A |
+| Edit enquiry email | Yes | No | No |
+| Delete announcement | Yes | Yes | Yes |
+| Duplicate | Yes | Yes | No |
+| Edit/delete draft | Yes | No | No |
 
-#### FR-3: Scheduled Posting
+### 2.3 School Type Variants
 
-- Schedule on create or from an existing draft; reschedule and cancel from the Created-by-you list.
-- Recipients and staff-in-charge are resolved at send time, not at scheduling.
-- Creator reminded before send unless within 24 hours.
-- `scheduledSendFailureCode` tracked; failure message shown in an expandable row.
-- Cancel moves the post back to Drafts.
+**IHL (Institute of Higher Learning):**
+- In-app shortcuts field hidden entirely
 
-#### FR-4: Read Tracking
+**SPED (Special Education):**
+- Excludes shortcut: `EDIT_CONTACT_DETAILS`
+- Other shortcuts (e.g. `DECLARE_TRAVELS`) remain available
 
-- Per recipient, track **Read / Unread** (`readStatus`/`readDate`); no reply values.
-- Summary stats Total / Read / Unread; clicking filters the table.
-- Filter by onboarding **Status**, **Class**, and interactive **Read summary**; configurable **Show Columns**.
-- `# Read` progress = `readPerStudent / totalStudents`, surfaced only for POSTED.
-- "First Read By" shows the parent identity/name/contact of the first read.
+### 2.4 Scheduling Rules
 
-#### FR-5: Export
+| Rule | Detail |
+|------|--------|
+| Scheduled time | Must be future (min 5 minutes), at 5-minute intervals |
+| Max window | 21 days (configurable) |
+| Group resolution | Targets resolved at SEND time, not schedule time |
+| Cancel | Reverts to DRAFT |
+| Failure codes | `INVALID_CREATOR`, `INVALID_FILE`, `INVALID_IMAGE`, `INVALID_RECIPIENT`, `UNEXPECTED_ERROR` |
 
-- Export the filtered read-status table to Excel (`.xlsx`).
-- Export respects column visibility and current filters; columns ordered per `EXCEL_DATA_COLUMNS`.
-- Disabled on mobile.
+### 2.5 Optimistic Concurrency
 
-#### FR-6: Roles and Access
+- Draft updates: `updatedAt` from previous response must match DB value
+- Enquiry email: `prevEnquiryEmailAddress` must match current value
 
-- **Staff (creator/owner):** full CRUD, manage staff-in-charge, edit enquiry email, export, duplicate, schedule.
-- **Staff (shared / co-owner):** see in "Shared with you"; can view read status and **Duplicate** posted; staff-in-charge can self-remove and delete the announcement.
-- **School Admin:** read-only oversight list + delete; no staff management, enquiry-email edit, or duplicate. Uses `/schoolAdmins/` API path.
-- **IHL (Institute of Higher Learning):** in-app shortcuts hidden; response table uses Class + Student ID columns instead of Class/Index.
-- **SPED:** Not separately encoded in the announcement code paths reviewed — the only school-type branch is `isIhl`. _(Consent Forms' SPED shortcut-hiding was not found for announcements; flagged rather than invented.)_
+### 2.6 Auto-Save
 
-#### FR-7: Navigation Prevention
+**Trigger**: Fires when `autoSaveStates === TRIGGER` AND form is dirty.
 
-- Unsaved changes trigger a React-Router `Prompt` ("…Any unsaved changes will be lost.") and `useUnloadEvent` guards browser unload while dirty and not posting.
+**Pre-conditions** (all must be non-empty):
+1. enquiryEmailAddress
+2. title
+3. content (plain text extracted from rich text)
+4. selectedIndividualStudentGroups (at least one)
+5. For scheduled: both `scheduledDateTime.date` and `.time`
 
-#### FR-8: Listing, Search, and URL State
+**Header**: `pg-no-extend: ''` prevents session extension during auto-save.
 
-- Created-by-you / Shared-with-you tabs persisted via `tab` query param.
-- Per-tab table state (pagination, sorting, filters, search) persisted in the URL; title search ≥3 chars with debounce.
+**States**: `PENDING` → `TRIGGER` → `SUCCESS` | `FAILED`
 
-### Key Entities
+### 2.7 Navigation Prevention
 
-| Entity                                         | Description                                                                                           |
-| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `Announcement`                                 | A posted announcement with content, targets, owners, students (with read status), images, attachments |
-| `AnnouncementDraft`                            | A pre-post draft holding all form fields incl. `scheduledDateTime`, by `fileToken` uploads            |
-| `AnnouncementPrefilled`                        | A magic-link pre-population payload with `EPrefilledAnnProcessStatus` (PROCESSING/COMPLETED)          |
-| `AnnouncementRecipient`                        | A targeted student + parent with `readDate`, parent name/phone/relationship, `onBoardedCategory`      |
-| `AnnouncementTarget`                           | A target group: school/level/class/cca/custom (`ETargetType`), acad year resolved server-side         |
-| `AnnouncementOwner`                            | A staff co-owner (`pgStaffId`, `isDeleted`) — **no access-type field**                                |
-| `AnnouncementShortcut`                         | In-app shortcut: `DECLARE_TRAVELS`, `EDIT_CONTACT_DETAILS`                                            |
-| `AnnouncementUrl`                              | A web link (`webLink` + `linkDescription`)                                                            |
-| `AnnouncementAttachment` / `AnnouncementImage` | File attachment / gallery image (name, size, sequence, `isCover`, downloadUrl)                        |
-| `EAnnouncementAPIResponseStatus`               | List row status (DRAFT, POSTED, SCHEDULED, POSTING — mapped from `EResourceStatus`)                   |
+- Triggers when `isDirtyState && !isPosting`
+- Browser unload event handler via `useUnloadEvent`
 
----
+### 2.8 Duplicate Behavior
 
-## Success Criteria
+**Copied**: Title, description, rich text, enquiry email, web links, shortcuts, photos, attachments, staff-in-charge, target groups.
 
-1. **Creation**: Staff can create and post an announcement with recipients, staff-in-charge, rich text, links, attachments, and gallery, receiving confirmation and the post appearing in the list.
-2. **Draft Persistence**: Drafts save/restore all fields incl. schedule and expiry-aware uploads; autosave fires on session-timeout trigger without extending the session.
-3. **Scheduled Posting**: Schedule, reschedule, and cancel work; failure codes render; recipients resolve at send time.
-4. **Read Tracking**: Summary stats (Total/Read/Unread) are accurate; Status/Class/Read filters and Show-Columns combine correctly; IHL column variant renders.
-5. **Export Accuracy**: Excel export matches the filtered table and column order; unavailable on mobile.
-6. **Role-Based Access**: Admin list/details correctly hide add-staff, edit-email, and duplicate; shared-with-you offers only duplicate of posted; IHL hides shortcuts and reskins columns.
-7. **Duplication & Deletion**: Draft and posted duplication both yield a new editable draft; deletion (staff and admin paths) removes the post and redirects with success notice.
-8. **Navigation Safety**: Dirty-state prompt and unload guard prevent accidental loss.
+**NOT copied**: Read receipts, posted date, audit records.
+
+### 2.9 Soft Delete
+
+Sets `isDeleted: true`. Records remain in DB.
+
+### 2.10 Prefilled Announcements
+
+- Staff can create announcements from a platform-provided template
+- Accessed via `/announcements/prefilled/:id`
+- Pre-populates form fields including students/staff targets
+- Validates recipients before populating (shows error for invalid)
 
 ---
 
-## Assumptions
+## 3. Validation Rules
 
-1. The backend is a Node/Express BFF alongside the React frontend, using Sequelize models from `@pgw/db-migration`; staff routes mount under `/api/web/v2/staff` and admin under `/api/web/v2/schoolAdmins`.
-2. File uploads (attachments/photos) use a token flow — files uploaded separately and referenced by `fileToken`.
-3. The Parents Gateway mobile app handles the parent reading flow; this spec covers the staff web portal. Announcements are one-way (read tracking only, no parental responses).
-4. Rich text is Tiptap JSON in `richTextContent` with a `content` plain-text fallback; supported nodes/marks are exactly those registered in `getSupportedExtensions`.
-5. `isIhl` derives from school config in Redux `indexPage`. SPED-specific behavior was **not** found in announcement code paths (only IHL branches); this is flagged, not assumed.
-6. WOGAA tracking is a Singapore-government analytics requirement; used for schedule-post transactions and search/filter.
-7. `EResourceStatus` (DRAFT, POSTED, POSTING, SCHEDULED) is the canonical status enum; `EAnnouncementAPIResponseStatus` maps it for list rows.
-8. The `R12` admin routes (`/schoolAdmins/r12/announcements`) are a transitional reskin coexisting with the legacy admin list.
+### 3.1 Required for Publishing
+
+1. Recipients (at least one student group)
+2. Enquiry email address (valid format)
+3. Title (non-empty, max 120 chars)
+4. Description (non-empty, max 2000 chars, valid rich text JSON)
+
+### 3.2 Field Validation
+
+| Field | Rule |
+|-------|------|
+| Title | Non-empty, max 120 chars |
+| Description | Non-empty plain text, max 2000 chars, valid JSON schema |
+| Enquiry email | Valid email format, max 250 chars |
+| Web links | `isValidLink` (URL format), `isSafeLink` (safety), `isMimeSafeLink` (MIME) |
+| Attachments | Valid non-expired token, size <= 5MB, accepted extension |
+| Photos | Valid non-expired token, accepted extension (jpg/jpeg/png) |
+| Schedule date | Future (5 min+), within 21 days, 5-min interval |
+
+### 3.3 Draft Save Blocking
+
+Save is blocked ONLY when:
+- Title exceeds 120 characters
+- Description exceeds 2000 characters
+- Schedule date/time is incomplete (only date OR only time filled)
+
+All other fields can be empty/partial for draft save.
+
+### 3.4 Rich Text Validation
+
+- `isValidSchema()`: Validates JSON structure
+- `JsonToCharacterCount()`: Extracts plain text char count
+- `JsonToPlainText()`: Converts for counting
+- Server rejects: `exceedRichTextLimit` (>2000 chars), `invalidRichTextSchema` (bad JSON)
+
+---
+
+## 4. Functional Behavior
+
+### 4.1 Create/Edit Form — Field Order
+
+1. Recipients (Parents) — student group combo box
+2. Recipients (School Staff) — staff group combo box (staff-in-charge)
+3. Enquiry Email — selector: staff email / school email / custom
+4. Title — text input with 120 char counter
+5. Description — rich text editor with 2000 char counter
+6. In-App Shortcuts — multi-select checkboxes (hidden for IHL)
+7. Website Links — up to 3 (URL + description each)
+8. File Attachments — upload up to 3 (5MB each)
+9. Photo Gallery — upload up to 12 (max 3 cover)
+10. Schedule Post — optional date/time picker
+
+### 4.2 List Page — Created by You
+
+**Columns**: Title, Date, Status, To Parents Of, Read Metrics
+
+**Actions per status**:
+| Status | Actions |
+|--------|---------|
+| DRAFT | Edit, Delete, Duplicate |
+| SCHEDULED | Reschedule, Cancel send |
+| POSTING | (none) |
+| OPEN | Duplicate, Delete |
+
+### 4.3 List Page — Shared with You
+
+**Columns**: Title, Date, Status, Created By, To Parents Of, Read Metrics
+
+**Actions**: Duplicate, Delete (if co-owner)
+
+### 4.4 List Page — School Admin
+
+All posted announcements in school. Actions: View details, Delete.
+
+### 4.5 Details Page — Read Status Tab
+
+**Summary**: Total recipients, Read count, Unread count
+
+**Table Columns**:
+- Student Name
+- Parent/Guardian Name
+- Read Date
+- Read Status (Read/Unread/Onboarded status)
+
+**Export to Excel**: Available (desktop only)
+
+### 4.6 Details Page — Details Tab
+
+Sections in order:
+1. Posted on [Date] by [Staff Name]
+2. Staff-in-charge list + "Add" button (creator only)
+3. Enquiry email + "Edit" button (creator only)
+4. Description (rich text / plain text)
+5. Shortcuts with icons
+6. Web links with descriptions
+7. Attachments with download links
+8. Photo gallery
+9. OTHER ACTIONS: Duplicate, Delete
+
+### 4.7 Post Flow
+
+1. Preview → Confirmation modal (title + target student count)
+2. API call → If rescan needed, poll draft endpoint
+3. Redirect to list + success notification
+
+### 4.8 Reschedule/Cancel from List
+
+**Reschedule**: Opens date/time picker. Validates same as initial schedule.
+
+**Cancel**: Confirmation modal → reverts to DRAFT.
+
+### 4.9 Edit Enquiry Email
+
+1. Overlay with selector (staff email / school email / custom)
+2. Confirmation modal
+3. Uses `prevEnquiryEmailAddress` for concurrency
+
+### 4.10 Add/Remove Staff-in-Charge
+
+**Add**: Creator opens overlay → selects staff → success notification.
+
+**Remove self**: Staff-in-charge clicks remove → confirmation → redirects to list.
+
+### 4.11 Delete
+
+- Confirmation modal required
+- Soft delete
+- Redirect to list + success notification
+
+### 4.12 Analytics Events (WOGAA)
+
+| Event | Trigger |
+|-------|---------|
+| NewAnnouncementButtonPressed | Create button clicked |
+| AnnouncementViewed | Detail page loaded |
+| AnnouncementReadStatusTabPressed | Read status tab |
+| AnnouncementDetailsTabPressed | Details tab |
+| DuplicatePostCreateDetailsPressed | Duplicate from details |
+| DuplicatePostCreateListingPressed | Duplicate from list |
+| DuplicatePostSuccess | Duplicate succeeded |
+| DuplicatePostFailure | Duplicate failed |
+| AnnouncementDeleted | Deletion completed |
+| StaffInChargeTooltipPressed | Tooltip viewed |
+| ExportToExcelButtonPressed | Export clicked |
+| DeleteAnnouncementButtonPressed | Delete button clicked |
+| SchedulePostAnnouncementCancelled | Schedule cancelled |
+
+---
+
+## 5. API Contracts
+
+### Base
+
+- **Base URL**: `/api/v2`
+- **Staff**: `/api/v2/staff/announcements`
+- **Admin**: `/api/v2/schoolAdmins/announcements`
+- **Auth**: SchoolStaffSessionMiddleware (staff), with `accessControlScope: 'Admin'` (admin)
+- **Rate Limit**: 250 requests per 60 minutes (staff), 20 per 24h (HQ)
+- **Auto-save header**: `pg-no-extend: ''`
+
+### Response Wrapper (all endpoints)
+
+```typescript
+{ resultCode: number; message: string; body: T; metadata?: Record<string, any> }
+```
+
+---
+
+### 5.1 POST `/staff/announcements` — Publish
+
+**Rate Limited**: Yes.
+
+**Request**:
+```typescript
+{
+  announcementDraftId?: number;
+  title: string;
+  content: Record<string, any>;         // Rich text JSON
+  enquiryEmailAddress: string;
+  staffInCharge?: number[];
+  targets: Array<{ targetType: 'CLASS'|'LEVEL'|'SCHOOL'|'CCA'|'GROUP'; targetId: number }>;
+  webLinkList?: Array<{ webLink: string; linkDescription: string }>;
+  photos?: Array<{ fileToken: string; isCover: boolean }>;
+  attachments?: Array<{ fileToken: string }>;
+  inAppShortcutLink?: string[];
+}
+```
+
+**Response**:
+```typescript
+{
+  body: {
+    announcement: {
+      id: number;
+      title: string;
+      content: string;
+      enquiryEmailAddress: string;
+      staffInCharge: number[];
+      targets: Array<{ targetId: number; targetType: string; targetSchool: number; targetAcadYear: string; groupId: number }>;
+      webLinkList: Array<{ webLink: string; linkDescription: string }>;
+      createdBy: string;
+      inAppShortcutLink: string[];
+      owners: Array<{ staffId: number }>;
+    };
+  }
+}
+```
+
+OR `{ body: number }` (draft ID needing file rescan)
+
+---
+
+### 5.2 POST `/staff/announcements/drafts` — Create Draft
+
+**Request** (`TAnnouncementDraftRequestBody`):
+```typescript
+{
+  title?: string;
+  content?: string | null;
+  richTextContent?: Record<string, any> | null;
+  enquiryEmailAddress?: string;
+  urls?: Array<{ webLink: string; linkDescription: string }>;
+  shortcuts?: string[];
+  attachments?: Array<{ fileToken: string }>;
+  images?: { images: Array<{ fileToken: string; isCover: boolean }>; imagesOrigin: string };
+  studentGroups?: Array<{ type: string; label: string; value: string|number }>;
+  staffGroups?: Array<{ type: string; label: string; value: string|number }>;
+  scheduledDateTime?: Date | null;
+}
+```
+
+**Response**: `{ body: { announcementDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.3 PUT `/staff/announcements/drafts/:announcementDraftId` — Update Draft
+
+**Request**: Same as 5.2.
+
+**Response**: `{ body: { announcementDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.4 GET `/staff/announcements/drafts/:announcementDraftId` — Get Draft
+
+**Response**:
+```typescript
+{
+  body: [{
+    announcementDraftId: number;
+    status: 'DRAFT' | 'SCHEDULED' | 'POSTING';
+    postedAnnouncementId: number | null;
+    studentGroups: Array<{ type: string; label: string; value: string }>;
+    staffGroups: Array<{ type: string; label: string; value: string }>;
+    title: string;
+    content: string | null;
+    richTextContent: Record<string, any> | null;
+    enquiryEmailAddress: string;
+    urls: Array<{ webLink: string; linkDescription: string }>;
+    shortcuts: string[];
+    attachments: Array<{ fileToken: string; name: string; size: number; status: 'success'|'failed'|'expired' }>;
+    images: { images: Array<{ fileToken: string; name: string; size: number; isCover: boolean; status: 'success'|'failed'|'expired' }>; imagesOrigin: string };
+    updatedAt: string;
+    pgSchoolId: number;
+    createdBy: number;
+    scheduledDateTime: Date | null;
+    cancelledBy: number | null;
+    cancelledAt: string | null;
+  }]
+}
+```
+
+---
+
+### 5.5 DELETE `/staff/announcements/drafts/:announcementDraftId` — Delete Draft
+
+**Response**: Standard success.
+
+---
+
+### 5.6 POST `/staff/announcements/drafts/duplicate` — Duplicate Draft
+
+**Request**: `{ announcementDraftId: number }`
+
+**Response**: `{ body: { announcementDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.7 POST `/staff/announcements/duplicate` — Duplicate Posted
+
+**Request**: `{ announcementId: number }`
+
+**Response**: `{ body: { announcementDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.8 POST `/staff/announcements/drafts/schedule` — Schedule New
+
+**Request**: Same as 5.2 with mandatory `scheduledDateTime: Date`.
+
+**Response**: `{ body: { announcementDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.9 PUT `/staff/announcements/drafts/schedule/:announcementDraftId` — Schedule Existing Draft
+
+**Request**: `{ scheduledDateTime: Date }`
+
+**Response**: Draft details.
+
+---
+
+### 5.10 PUT `/staff/announcements/drafts/:announcementDraftId/rescheduleSchedule` — Reschedule
+
+**Request**: `{ scheduledDateTime: Date }`
+
+**Response**: Updated draft details.
+
+---
+
+### 5.11 POST `/staff/announcements/drafts/:announcementDraftId/cancelSchedule` — Cancel
+
+**Request**: None.
+
+**Response**: Standard success.
+
+---
+
+### 5.12 GET `/staff/announcements` — List Created by You
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    id: string; postId: number; title: string; date: Date;
+    status: 'DRAFT'|'OPEN'|'SCHEDULED'|'POSTING';
+    toParentsOf: string[];
+    readMetrics: { readCount: number; totalRecipients: number };
+    scheduledSendFailureCode: string | null;
+  }>
+}
+```
+
+---
+
+### 5.13 GET `/staff/announcements/shared` — List Shared with You
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    id: string; postId: number; title: string; date: Date;
+    status: 'OPEN';
+    createdByName: string;
+    toParentsOf: string[];
+    readMetrics: { readCount: number; totalRecipients: number };
+  }>
+}
+```
+
+---
+
+### 5.14 GET `/staff/announcements/:id` — Get Posted Announcement Details
+
+**Response**:
+```typescript
+{
+  body: [{
+    announcementId: number;
+    title: string;
+    content: string;
+    richTextContent: Record<string, any> | null;
+    enquiryEmailAddress: string;
+    postedDate: Date;
+    staffName: string;
+    createdBy: number;
+    createdAt: Date;
+    webLinkList: Array<{ webLink: string; linkDescription: string | null }>;
+    shortcutLinkList: Array<{ shortcutName: string }>;
+    targets: Array<{ announcementId: number; targetSchool: number; targetType: string; targetAcadYear: string|null; targetId: number; targetName: string }>;
+    staffOwners: Array<{ staffName: string; staffID: number }>;
+    images: Array<{ imageId: number; size: number; name: string; url: string; thumbnailUrl: string; expiryDate?: string; isCover: boolean }>;
+    announcementRecipients: Array<{
+      announcementId: number;
+      studentId: number;
+      readDate: Date | null;
+      parent: { parentId: number; parentName: string; phone: string; relationship: string|null } | null;
+      student: { studentId: number; studentName: string; indexNumber: string; className: string };
+      onBoardedCategory: 'Onboarded' | 'Not Onboarded';
+    }>;
+    attachments?: Array<{ name: string; size: number; sequence: number; downloadUrl: string }>;
+  }]
+}
+```
+
+---
+
+### 5.15 DELETE `/staff/announcements/:id` — Delete Posted
+
+**Response**: Standard success.
+
+---
+
+### 5.16 PUT `/staff/announcements/:id/enquiryEmailAddress` — Update Email
+
+**Request**:
+```typescript
+{ enquiryEmailAddress: string; prevEnquiryEmailAddress: string }
+```
+
+**Response**: Standard success.
+
+---
+
+### 5.17 POST `/staff/announcements/:id/addStaffInCharge` — Add Staff
+
+**Request**: `{ announcementId: number; staffIDs: number[] }`
+
+**Response**: Standard success.
+
+---
+
+### 5.18 PUT `/staff/announcements/:id/removeAccess` — Remove Self
+
+**Request**: None.
+
+**Response**: Standard success.
+
+---
+
+### 5.19 GET `/staff/announcements/prefilled/:announcementPrefilledId` — Get Prefilled
+
+**Response**: Prefilled announcement details (same shape as draft but from platform template).
+
+---
+
+### 5.20 GET `/schoolAdmins/announcements` — Admin List (Legacy)
+
+**Response**: Array of summary data.
+
+---
+
+### 5.21 GET `/schoolAdmins/r12/announcements` — Admin List (Current)
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    id: string; postId: number; title: string; date: Date;
+    status: 'OPEN';
+    createdByName: string; toParentsOf: string[];
+    readMetrics: { readCount: number; totalRecipients: number };
+  }>
+}
+```
+
+---
+
+### 5.22 GET `/schoolAdmins/announcements/:id` — Admin Get Details
+
+**Response**: Same shape as 5.14.
+
+---
+
+### 5.23 DELETE `/schoolAdmins/announcements/:id` — Admin Delete
+
+**Response**: Standard success.
+
+---
+
+## 6. Error Handling
+
+### 6.1 Server Error Messages
+
+| Key | Message |
+|-----|---------|
+| exceedRichTextLimit | Content exceeds 2000 characters |
+| invalidRichTextSchema | Rich text JSON format invalid |
+| unauthorised | User not creator/staff-in-charge |
+| notExist | Announcement/draft not found |
+| invalidTargetAcadYear | Academic year mismatch |
+| noTargetAccess | User cannot access target groups |
+| invalidAnnouncementCode | Invalid code/type |
+
+### 6.2 Scheduled Send Failure Codes
+
+| Code | Meaning |
+|------|---------|
+| INVALID_CREATOR | Creator account became invalid |
+| INVALID_FILE | File attachment error |
+| INVALID_IMAGE | Image attachment error |
+| INVALID_RECIPIENT | All recipients became invalid |
+| UNEXPECTED_ERROR | System error |
+
+### 6.3 HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Validation error |
+| 401 | Unauthorized (session expired) |
+| 403 | Forbidden (insufficient permission) |
+| 404 | Not found |
+| 409 | Conflict (stale updatedAt / concurrent edit) |
+| 429 | Rate limited |
+| 500 | Internal error |

--- a/docs/requirements/custom-groups-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/custom-groups-1-pg-reverse-engineer-specs.md
@@ -1,282 +1,543 @@
-# Feature Specification: Custom Student Groups
+# Custom Groups - Complete Redevelopment Spec (Staff)
 
-**Feature Branch**: `004-custom-groups`
 **Created**: 2026-06-09
-**Status**: Reverse-Engineered
-**Input**: Reverse-engineered from existing codebase (pgw-web)
+**Purpose**: Comprehensive reference for frontend redevelopment — business logic, validation, functional behavior, and API contracts.
 
 ---
 
-## Overview
+## 1. Constants & Constraints
 
-Custom Student Groups is a roster-management feature in Parents Gateway Web that lets school staff assemble ad-hoc groups of students that cut across class/level/CCA boundaries. Staff create a group by manually selecting students from the school roster or by bulk-uploading an Excel (`.xlsx`) file, then reuse the saved group as a recipient target when creating Posts/Consent Forms/Announcements. Groups support co-ownership-style sharing (any staff a group is shared with gets full edit/share/send rights), edit (rename, add/remove students), deletion by the last remaining owner, and self-removal by non-last owners. The feature has two roster variants: a mainstream-school (MS) variant keyed on student Name + Class, and an Institute-of-Higher-Learning (IHL) variant keyed on Student ID, with a hard cap of 5,000 students per group. File-upload validation runs as an asynchronous, token-and-polling job on the BFF and returns a valid/invalid breakdown with per-row error reasons.
+### 1.1 Group Limits
 
----
-
-## User Scenarios & Testing
-
-### US-1: Create a Custom Group by Manual Student Selection (Staff)
-
-**As a** school staff member,
-**I want to** create a custom group by hand-picking students from my school roster,
-**So that** I can target a bespoke set of students in future posts.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/groups` and clicks "Create New" (links to `/groups/customGroups/new`), firing analytics `NewCustomGroupButtonPressed`.
-- The Create page (`CustomGroupPage`, `pageType === 'create'`) shows title "Create new group", a mandatory `Title` field (max 120 chars, placeholder "What would you like to call your group?"), and a Students section.
-- Clicking "Add Students" opens a dropdown (`AddStudentDropdownComponent`) with two options: "Add manually" and "Upload via Excel".
-- "Add manually" opens the "Add students" overlay (`AddStudentsComponent`) populated from `StudentService.getStudents()` → `GET /api/web/v2/staff/school/students`.
-- Selected students render in `StudentTable`, sorted by class description then index. Each row has a delete action; deleting with `studentId === null` opens a "Delete all?" modal ("All **N** student(s) will be removed.").
-- The "Create Now" button is enabled only when `groupName.trim().length > 0 && selectedStudentIds.length > 0` (and, for IHL, `selectedStudentIds.length <= 5000`). Label flips to "Creating..." while posting.
-- On submit (analytics `CustomGroupCreateButtonPressed`), the FE dedupes IDs (`_.uniq`) and calls `actions.createGroup` → `POST /api/web/v2/staff/groups/custom` with `{ groupName, selectedSchoolStudents }`.
-- On success: analytics `CustomGroupCreated`, success notification `create_group_success`, redirect to `/groups`.
-- Duplicate-name error (`error.errorReason === 'customGroup name duplicated'`) renders inline: "The title you entered already exists. Please use a different title." (Server enforces uniqueness only for IHL — see FR-7.)
-- A `Prompt` / `beforeunload` guard ("You are about to leave this page. Any unsaved changes will be lost.") fires if the form is edited and not yet posted.
-
-### US-2: Create a Custom Group by Excel File Upload (Staff)
-
-**As a** school staff member,
-**I want to** bulk-add students by uploading an Excel file,
-**So that** I can build large groups without selecting students one by one.
-
-**Acceptance Criteria:**
-
-- From the "Add Students" dropdown, staff clicks "Upload via Excel" (analytics `CustomGroupUploadViaExcelPressed`; on create, starts WOGAA transaction `CREATE_CUSTOM_GROUP_FILE_UPLOAD`). This opens the upload overlay (`UploadStudentsComponent`).
-- "Upload via Excel" is **disabled when the list already has students**; conversely the manual "Add Students" button is disabled once a file-upload result is displayed. The two paths are mutually exclusive.
-- **Accepted file type**: `.xlsx` only (`CUSTOM_GROUP_ACCEPTED_MIME_TYPES`). Wrong type toast: "Only .xlsx file type is allowed." (CSV is **not** accepted.)
-- **Max file size**: 5 MB (`MAX_UPLOAD_FILE_SIZE`). Oversize toast: "You may only add files up to 5 MB." **Max files**: 1.
-- **Max students**: `CUSTOM_GROUP_MAX_STUDENTS_COUNT = 5000`.
-- **Expected columns**:
-  - **MS** (`isIhl === false`): two columns `Name` and `Class`. Copy: "Upload an Excel file (.xlsx) with two columns: 'Name' and 'Class'. The columns can be in any order and any position, as long as they are named correctly." Header matching is case-insensitive and whitespace-trimmed.
-  - **IHL** (`isIhl === true`): one column `Student ID` (`CUSTOM_GROUP_FILE_UPLOAD_COLUMN_HEADER`).
-- First worksheet parsed client-side (`XLSX.read`); user-facing row numbers are `index + 2` (header is row 1).
-- **Client-side validation order & exact messages** (`ValidationMessages`):
-  - Blank file → "The file is empty. Please check it and re-upload."
-  - IHL missing/duplicate header → "The column header must be \"Student ID\". Please amend and re-upload." / "We found duplicate columns with the header \"Student ID\". Please amend and re-upload."
-  - IHL over cap → "You may only upload up to 5000 Student IDs. Please amend and re-upload."
-  - IHL duplicate IDs → "We found N duplicate Student ID(s). Please amend and re-upload."
-  - MS duplicate headers → "The column 'Name' and/or 'Class' appears more than once. Please remove the duplicate(s) and re-upload."
-  - MS missing headers → "The columns 'Name' and/or 'Class' are missing. Please add them and re-upload."
-  - MS missing values → "Your file is missing 'Name' or 'Class' entries in row(s): {rows}{ and N more}. Please update these rows and re-upload." (first 5 rows listed)
-  - MS over cap → "You may only upload up to 5000 students. Please reduce the number and re-upload."
-  - MS duplicate Name+Class → "We found duplicate entries with the same 'Name' and 'Class': • {name in rows …}{ and N more}. Please remove the duplicates and re-upload." (case-insensitive; first 5)
-  - Generic parse failure → "There was an error processing your file. Please check the format and try again." Server failure → "Sorry, an unexpected error occurred on our side. Please try again later."
-- On passing client validation, rows go to the BFF for **server-side roster matching**:
-  - `POST /api/web/v2/staff/groups/custom/validateStudents` with `[{ studentId }]` (IHL) or `[{ name, className }]` (MS). **Asynchronous**: BFF stores a `pending` result in Redis (10-min TTL) and returns a signed `token`.
-  - FE polls `POST /api/web/v2/staff/groups/custom/validateStudents/results` with `{ token }` every 3 s, up to 100 attempts, until `status === 'success'` (throws on `error`).
-- The result (`{ validStudents, invalidStudents }`) renders in collapsible accordions "Valid students (N)" / "Invalid students (N)" with per-row reasons. Header shows filename + size + "Total unique students".
-- Only `validStudents.pgStudentId` become the group's students; the group can be created from the valid subset while invalid rows are reported.
-- Removing the file opens a "Remove file?" modal which clears students and the validation result.
-
-### US-3: View Custom Groups List (Staff)
-
-**As a** school staff member,
-**I want to** see all custom groups I own or that are shared with me,
-**So that** I can manage them.
-
-**Acceptance Criteria:**
-
-- `/groups` (`GroupsPage`) renders an "Assigned Groups" section (US-9) above a "Custom Groups" section.
-- `getGroupsStaffOwns()` → `GET /api/web/v2/staff/groups/custom?type=summary` returns `IGroupSummaryDetails[]` (`id`, `groupName`, `numberOfStaff`, `numberOfStudents`).
-- Each row shows the name + student count; a shared icon prefixes the name when `numberOfStaff > 1`.
-- Empty state: "You have not created any groups yet." / "Try creating one now!"
-- Only groups with `numberOfStudents > 0` are returned. Clicking a row → `/groups/customGroups/{id}`.
-
-### US-4: View Custom Group Details (Staff)
-
-**As a** school staff member,
-**I want to** open a custom group and review its members and metadata,
-**So that** I can verify the roster and decide on actions.
-
-**Acceptance Criteria:**
-
-- `/groups/customGroups/:id` (`CustomGroupDetails`); `getSingleGroupWithStudents(id)` → `GET /api/web/v2/staff/groups/custom/:id` (analytics `CustomGroupViewed`).
-- Header shows name + "Custom Group" label. Two tabs: "Students (N)" (default) and "Details".
-- **Students tab**: members grouped by class (sorted by `classSerialNo`); each row shows name, index/UIN (MS) or Student ID (IHL), gender, and an "Onboarded & Can Respond" status icon. `-404` redirect if the group isn't in the owned list.
-- **Details tab**: "Created on {date} by {createdBy}." and "Group shared with" = owner names. "OTHER ACTIONS" exposes Edit / Share / Delete-or-Remove.
-- **IHL only**: an "Export to Excel" button on the Students tab (desktop). Columns: Student ID, Name, Class, Course.
-
-### US-5: Edit a Custom Group (Staff)
-
-**As a** staff member with access to a group,
-**I want to** rename it and add/remove students,
-**So that** I can keep the roster current.
-
-**Acceptance Criteria:**
-
-- Details → "Edit Group" → `/groups/customGroups/:id/edit` (`CustomGroupPage`, `pageType === 'edit'`).
-- `getGroupData(id)` → `GET /api/web/v2/staff/groups/custom/:id` pre-populates `groupName` + `selectedStudentIds`.
-- Both manual add and Excel upload available. "Save" enabled only when changed (`isFormEdited`) and valid → `PUT /api/web/v2/staff/groups/custom/:id` with `{ groupName, selectedSchoolStudents }`.
-- On success: notification `edit_group_success`, redirect to `/groups/customGroups/:id`.
-
-### US-6: Share a Custom Group with Other Staff (Staff)
-
-**As a** staff member who owns/has access to a group,
-**I want to** share it with other staff,
-**So that** they can also send to and manage the group.
-
-**Acceptance Criteria:**
-
-- Details → "Share this custom group" (body: "You will be granting access to edit this group. Please be certain.") → `ShareGroupOverlay`.
-- Pick staff via `ShareStaffComboBox`. "Share group" disabled until ≥1 selected.
-- **Permissions model is co-ownership, not editor/viewer.** The overlay states verbatim the granted rights: **View and send to the group**, **Edit the group name**, **Add or delete students**, **Share the group with other staff**. Shared staff become `owners` with the full action set.
-- On confirm → `PUT /api/web/v2/staff/groups/custom/:id/share` with `{ selectedStaff }`. Server validates same-school, not-already-owner, and emails the added staff.
-
-### US-7: Delete a Custom Group (Last Owner) (Staff)
-
-**As a** staff member who is the sole owner of a group,
-**I want to** delete it permanently,
-**So that** obsolete groups are removed.
-
-**Acceptance Criteria:**
-
-- The Delete action appears **only when `owners.length === 1`** and the current staff is that owner. Surfaces an `isPartOfMessageGroup` warning when used by a message group.
-- Confirm → `DELETE /api/web/v2/staff/groups/custom/:id`. On success: redirect to `/groups`, notification `delete_group_success`.
-- Server guard: deletion only proceeds when the requester is the **last** remaining owner; else `{ success: false, reason: 'Invalid custom group or Staff not last owner' }`.
-- **Multi-select / bulk delete is NOT implemented in pgw-web.** Deletion is per-group from the detail page only. (See Assumptions #6.)
-
-### US-8: Remove Own Access from a Shared Group (Non-Last Owner) (Staff)
-
-**As a** staff member sharing a group with others,
-**I want to** remove my own access,
-**So that** I stop seeing/sending to a group I no longer need, without affecting other owners.
-
-**Acceptance Criteria:**
-
-- The Remove action appears **only when `owners.length > 1`** and the current staff is among them (body: "You will no longer be able to select this group when creating new posts.").
-- Confirm → `PUT /api/web/v2/staff/groups/custom/:id/removeAccess`. On success: redirect `/groups`, notification `remove_access_group_success`.
-- Server guard: only proceeds when more than one owner exists and the requester is one of them (the last owner must Delete instead).
-
-### US-9: View Assigned (Auto-Provisioned School Cockpit) Groups (Staff)
-
-**As a** school staff member,
-**I want to** see the class and CCA groups assigned to me by School Cockpit,
-**So that** I can deep-link into them without creating anything.
-
-**Acceptance Criteria:**
-
-- On `/groups`, `getAssignedGroups()` → `GET /api/web/v2/staff/groups/assigned?type=summary` populates an "Assigned Groups" section (shown only when classes or CCA groups exist).
-- For MS the title includes the academic year; for IHL it is just "Assigned Groups".
-- Assigned **class** → `/groups/class/details/:id`; assigned **CCA** → `/groups/cca/details/:id`.
-- These are derived from SC staff allocations (read-only) — not custom groups, no create/edit/share/delete. There is **no separate "SC custom group" entity** — PGTW-15's "SC custom group" maps to this assigned grouping.
-
-### US-10: Reuse a Custom Group as a Post Recipient (Staff)
-
-**As a** staff member composing a post/consent form/announcement,
-**I want to** select a saved custom group as a recipient target,
-**So that** I don't re-select students each time.
-
-**Acceptance Criteria:**
-
-- The recipient picker (`StudentGroupsComboBox`) exposes a "Group" tab alongside Class / Level / School / CCA / Individual; custom groups surface there (`GroupTypes.GROUP = 'group'`), with an inline "+ Create Custom Group" link.
-- A selected group resolves to its current members at send time; recipient counts via `POST .../groups/student/count`. Self-removal (US-8) and deletion (US-7) make the group unavailable as a future recipient.
-
-### US-11: IHL Variant (Student ID vs Index) (Staff)
-
-**As a** staff member at an Institute of Higher Learning,
-**I want to** identify students by Student ID rather than class index,
-**So that** rosters match my institution's records.
-
-**Acceptance Criteria:**
-
-- `isIhl` (Redux `indexPage.isIhl`, server-derived via `IHL_SCHOOL_IDS`) switches all identity displays (Student ID vs index/UIN), the upload schema (Student ID vs Name+Class), the valid/invalid result tables, and IHL-only Excel export on the detail Students tab.
-- The 5,000 cap is gated for IHL at the UI submit, on upload validation, and server-side; MS create/edit don't gate the cap in the button but the BFF still rejects > 5000 on upload.
-- IHL additionally enforces **unique group names** server-side on create/edit; MS does not.
+| Constraint | Value |
+|-----------|-------|
+| Group name min length | 1 character |
+| Group name max length | 120 characters |
+| Max students per group | 5,000 |
+| File upload format | `.xlsx` only |
+| File MIME type | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` |
+| Validation result cache TTL | 10 minutes (Redis) |
 
 ---
 
-## Requirements
+## 2. Business Logic Rules
 
-### Functional Requirements
+### 2.1 Group Types Enum
 
-#### FR-1: Group Creation (manual)
+| Value | Label | Usage |
+|-------|-------|-------|
+| `school` | School | All students in school |
+| `class` | Class | Students in a class |
+| `level` | Level | Students in a level |
+| `group` | Custom Group | Custom staff-created group |
+| `cca` | CCA | Co-curricular activity |
 
-- A group requires a non-empty `groupName` (UI max 120 chars) and at least one student.
-- Manual selection sources the roster from `GET /api/web/v2/staff/school/students` and submits deduped `selectedSchoolStudents` to `POST /api/web/v2/staff/groups/custom`.
-- Server validates each student exists, is in the school, has an active allocation and a level; else `'custom group has invalid student'`. Duplicate IDs → `'customGroups has duplicate elements'`. Empty target → `'customGroups targets cannot be empty'`.
+### 2.2 Ownership Model
 
-#### FR-2: File Upload + Validation
+- Multiple staff can own a single group (shared ownership)
+- Creator is automatically first owner
+- Additional owners added via "Share" action
+- Only owners can view/edit the group
+- Groups are school-scoped (isolated by `customGroupSchoolCode`)
 
-- **Accepted type**: `.xlsx` only. **Max size**: 5 MB. **Max files**: 1. **Max students**: 5,000.
-- **MS columns**: `Name`, `Class` (any order, case-insensitive, trimmed). **IHL column**: `Student ID`.
-- Two-stage validation: (1) client-side structural checks with the exact `ValidationMessages` strings; (2) server-side roster matching via an async token + Redis + 3 s polling job.
-- Per-row invalid reasons (`CUSTOM_GROUP_FILE_UPLOAD_INVALID_MESSAGES`): IHL `Not found` / `Currently inactive` / `No level`; MS `Name not found…` / `Class not found…` / `Name and class do not match…` / `Student is marked as inactive…`. Row numbers are `excel index + 2`.
-- Only valid students are added; the group may be created with the valid subset. Manual and upload paths are mutually exclusive within one editing session.
+### 2.3 Access Control
 
-#### FR-3: Sharing / Permissions
+| Action | Owner | Shared Staff | Non-Owner |
+|--------|-------|-------------|-----------|
+| View group | Yes | Yes | No |
+| Edit group (name/students) | Yes | Yes | No |
+| Share with others | Yes | Yes | No |
+| Delete group | Only if LAST owner | No | No |
+| Remove own access | Only if other owners exist | Only if other owners exist | N/A |
 
-- Sharing is **co-ownership**: every shared staff becomes an `owner` with rights to view, send to, rename, add/remove students, and re-share. **No editor/viewer distinction.**
-- `PUT .../groups/custom/:id/share` with `{ selectedStaff }`. Server rejects out-of-school or already-owner targets; sends a share-notification email.
+### 2.4 Delete vs Remove Access
 
-#### FR-4: Lifecycle / Edit / Delete / Remove-access
+| Condition | Action Available |
+|-----------|----------------|
+| Staff is LAST owner | Delete (permanently removes group) |
+| Staff is one of multiple owners | Remove Access (removes self, group persists) |
+| Staff is one of multiple owners | Cannot delete (must remove access instead) |
 
-- Edit: `PUT .../groups/custom/:id` (rename + replace student set). Save gated on actual change + validity.
-- Delete (last owner only): `DELETE .../groups/custom/:id` (server "last owner" guard).
-- Remove access (non-last owner only): `PUT .../groups/custom/:id/removeAccess`.
-- Delete vs Remove chosen by owner count in the UI. **No bulk/multi-select delete exists.**
+### 2.5 Message Group Impact
 
-#### FR-5: SC / Assigned Groups Integration
+- If group is part of a message group, deletion/removal also removes it from message groups
+- Warning shown: "This group is part of a message group. Deleting it will also remove it from your message groups."
 
-- Assigned class/CCA groups come from `GET .../groups/assigned?type=summary` and deep-link to read-only `/groups/class/details/:id` and `/groups/cca/details/:id`. Auto-provisioned from SC allocations; no CRUD/share. No standalone SC-custom-group entity exists.
+### 2.6 Soft Delete
 
-#### FR-6: Reuse as Recipients
+- Groups use `isDeleted` boolean flag
+- Deleted groups remain in database for audit trail
+- Queries filter out deleted groups
 
-- Saved custom groups appear under the "Group" tab of `StudentGroupsComboBox` when composing posts/forms/announcements, with an inline "+ Create Custom Group" shortcut. Recipient counts via `POST .../groups/student/count`.
+### 2.7 Usage as Target
 
-#### FR-7: Roles / IHL / Variants
-
-- **Owner (creator or shared)**: full edit/share/send; delete only if last owner; remove-access only if not last owner. All owners are equal.
-- **IHL**: Student-ID-keyed upload/match/display; IHL-only Excel export; 5,000 cap gated in UI submit; unique group name enforced server-side.
-- **MS**: Name+Class-keyed; UIN/FIN + index display; no UI submit cap (BFF still caps upload at 5,000); group-name uniqueness not enforced.
-
-#### FR-8: Navigation Guard
-
-- Create/Edit pages guard accidental navigation via `Prompt` + `beforeunload` while dirty and not yet posted; Safari bfcache defeated via `onpageshow`.
-
-### Key Entities
-
-| Entity                              | Description                                                                                                                                                              |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `CustomGroup`                       | A staff-owned group: `id`, `groupName`, `createdBy`, `createdAt`, `owners[]`, `studentsList[]`, `isPartOfMessageGroup`.                                                  |
-| `IGroupSummaryDetails`              | List-row projection: `id`, `groupName`, `numberOfStaff`, `numberOfStudents` (only groups with > 0 students).                                                             |
-| `CustomGroupMember`                 | A student in a group: `studentId`, `studentName`, `className`, `classSerialNo`, `levelCode/Description`, `gender`, `uinFinNo`, `schoolStudentId` (IHL), onboarding flag. |
-| `CustomGroupOwner`                  | Staff with full access (`staffId`, `staffName`) — the join that encodes co-ownership/sharing.                                                                            |
-| `ValidateStudents…Request/Response` | Upload payload `{ studentId }` (IHL) / `{ name, className }` (MS); response `{ token }`; poll result `{ status, data: { validStudents, invalidStudents } }`.             |
-| Assigned / SC group                 | Auto-provisioned `class`/`cca` targets from SC; read-only deep-links.                                                                                                    |
-| `StudentType` enum                  | `IHL` / `MS` — selects the upload/validation/display variant.                                                                                                            |
+Custom groups appear as target option (type = `'group'`) in:
+- Announcements
+- Consent Forms
+- Meetings (PTM)
 
 ---
 
-## Success Criteria
+## 3. Validation Rules
 
-1. **Manual creation**: Staff can create a named group from hand-picked students and see it in the list and as a post recipient.
-2. **Upload creation**: A valid `.xlsx` (≤ 5 MB, correct columns, ≤ 5,000 rows) produces a correct valid/invalid breakdown; a group can be created from the valid subset; every encoded validation message renders verbatim.
-3. **Async validation robustness**: Token issuance, Redis `pending` seeding, and 3-second polling resolve without UI hang; 10-minute TTL / 100-attempt ceiling respected.
-4. **Sharing/co-ownership**: Sharing grants the full action set, triggers the email, and rejects out-of-school or duplicate owners.
-5. **Lifecycle guards**: Delete only for last owner; Remove-access only for non-last owners; the UI shows the correct one based on owner count.
-6. **IHL/MS parity**: Identity columns, upload schema, export availability, name-uniqueness, and the 5,000 cap behave per variant.
-7. **Reuse**: A saved group is selectable under the recipient "Group" tab and resolves to its current membership.
+### 3.1 Group Name
+
+| Rule | Detail |
+|------|--------|
+| Length | 1-120 characters |
+| Trimmed | Whitespace trimmed before save |
+| Uniqueness | Must be unique within school (IHL schools enforce this) |
+
+### 3.2 Student List
+
+| Rule | Detail |
+|------|--------|
+| Non-empty | At least 1 student required |
+| No duplicates | Duplicate student IDs rejected |
+| Max count | Cannot exceed 5,000 |
+| Validity | Each student must pass validity checks |
+
+### 3.3 Student Validity Checks
+
+Each student must:
+1. Exist in database
+2. Not be marked as deleted
+3. Not have status code 'I' (inactive)
+4. Belong to the same school
+5. Have class allocation (not deleted)
+6. Have assigned level code
+
+### 3.4 File Upload Validation
+
+**IHL Format** (single column):
+| Rule | Detail |
+|------|--------|
+| Column header | Exactly "Student ID" (case-sensitive) |
+| Data | UinFinNo values |
+| No duplicate headers | Rejected |
+| No duplicate IDs | Rejected |
+| Max rows | 5,000 |
+| Non-empty | File cannot be empty |
+
+**MS (Mainstream Schools) Format** (two columns):
+| Rule | Detail |
+|------|--------|
+| Column headers | "Name" AND "Class" (both required) |
+| No duplicate headers | Rejected |
+| No missing values | Both columns must have data in each row |
+| No duplicate Name+Class combos | Rejected |
+| Class must exist | In school for current academic year |
+| Name matching | Case-insensitive |
+| Max rows | 5,000 |
+| Non-empty | File cannot be empty |
+
+### 3.5 File Upload Error Messages
+
+| Code | Message |
+|------|---------|
+| NOT_FOUND | Not found |
+| CURRENTLY_INACTIVE | Currently inactive |
+| NO_LEVEL | No level |
+| MS_CURRENTLY_INACTIVE | Student is marked as inactive. Remove from uploaded file. |
+| MS_NAME_NOT_FOUND | Name not found in school. Check that name matches the school system records. |
+| MS_CLASS_NOT_FOUND | Class not found in school. Check that class matches the school system records. |
+| MS_STUDENT_IN_CLASS_NOT_FOUND | Name and class do not match. Check that name/class are correct. |
 
 ---
 
-## Assumptions
+## 4. Functional Behavior
 
-1. The backend is a Node/Express BFF colocated with the React app (Sequelize via `@pgw/db-migration`); routes under `/api/web/v2/staff/groups/custom`.
-2. File parsing happens **client-side** (`xlsx`); only structurally valid rows are sent to the BFF, which performs roster matching against School Cockpit data.
-3. Upload validation is intentionally asynchronous (token + Redis + polling) to tolerate large files (up to 5,000 students).
-4. `isIhl` is derived from school configuration (`IHL_SCHOOL_IDS`), exposed via Redux `indexPage.isIhl`.
-5. CSV is **not** an accepted upload format — only `.xlsx`.
-6. **No multi-select/bulk group deletion exists in pgw-web** (PGTW-20's "multi-select delete" is not present). Deletion is single-group from the detail page, governed by the last-owner guard. Flagged as a gap rather than invented.
-7. "SC custom group" (PGTW-15) corresponds to the read-only Assigned (class/CCA) groups; there is no separate SC-owned custom-group write path.
-8. Group-name uniqueness is enforced only for IHL schools server-side.
+### 4.1 Create Group Flow
+
+1. Staff enters group name (1-120 chars)
+2. Staff adds students via:
+   - **Manual add**: Individual student selection via dropdown/combo box
+   - **Excel upload**: Batch upload via .xlsx file
+3. Student list validated (max 5000, no duplicates, all valid)
+4. On success: redirect to group details page + success notification
+
+### 4.2 Edit Group Flow
+
+1. Staff navigates to group detail and clicks Edit
+2. Can change group name and/or replace entire student list
+3. Same validation as create
+4. On success: success notification
+
+### 4.3 Share Group Flow
+
+1. Owner clicks "Share" button
+2. Selects staff members (must be in same school, not already owners)
+3. On success:
+   - Staff added as co-owners
+   - Email notification sent to shared staff (SES template: `CustomGroupShare`)
+   - Success notification shown
+
+### 4.4 Delete Group Flow
+
+1. Only available if staff is LAST remaining owner
+2. Confirmation modal with warning
+3. If part of message group: additional warning shown
+4. On confirm: soft delete + redirect to list + success notification
+
+### 4.5 Remove Access Flow
+
+1. Available if other owners exist
+2. Confirmation modal
+3. If part of message group: additional warning shown
+4. On confirm: removes own ownership + redirect to list
+
+### 4.6 Excel Upload Flow (Async)
+
+1. Staff selects .xlsx file
+2. Frontend calls `POST /validateStudents` with parsed data
+3. Server returns token immediately (UUID)
+4. Server processes validation in background (Redis-cached results)
+5. Frontend polls `POST /validateStudents/results` with token
+6. Results show valid/invalid students with error reasons
+7. Invalid students limited to 5 displayed entries + "+X more" indicator
+8. Staff can proceed with valid students or fix and re-upload
+
+### 4.7 List Page
+
+**Displayed per group**:
+- Group name
+- Number of staff (owners)
+- Number of students
+- Actions: View, Edit, Share, Delete/Remove Access
+
+### 4.8 Detail Page — Tabs
+
+**Students Tab**:
+- Student list table with: Name, Class, Level, Index Number
+- IHL variant: Student ID (UIN/FIN) instead of Index Number
+- Parent onboarding status indicator
+- Legal guardian/caregiver indicator
+
+**Details Tab**:
+- Group name
+- Created by (staff name)
+- Created date
+- Owners list (staff names)
+- Is part of message group (boolean)
+
+### 4.9 IHL vs MS Behavior
+
+**IHL Schools**:
+- File upload uses single "Student ID" column
+- Group name uniqueness enforced
+- Student lookup by UinFinNo
+- Detail view shows Student ID instead of Index Number
+
+**MS Schools**:
+- File upload uses "Name" + "Class" columns
+- Case-insensitive name matching
+- Student lookup by name/class combination
+
+### 4.10 Analytics Events
+
+| Event | Trigger |
+|-------|---------|
+| NewCustomGroupButtonPressed | Create button clicked |
+| CustomGroupCreated | Group successfully created |
+| CustomGroupCreateButtonPressed | Create confirm clicked |
+| CustomGroupSaveButtonPressed | Save (edit) clicked |
+| CustomGroupEditButtonPressed | Edit button clicked |
+| CustomGroupShareButtonPressed | Share button clicked |
+| CustomGroupDeleteButtonPressed | Delete button clicked |
+| CustomGroupRemoveAccessButtonPressed | Remove access clicked |
+| CustomGroupUpdated | Edit completed |
+| CustomGroupDeleted | Delete completed |
+| CustomGroupViewed | Detail page loaded |
+| CustomGroupShared | Share completed |
+| CustomGroupStudentTabPressed | Students tab clicked |
+| CustomGroupDetailsTabPressed | Details tab clicked |
+| CustomGroupUploadViaExcelPressed | Upload button clicked |
+| CustomGroupDropzoneDropFile | File dropped |
+| CustomGroupExcelUploadSuccess | Upload validation passed |
+| CustomGroupExcelUploadFailure | Upload validation failed |
+| CustomGroupExcelUploadModalClose | Upload modal closed |
+| CustomGroupCancelPressed | Cancel action |
 
 ---
 
-## Jira Mapping
+## 5. API Contracts
 
-- **PGTW-13 — Create custom group (manual + file upload)**: US-1 (manual), US-2 (Excel upload), US-11 (IHL); FR-1, FR-2, FR-7, FR-8.
-- **PGTW-14 — Share + edit custom group**: US-5 (edit), US-6 (share); FR-3, FR-4.
-- **PGTW-15 — SC custom group / auto-provisioned groups**: US-9 (Assigned/SC groups); FR-5. (No standalone SC-custom-group write path exists.)
-- **PGTW-20 — Delete (single + multi-select)**: US-7 (single delete, last-owner guard), US-8 (remove access); FR-4. **Multi-select delete is NOT implemented in pgw-web — net-new for TW.**
-- **Cross-cutting — Reuse as recipients**: US-10; FR-6.
+### Base
+
+- **Base URL**: `/api/v2`
+- **Staff**: `/api/v2/staff/groups`
+- **Auth**: SchoolStaffSessionMiddleware
+
+### Response Wrapper (all endpoints)
+
+```typescript
+{ resultCode: number; message: string; body: T; metadata?: Record<string, any> }
+```
+
+---
+
+### 5.1 POST `/staff/groups/custom` — Create Group
+
+**Request**:
+```typescript
+{
+  groupName: string;                    // 1-120 chars, trimmed
+  selectedSchoolStudents: number[];     // Student IDs, no duplicates, max 5000
+}
+```
+
+**Response**: `{ body: { id: number } }`
+
+---
+
+### 5.2 GET `/staff/groups/custom` — List Groups
+
+**Query Params**: `type?: 'summary'`
+
+**Response (summary)**:
+```typescript
+{
+  body: Array<{
+    id: number;
+    groupName: string;
+    numberOfStaff: number;
+    numberOfStudents: number;
+  }>
+}
+```
+
+**Response (full)**:
+```typescript
+{
+  body: Array<{
+    id: number;
+    groupName: string;
+    createdBy: string;
+    createdAt: Date;
+    owners: Array<{ staffName: string; staffId: number }>;
+    studentsList: Array<{
+      studentId: number;
+      studentName: string;
+      gender: string;
+      classSerialNo: string;
+      className: string;
+      levelCode: string;
+      levelDescription: string;
+      hasParentsOnboardedAndCanConsent?: boolean;
+      hasLegalGuardianOrCaregiver?: boolean;
+      uinFinNo?: string;
+      displayName?: string;
+    }>;
+    isPartOfMessageGroup: boolean;
+  }>
+}
+```
+
+---
+
+### 5.3 GET `/staff/groups/custom/:customGroupId` — Get Single Group
+
+**Path Params**: `customGroupId: number`
+
+**Response**: Same shape as full list (single object in array).
+
+---
+
+### 5.4 PUT `/staff/groups/custom/:customGroupId` — Edit Group
+
+**Path Params**: `customGroupId: number`
+
+**Request**:
+```typescript
+{
+  groupName: string;                    // Max 120 chars
+  selectedSchoolStudents: number[];     // Must be unique, max 5000
+}
+```
+
+**Response**: `{ body: true }`
+
+---
+
+### 5.5 PUT `/staff/groups/custom/:customGroupId/share` — Share Group
+
+**Path Params**: `customGroupId: number`
+
+**Request**:
+```typescript
+{
+  selectedStaff: number[];   // Staff IDs, must be unique, same school, not already owners
+}
+```
+
+**Response**: `{ body: true }`
+
+Triggers email notification to shared staff.
+
+---
+
+### 5.6 DELETE `/staff/groups/custom/:customGroupId` — Delete Group
+
+**Path Params**: `customGroupId: number`
+
+**Response**: `{ body: { success: boolean; reason?: string } }`
+
+Fails with reason if staff is not the last owner.
+
+---
+
+### 5.7 PUT `/staff/groups/custom/:customGroupId/removeAccess` — Remove Own Access
+
+**Path Params**: `customGroupId: number`
+
+**Request**: None.
+
+**Response**: `{ body: { success: boolean } }`
+
+If staff is last owner, attempts delete instead.
+
+---
+
+### 5.8 POST `/staff/groups/custom/validateStudents` — Start File Validation
+
+**Request (IHL)**:
+```typescript
+Array<{ studentId: string }>   // UinFinNo values
+```
+
+**Request (MS)**:
+```typescript
+Array<{ name: string; className: string }>
+```
+
+**Response**: `{ body: { token: string } }` (JWT token, 10-minute expiry)
+
+---
+
+### 5.9 POST `/staff/groups/custom/validateStudents/results` — Poll Validation Results
+
+**Request**:
+```typescript
+{ token: string }
+```
+
+**Response**:
+```typescript
+{
+  body: {
+    status: 'pending' | 'success' | 'error';
+    data: {
+      validStudents: Array<{
+        pgStudentId: number;
+        studentId: string;
+        studentName: string;
+        className: string;
+        classCode: string;
+        levelCode: string;
+        levelCodeDescription: string;
+        uinFinNo?: string;
+        indexNumber?: string;
+        cca?: Array<{ ccaId: number; ccaDescription: string }>;
+      }>;
+      invalidStudents: Array<{
+        message: string;        // Error reason
+        row: number;            // Excel row number (starts at 2)
+        studentId?: string;     // IHL
+        name?: string;          // MS
+        className?: string;     // MS
+      }>;
+    } | null;
+    error: string | null;
+  }
+}
+```
+
+---
+
+### 5.10 GET `/staff/groups/assigned` — Get Assigned Groups (Classes + CCAs)
+
+**Query Params**: `type?: 'summary'`
+
+**Response**:
+```typescript
+{
+  body: {
+    classes: Array<{
+      className: string;
+      classId: number;
+      classCode: string;
+      schoolId: number;
+      academicYear: string;
+      studentList?: Array<{
+        classCode: string;
+        className: string;
+        displayName: string;
+        classSerialNo: string;
+        studentId: number;
+        studentName: string;
+        gender: string;
+        hasParentsOnboardedAndCanConsent: boolean;
+        hasLegalGuardianOrCaregiver: boolean;
+      }>;
+    }>;
+    ccaGroups: Array<{ ccaId: number; ccaDescription: string }>;
+  }
+}
+```
+
+---
+
+### 5.11 POST `/staff/groups/student/count` — Count Students in Groups
+
+**Request**:
+```typescript
+{
+  acadYear: string;
+  studentGroups: Array<{ type: 'school'|'class'|'level'|'group'|'cca'; id: string }>;
+}
+```
+
+**Response**: `{ body: { numberOfStudents: number } }`
+
+---
+
+### 5.12 GET `/staff/groups/cca/students/:ccaId` — Get CCA Students
+
+**Path Params**: `ccaId: number`
+
+**Response**:
+```typescript
+{
+  body: {
+    numOfStudents: number;
+    cca: string;
+    classes: Record<string, Array<{ classSerialNo: number; displayName: string; studentId: number; studentName: string }>>;
+  }
+}
+```
+
+---
+
+## 6. Error Handling
+
+### 6.1 Business Logic Errors
+
+| Error | Message |
+|-------|---------|
+| Duplicate group name | "customGroup name duplicated" |
+| Max students exceeded | "customGroup has reached the maximum student limit" |
+| Duplicate students | "customGroups has duplicate elements" |
+| Invalid student | "custom group has invalid student" |
+| Group not found | "customGroups is not found" |
+| Not last owner (delete) | "Invalid custom group or Staff not last owner" |
+
+### 6.2 HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Validation error |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | Group not found |
+| 500 | Internal error |

--- a/docs/requirements/forms-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/forms-1-pg-reverse-engineer-specs.md
@@ -1,326 +1,791 @@
-# Feature Specification: Consent Forms
+# Consent Forms - Complete Redevelopment Spec (Staff & Admin)
 
-**Feature Branch**: `003-consent-forms`
-**Created**: 2026-05-12
-**Status**: Reverse-Engineered
-**Input**: Reverse-engineered from existing codebase
+**Created**: 2026-06-09
+**Purpose**: Comprehensive reference for frontend redevelopment — business logic, validation, functional behavior, and API contracts.
 
 ---
 
-## Overview
+## 1. Constants & Constraints
 
-Consent Forms is a core communication feature in Parents Gateway Web that allows school staff to create, publish, and manage consent/acknowledgement forms sent to parents. Parents respond via the PG mobile app; staff track responses, filter data, edit responses on behalf of parents, and export results to Excel. The feature supports two response types (Yes/No and Acknowledgement), custom follow-up questions, scheduled posting, draft management, and duplication of both drafts and posted forms.
+### 1.1 Character Limits
 
----
+| Field | Max Length |
+|-------|-----------|
+| Title | 120 characters |
+| Description (rich text) | 2,000 characters (plain text count) |
+| Custom question title | 120 characters |
+| Custom question description | 250 characters |
+| Choice label | 120 characters |
+| Response remarks/comments | 500 characters |
+| Enquiry email | 250 characters |
+| Venue | 255 characters |
 
-## User Scenarios & Testing
+### 1.2 File Upload Limits
 
-### US-1: Create a New Consent Form (Staff)
+| Constraint | Value |
+|-----------|-------|
+| Max attachments | 3 files |
+| Max photos | 12 photos |
+| Max cover photos | 3 |
+| Max file size | 5 MB |
+| Attachment extensions | `.pdf, .csv, .docx, .xlsx, .xls, .pptx, .jpg, .jpeg, .gif, .png, .mp3, .mp4, .m4v` |
+| Photo extensions | `.jpg, .jpeg, .png` |
 
-**As a** school staff member,
-**I want to** create a new consent form with all required fields,
-**So that** I can collect consent from parents for school activities.
+### 1.3 Custom Questions
 
-**Acceptance Criteria:**
+| Constraint | Value |
+|-----------|-------|
+| Max questions per form | 5 |
+| Min choices (selection types) | 2 |
+| Max choices (selection types) | 7 |
 
-- Staff navigates to `/consentForms/new`.
-- Staff selects target student groups (by class, level, school, CCA, or custom group) and optionally individual students.
-- Staff selects staff-in-charge (co-owners who can view responses).
-- Staff enters enquiry email address (from staff email, school email, or custom).
-- Staff enters title (max 120 characters) and description (rich text, max 2000 characters).
-- Staff optionally adds in-app shortcuts (e.g., Declare Travels, Edit Contact Details -- hidden for SPED schools).
-- Staff adds web links (URL + optional description), file attachments (up to limit), and photo gallery images (with cover photo designation).
-- Staff selects response type: **Yes/No** or **Acknowledgement**.
-- If Yes/No is selected, staff can optionally add custom questions (text, single selection, or multi selection).
-- Staff enters event details: start date/time, end date/time, venue.
-- Staff enters consent due date (mandatory) and configures reminders (none, one-time, or daily).
-- Staff can optionally set a scheduled post date/time for future publishing.
-- A preview is shown before posting.
-- On post, a confirmation modal shows the form title and number of target students.
-- Successful post redirects to the consent forms list with a success notification.
-- WOGAA transaction tracking is fired for scheduled posts.
+### 1.4 Other
 
-### US-2: Save Form as Draft
-
-**As a** school staff member,
-**I want to** save an incomplete consent form as a draft,
-**So that** I can continue editing it later.
-
-**Acceptance Criteria:**
-
-- Staff can click "Save as Draft" at any point during creation.
-- Draft is saved via `POST /staff/consentForms/drafts` (new) or `PUT /staff/consentForms/drafts/:id` (existing).
-- After first save, the URL updates to `/consentForms/drafts/:id`.
-- Auto-save triggers on session timeout countdown (auto-save state context).
-- Toast notification confirms successful save.
-- Draft upload expiry is tracked for attachments and photos.
-- If title or description exceeds character limits, save is blocked with inline error.
-- Incomplete schedule date/time (only date or only time filled) blocks save with error.
-
-### US-3: Edit a Draft Consent Form
-
-**As a** school staff member,
-**I want to** open an existing draft and continue editing,
-**So that** I can finalize and post the form.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/consentForms/drafts/:id`.
-- The `useDraftGetter` hook fetches the draft via `ConsentFormDraftManager.getConsentFormDraftById`.
-- All fields are pre-populated from the draft data (student groups, staff groups, title, content, email, shortcuts, URLs, attachments, photos, response type, custom questions, event dates, venue, due date, reminder, schedule).
-- Expired attachments/photos show an expiry alert notification.
-- Staff can edit any field and save again as draft or post.
-
-### US-4: Schedule a Consent Form Post
-
-**As a** school staff member,
-**I want to** schedule a consent form to be posted at a future date/time,
-**So that** I can prepare forms in advance.
-
-**Acceptance Criteria:**
-
-- Staff fills in the schedule date/time picker.
-- On preview, staff clicks "Schedule Post" which opens a confirmation modal showing the scheduled date, time, and a note that student/staff assignments are evaluated at send time.
-- On confirm, the form is saved via `ConsentFormScheduleService.post` (new) or `.put` (existing draft).
-- Scheduled forms appear in the "Created by you" list with status SCHEDULED.
-- Staff can reschedule or cancel scheduled forms from the list action menu.
-- Rescheduling calls `ConsentFormScheduleService.rescheduleScheduledConsentForm`.
-- Cancellation calls `ConsentFormScheduleService.cancelScheduledConsentForm`.
-- Scheduled send failure codes are tracked and displayed.
-
-### US-5: View Consent Forms List (Staff)
-
-**As a** school staff member,
-**I want to** see all consent forms I created or that are shared with me,
-**So that** I can manage and track responses.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/consentForms`.
-- Page shows two tabs: "Created by you" and "Shared with you" (Mantine Tabs, URL query param `tab`).
-- **Created by you** tab: shows forms with columns Title, Date, Status, To Parents Of, # Responded, and an action menu.
-  - Statuses: DRAFT, OPEN, CLOSED, SCHEDULED, POSTING.
-  - Action menu varies by status: Draft (Edit, Duplicate, Delete), Open/Closed (Duplicate), Scheduled (Reschedule, Cancel).
-  - Response progress bar shows `respondedPerStudent / totalStudents`.
-  - Date column is sortable. Status, To Parents Of columns are filterable.
-- **Shared with you** tab: shows forms shared by other staff with columns Title, Date, Status, Created By, To Parents Of, # Responded, and action menu (Duplicate for Open/Closed only).
-- "Create New" button navigates to `/consentForms/new`.
-
-### US-6: View Consent Form Details and Responses (Staff)
-
-**As a** school staff member,
-**I want to** view detailed responses for a posted consent form,
-**So that** I can track parent consent and take action.
-
-**Acceptance Criteria:**
-
-- Staff navigates to `/consentForms/details/:id`.
-- Page shows a header with title, event date range, and target groups.
-- Two tabs: "Responses" and "Details".
-- **Responses tab:**
-  - Summary stats at top showing Total, Yes, No, Pending counts (or Total, Yes, Pending for Acknowledgement type).
-  - Clicking a stat filters the response table by that reply value.
-  - Filter section with dropdowns for Status (Onboarded/Not Onboarded), Class, and Show Columns (multi-select).
-  - Response data table with configurable columns: Name (fixed), Class/Index, Gender, Response, Custom Questions (dynamic per question), Comments, Last Responded By, Last Responded On, Status.
-  - IHL schools have alternative column layout (IHL Class, Student ID instead of Class/Index).
-  - "Edit Response" link per student (restricted for onboarded custodians before due date for Yes/No forms).
-  - "Export to Excel" button (desktop only) exports filtered data to .xlsx.
-  - "View more" link on Last Responded By shows reply audit history modal.
-  - For Yes/No response type, a reminder banner is displayed: "Custodians may edit their responses till the due date."
-- **Details tab:**
-  - Shows posting details (date, staff name), staff-in-charge (with Add button), enquiry email (with Edit button), description, shortcuts, venue, web links, file attachments, photo gallery, type of response, custom questions with choices, due date and reminder info (with Edit button), view history (accordion), and Other Actions (Duplicate, Delete).
-
-### US-7: Edit a Student's Response (Staff)
-
-**As a** school staff member,
-**I want to** edit a parent's response on behalf of them,
-**So that** I can correct or update consent information.
-
-**Acceptance Criteria:**
-
-- Staff clicks "Edit Response" for a student in the Responses tab.
-- An overlay opens showing the student name, submitted-by info, and editable fields.
-- Staff can change the reply (Yes/No or Yes for Acknowledgement).
-- If Yes is selected and custom questions exist, staff can edit custom question answers (text input, radio buttons for single selection, checkboxes for multi selection).
-- Staff can edit optional comments (max 500 characters).
-- On save, a confirmation modal appears. On confirm, the response is updated via `PUT /staff/consentForms/:id/student/:studentId/reply`.
-- Custom question replies are only sent when reply is YES.
-- Success notification shown; response table refreshes.
-
-### US-8: Manage Staff-in-Charge
-
-**As a** school staff member,
-**I want to** add or remove staff-in-charge for a consent form,
-**So that** the right staff can manage responses.
-
-**Acceptance Criteria:**
-
-- From the Details tab, staff clicks "Add" next to Staff-in-charge.
-- An overlay shows a staff selector; selected staff are added via `POST /staff/consentForms/:id/addStaffInCharge`.
-- Staff can remove themselves via "Remove" link, which calls `PUT /staff/consentForms/:id/removeAccess` and redirects to the list.
-
-### US-9: Edit Enquiry Email and Due Date
-
-**As a** school staff member,
-**I want to** update the enquiry email or extend the due date of a posted form,
-**So that** parents have the correct contact information and enough time to respond.
-
-**Acceptance Criteria:**
-
-- Edit Enquiry Email overlay allows selecting from staff email, school email, or custom. Calls `PUT /staff/consentForms/:id/updateEnquiryEmail`.
-- Edit Due Date overlay allows changing due date and reminder. Calls `PUT /staff/consentForms/:id/updateDueDate`.
-- History records are created for due date changes and shown in the View History section.
-
-### US-10: Delete a Consent Form
-
-**As a** school staff member,
-**I want to** permanently delete a consent form,
-**So that** obsolete forms are removed.
-
-**Acceptance Criteria:**
-
-- From the Details tab, staff checks a disclaimer checkbox and clicks "Delete Forever".
-- A confirmation modal appears.
-- On confirm, the form is deleted via `DELETE /staff/consentForms/:id` (or `/schoolAdmins/consentForms/:id` for admins).
-- Redirects to the consent forms list with a success notification.
-
-### US-11: Duplicate a Consent Form
-
-**As a** school staff member,
-**I want to** duplicate an existing consent form (draft or posted),
-**So that** I can reuse it with modifications.
-
-**Acceptance Criteria:**
-
-- From the list action menu or Details tab, staff can duplicate.
-- Draft duplication calls `POST /staff/consentForms/drafts/duplicate`.
-- Posted form duplication calls `POST /staff/consentForms/duplicate`.
-- Both return a new draft ID; staff is redirected to `/consentForms/drafts/:newId` with a success toast.
-- Analytics events are tracked for duplication.
-
-### US-12: View Consent Forms List (School Admin)
-
-**As a** school admin,
-**I want to** view all consent forms across my school,
-**So that** I can oversee school communications.
-
-**Acceptance Criteria:**
-
-- Admin navigates to `/admin/consentForms`.
-- Legacy list view showing all posted forms with title, event dates, due date indicator, creator name, posted date, and total recipient count.
-- Clicking navigates to `/admin/consentForms/details/:id`.
-- Admin has `isAdmin=true` flag which maps to `/schoolAdmins/consentForms` API endpoint.
-- Admin can delete forms but cannot add/remove staff or edit email/due date.
+| Constraint | Value |
+|-----------|-------|
+| Max web links | 3 |
+| Schedule min delay | 5 minutes from now |
+| Schedule max delay | 21 days (configurable via `SCHEDULE_POST_MAX_NUM_DAYS` env) |
+| Schedule interval | 5-minute intervals only |
 
 ---
 
-## Requirements
+## 2. Business Logic Rules
 
-### Functional Requirements
+### 2.1 Response Type Rules
 
-#### FR-1: Form Creation
+| Rule | Detail |
+|------|--------|
+| Custom questions | Only valid when `responseType === 'YES_NO'` |
+| Custom question replies | Mandatory when reply is `YES` and questions exist |
+| Custom question replies | Must be null/omitted when reply is `NO` |
+| Acknowledgement | Only `YES` is valid (no `NO` option) |
+| Reminder banner | Only shown for YES_NO forms: "Custodians may edit their responses till the due date." |
 
-- Support two response types: `YES_NO` and `ACKNOWLEDGEMENT`.
-- Support custom questions with types: `text`, `single_selection`, `multi_selection`.
-- Custom questions are only applicable when response type is `YES_NO`.
-- Each custom question has a title, optional description, and for selection types, a list of choices with id/label.
-- Support event date range (start date/time, end date/time), venue, consent due date.
-- Support three reminder types: `NONE` (default due-date reminder only), `ONE_TIME` (additional reminder on specific date), `DAILY` (daily reminders from date until due date).
-- Support rich text content (JSON format via `richTextContent` field).
-- Support file attachments and photo gallery with file token-based upload.
-- Support in-app shortcuts selection.
-- Support web links with optional descriptions.
-- Support staff groups selection for co-ownership.
-- Title max length: 120 characters. Description max length: 2000 characters.
+### 2.2 Status Model
 
-#### FR-2: Draft Management
+**Backend** (`EResourceStatus`): `DRAFT`, `POSTED`, `SCHEDULED`, `POSTING`
 
-- Auto-save on session timeout trigger.
-- Manual save as draft at any time.
-- Draft persists all form fields including scheduled post date/time.
-- Draft upload expiry tracking for attachments and photos.
-- Drafts can be edited, deleted, or duplicated.
+**Frontend display** (`EConsentFormAPIResponseStatus`):
+| Display Status | Derived From |
+|----------------|-------------|
+| `DRAFT` | EResourceStatus.DRAFT |
+| `OPEN` | POSTED where `consentByDate` > today |
+| `CLOSED` | POSTED where `consentByDate` <= today |
+| `SCHEDULED` | EResourceStatus.SCHEDULED |
+| `POSTING` | EResourceStatus.POSTING |
 
-#### FR-3: Scheduled Posting
+### 2.3 Response Editing Restrictions
 
-- Forms can be scheduled for future posting with a specific date and time.
-- Scheduled forms can be rescheduled or cancelled.
-- Students and staff assignments are evaluated at the time of actual sending, not scheduling.
-- A reminder is sent to the creator before the scheduled time (unless within 24 hours).
-- Scheduled send failure codes are tracked and displayed.
+| Condition | Staff can edit? |
+|-----------|----------------|
+| YES_NO, custodian onboarded, BEFORE due date | **No** |
+| YES_NO, custodian onboarded, AFTER due date | Yes |
+| YES_NO, custodian NOT onboarded | Yes (anytime) |
+| ACKNOWLEDGEMENT form | Yes (anytime, only YES valid) |
 
-#### FR-4: Response Tracking
+### 2.4 Access Control
 
-- Track responses per student: YES, NO, or Pending (for YES_NO); YES or Pending (for ACKNOWLEDGEMENT).
-- Display response summary stats with interactive filtering.
-- Support filtering by class, onboarding status, and reply type.
-- Support configurable column visibility.
-- Custom question responses displayed inline in the data table.
-- Reply audit trail shows history of response changes (by custodian or teacher).
+| Action | Creator | Staff-in-Charge | School Admin |
+|--------|---------|-----------------|--------------|
+| View form details | Yes | Yes | Yes |
+| View responses | Yes | Yes | Yes |
+| Edit student response | Yes | No | No |
+| Add staff-in-charge | Yes | No | No |
+| Remove self as staff | N/A | Yes | N/A |
+| Edit enquiry email | Yes | No | No |
+| Edit due date | Yes | No | No |
+| Delete form | Yes | No | Yes |
+| Duplicate posted form | Yes | Yes | No |
+| Edit/delete draft | Yes | No | No |
 
-#### FR-5: Response Editing
+### 2.5 School Type Variants
 
-- Staff can edit responses on behalf of parents.
-- For Yes/No forms, editing is restricted for onboarded custodians until after the due date.
-- Custom question replies are mandatory when reply is YES.
-- Comments are optional (max 500 characters).
+**IHL (Institute of Higher Learning):**
+- In-app shortcuts field hidden entirely
+- Response table: "IHL Class" and "Student ID" (UIN/FIN) instead of "Class/Index"
 
-#### FR-6: Export
+**SPED (Special Education):**
+- Excludes shortcut: `EDIT_CONTACT_DETAILS`
+- Other shortcuts (e.g. `DECLARE_TRAVELS`) remain available
 
-- Export filtered response data to Excel (.xlsx).
-- Export respects column visibility and filter settings.
-- Export includes class, index, name, gender, response, custom questions, comments, last responded by/on, status.
-- Export is not available on mobile devices.
+### 2.6 Scheduling Rules
 
-#### FR-7: Roles and Access
+| Rule | Detail |
+|------|--------|
+| Scheduled time | Must be future (min 5 minutes), at 5-minute intervals |
+| Max window | 21 days (configurable) |
+| Group resolution | Targets resolved at SEND time, not schedule time |
+| Pre-send reminder | Sent to creator unless scheduled <24h from now |
+| Must be before | Event start, event end, due date, and reminder date |
+| Cancel | Reverts to DRAFT, records `cancelledBy`/`cancelledAt` |
+| Failure | `scheduledSendFailureCode` set on draft if send fails |
 
-- **Staff**: Full CRUD on own forms, edit responses, manage staff-in-charge, edit email/due date.
-- **Staff (shared)**: View responses, duplicate posted forms. No edit/delete.
-- **School Admin**: View all school forms, delete forms. No staff management or field editing. Uses `/schoolAdmins/` API path.
-- **IHL (Institute of Higher Learning)**: Alternative column layout with Student ID instead of index number.
-- **SPED (Special Education)**: In-app shortcut "Edit Contact Details" is hidden.
+### 2.7 Optimistic Concurrency
 
-#### FR-8: Navigation Prevention
+- Draft updates: `updatedAt` from previous response must match DB value → 409 on mismatch
+- Enquiry email: `prevEnquiryEmailAddress` must match current value → 409 on mismatch
 
-- Unsaved changes trigger a browser navigation prompt ("You are about to leave this page. Any unsaved changes will be lost.").
-- `useUnloadEvent` hook prevents accidental page close.
+### 2.8 Auto-Save
 
-### Key Entities
+**Trigger**: Fires when `autoSaveStates === TRIGGER` AND form is dirty.
 
-| Entity                  | Description                                               |
-| ----------------------- | --------------------------------------------------------- |
-| `ConsentForm`           | A posted consent form with full response data             |
-| `ConsentFormDraft`      | A draft consent form (pre-posting)                        |
-| `ConsentFormRecipient`  | A student-parent pair targeted by a form, with reply data |
-| `CustomQuestion`        | A follow-up question attached to a Yes/No form            |
-| `CustomQuestionReply`   | A parent's answer to a custom question                    |
-| `ConsentFormTarget`     | Target group (class, level, school, CCA, custom group)    |
-| `ConsentFormOwner`      | Staff member who owns/co-owns the form                    |
-| `ConsentFormHistory`    | Audit trail of form changes (creation, due date edits)    |
-| `ConsentFormReplyAudit` | Audit trail of individual reply changes                   |
+**Pre-conditions** (all must be non-empty):
+1. enquiryEmailAddress
+2. title
+3. content (plain text extracted from rich text)
+4. selectedIndividualStudentGroups (at least one)
+5. responseType
+6. consentByDate
+7. For scheduled: both `scheduledDateTime.date` and `.time`
+
+**Header**: `pg-no-extend: ''` prevents session extension during auto-save.
+
+**States**: `PENDING` → `TRIGGER` → `SUCCESS` | `FAILED`
+
+### 2.9 Navigation Prevention
+
+- Triggers when `isDirtyState && !isPosting`
+- Message: "You are about to leave this page. Any unsaved changes will be lost."
+- Uses `useUnloadEvent` hook for browser close/refresh
+
+### 2.10 Duplicate Behavior
+
+**Copied**: Title, description, rich text, venue, web links, shortcuts, photos, attachments, response type, custom questions, event dates, due date, reminder settings, staff-in-charge, target groups.
+
+**NOT copied**: Student responses, posted date, audit/history records.
+
+### 2.11 Soft Delete
+
+Sets `isDeleted: true` on: consent form, owners, targets, audit records, URLs, shortcuts. Records stay in DB.
 
 ---
 
-## Success Criteria
+## 3. Validation Rules
 
-1. **Form Creation**: Staff can successfully create and post a consent form with all field types, receiving confirmation and seeing it in the list.
-2. **Draft Persistence**: Drafts save all fields and restore correctly on reload, including auto-save on timeout.
-3. **Scheduled Posting**: Scheduled forms are sent at the correct time; reschedule and cancel work without data loss.
-4. **Response Tracking**: Response summary stats are accurate; filters work correctly across all combinations; data table displays all columns including dynamic custom question columns.
-5. **Response Editing**: Staff can edit responses with all custom question types; validation enforces mandatory fields; confirmation modal prevents accidental changes.
-6. **Export Accuracy**: Excel export matches the filtered data table exactly, including custom question columns.
-7. **Role-Based Access**: Admin and staff views correctly restrict/enable actions based on role; IHL and SPED variants render correctly.
-8. **Data Integrity**: Optimistic concurrency via `updatedAt` field; file upload state tracking (success/fail/expired).
+### 3.1 Required for Publishing
+
+1. Recipients (at least one student group)
+2. Enquiry email address (valid format)
+3. Title (non-empty, max 120 chars)
+4. Description (non-empty, max 2000 chars, valid rich text JSON)
+5. Response type (`YES_NO` or `ACKNOWLEDGEMENT`)
+6. Due date (today or future)
+
+### 3.2 Field Validation
+
+| Field | Rule |
+|-------|------|
+| Title | Non-empty, max 120 chars. Error: "Exceeded by X characters" |
+| Description | Non-empty plain text, max 2000 chars, valid JSON schema |
+| Due date | Today or future. Error: "Please enter a valid date from today onwards." |
+| Reminder date | Must be before or equal to due date |
+| Event dates | If one is set, both must be valid. No past-date restriction |
+| Schedule date | Future (5 min+), within 21 days, 5-min interval, before event/due/reminder dates. Error: "Please enter a valid date before {labels}" |
+| Web links | `isValidLink` (URL format), `isSafeLink` (safety), `isMimeSafeLink` (MIME) |
+| Enquiry email | Valid email format |
+| Attachments | Valid non-expired token, size <= 5MB, accepted extension |
+| Photos | Valid non-expired token, accepted extension (jpg/jpeg/png) |
+| Question title | Non-empty, max 120 chars |
+| Question choices | Min 2, max 7, no duplicates (case-insensitive, trimmed), each max 120 chars |
+
+### 3.3 Draft Save Blocking
+
+Save is blocked ONLY when:
+- Title exceeds 120 characters
+- Description exceeds 2000 characters
+- Schedule date/time is incomplete (only date OR only time filled)
+
+All other fields can be empty/partial for draft save.
+
+### 3.4 Edit Response Validation
+
+| Field | Rule |
+|-------|------|
+| consentType | Required: `YES` or `NO` (YES_NO) or `YES` (Acknowledgement) |
+| remarks | Optional, max 500 chars |
+| Custom replies | Required when `YES` AND form has questions |
+| Text answers | Required for `text` type when reply is YES |
+| Single selection | Exactly 1 valid choice ID |
+| Multi selection | >= 1 valid choice IDs |
 
 ---
 
-## Assumptions
+## 4. Functional Behavior
 
-1. The backend API is a Node.js BFF (Backend-For-Frontend) running alongside the React frontend, using Sequelize ORM (`@pgw/db-migration`).
-2. File uploads (attachments, photos) use a token-based upload flow where files are uploaded separately and referenced by `fileToken`.
-3. The mobile app (Parents Gateway) handles the parent-side response flow; this spec covers only the staff web portal.
-4. Rich text content is stored as JSON (`richTextContent`) with a plain-text fallback (`content`).
-5. The `isIhl` and `isSped` flags are derived from school configuration and stored in the Redux `indexPage` state.
-6. WOGAA (Whole-of-Government Application Analytics) tracking is a Singapore government requirement for public-facing applications.
-7. The `EResourceStatus` enum (DRAFT, POSTED, SCHEDULED, POSTING) comes from a shared status type; the frontend maps POSTED to OPEN/CLOSED based on the consent-by date.
-8. Session timeout auto-save uses the `AutoSaveStatesContext` (PENDING -> TRIGGER -> SUCCESS/FAILED).
+### 4.1 Create/Edit Form — Field Order
+
+1. Recipients (Parents) — student group combo box
+2. Recipients (School Staff) — staff group combo box
+3. Enquiry Email — selector: staff email / school email / custom
+4. Title — text input with 120 char counter
+5. Description — rich text editor with 2000 char counter
+6. In-App Shortcuts — multi-select checkboxes (hidden for IHL)
+7. Website Links — up to 3 (URL + description each)
+8. File Attachments — upload up to 3 (5MB each)
+9. Photo Gallery — upload up to 12 (max 3 cover)
+10. Event Start Date/Time
+11. Event End Date/Time
+12. Venue — text input
+13. Response Type — YES_NO or ACKNOWLEDGEMENT
+14. Custom Questions — dynamic list (only for YES_NO)
+15. Due Date — date picker (today or future)
+16. Reminders — type selector + date
+17. Schedule Post — optional date/time picker
+
+### 4.2 List Page — Created by You
+
+**Columns**: Title, Date, Status, To Parents Of, # Responded (progress bar)
+
+**Actions per status**:
+| Status | Actions |
+|--------|---------|
+| DRAFT | Edit, Delete, Duplicate |
+| SCHEDULED | Reschedule, Cancel send |
+| POSTING | (none) |
+| OPEN | Duplicate |
+| CLOSED | Duplicate |
+
+### 4.3 List Page — Shared with You
+
+**Columns**: Title, Date, Status, Created By, To Parents Of, # Responded
+
+**Actions**: Duplicate only (OPEN/CLOSED)
+
+### 4.4 List Page — School Admin
+
+All posted forms in school. Actions: View details, Delete.
+
+### 4.5 Details Page — Responses Tab
+
+**Summary Stats** (clickable to filter table):
+- YES_NO: Total, Yes, No, Pending
+- ACKNOWLEDGEMENT: Total, Yes, Pending
+
+**Filters**:
+- Status: All, Onboarded, Not Onboarded, Inactive, Left School
+- Class: Sorted list (No Class Allocated first, Left School last, Pre-P1 first)
+- Reply: All, Yes, No, Pending
+- Columns: Multi-select toggle visibility
+
+**Table Columns**:
+| Column | Standard | IHL Variant |
+|--------|----------|-------------|
+| Name + Edit link | Always shown | Same |
+| Class/Index | Class, index number | Class only |
+| IHL Student ID | N/A | UIN/FIN |
+| Gender | M/F | M/F |
+| Response | Yes/No/Pending | Same |
+| Custom Questions (1..N) | Dynamic per question | Same |
+| Comments | Remarks | Same |
+| Last Responded By | Identity, Name, Contact | Same |
+| Last Responded On | Date/time | Same |
+| Status | Onboarded/Not Onboarded | Same |
+
+**Custom Question Columns**: Only populated when response is YES. Multi-selection values joined with semicolons.
+
+**Last Responded By**: Custodian shows (Relationship, Name, Phone). Staff shows ("Teacher", Name, Email). Multiple edits show "View more" → Reply Audit modal (reverse chronological, "Submitted" then "Edited" labels).
+
+### 4.6 Details Page — Details Tab
+
+Sections in order:
+1. Posting details: "Posted on [Date] by [Staff Name]"
+2. Staff-in-charge: Creator first, others listed, "Add" button (creator only)
+3. Enquiry email + "Edit" button (creator only)
+4. Description (rich text / plain text)
+5. Shortcuts with icons
+6. Venue
+7. Web links with descriptions
+8. Attachments with download links
+9. Photo gallery
+10. Type of response + description text
+11. Custom questions (numbered, with choices listed)
+12. Response due date and reminders + edit history
+13. View history (expandable accordion)
+14. OTHER ACTIONS: Duplicate, Delete (with disclaimer checkbox)
+
+### 4.7 Export to Excel
+
+- Desktop only (hidden on mobile)
+- Exports only visible/selected columns
+- File name: form title with special chars → dashes
+- Names prefixed with apostrophe for Excel text preservation
+- Custom questions exported only for YES answers
+- Multi-selection joined with semicolons
+- Pending responses show "No response"
+
+### 4.8 Post Flow
+
+1. Preview → Confirmation modal (title + target student count)
+2. API call → If rescan needed, poll `GET /drafts/:id`
+3. When `postedConsentFormId` is set → post complete
+4. Redirect to list + success notification + WOGAA transaction (prod only)
+
+### 4.9 Reschedule/Cancel from List
+
+**Reschedule**: Opens date/time picker modal. Shows event dates, due date, reminder for reference. Validates same as initial schedule.
+
+**Cancel**: Confirmation: "Cancel sending this post? Once cancelled, the post will be moved to Drafts." → Reverts to DRAFT.
+
+### 4.10 Edit Due Date Flow
+
+1. Opens overlay with: new due date picker, reminder type selector, reminder date
+2. Displays event date range for reference
+3. Confirmation: "Confirm New Due Date?" showing old → new date
+4. Note: "Notifications will now be sent to parents who have not responded."
+5. Creates audit history record
+
+### 4.11 Edit Enquiry Email Flow
+
+1. Opens overlay with: email selector (staff email / school email / other)
+2. Confirmation: "Confirm Enquiry Email?" showing current email
+3. Uses `prevEnquiryEmailAddress` for concurrency
+
+### 4.12 Add/Remove Staff-in-Charge
+
+**Add**: Creator opens overlay → selects staff (excludes self) → success notification.
+
+**Remove self**: Staff-in-charge clicks remove → confirmation → redirects to list.
+
+### 4.13 Delete Form
+
+1. Disclaimer checkbox: "I am sure I want to delete this form."
+2. Delete button enabled only after checkbox checked
+3. Confirmation modal
+4. Soft delete → redirect to list + success notification
+
+### 4.14 Analytics Events (WOGAA)
+
+| Event | Trigger |
+|-------|---------|
+| FormPreviewButtonPressed | Preview clicked |
+| FormPostButtonPressed | Post clicked |
+| FormCreated | Successful creation |
+| SchedulePostFormButtonClick | Schedule clicked |
+| SchedulePostFormCreated | Successful schedule |
+| SchedulePostFormCancelled | Schedule cancelled |
+| FormBackButtonPressed | Back/cancel |
+| DueDateTooltipPressed | Due date tooltip |
+| ReminderTooltipPressed | Reminder tooltip |
+| ExportToExcelButtonPressed | Export clicked |
+| EditEnquiryEmailButtonPressed | Edit email |
+| EditDueDateButtonPressed | Edit due date |
+| AddStaffButtonPressed | Add staff |
+| DuplicatePostCreateDetailsPressed | Duplicate from details |
+| FormDeleted | Form deleted |
+| ChangeResponseAuditLogViewed | Audit modal opened |
+
+WOGAA: `window.wogaaCustom`, production only. Schedule uses transactional tracking (start on click, complete on success with UUID).
+
+---
+
+## 5. API Contracts
+
+### Base
+
+- **Base URL**: `/api/v2`
+- **Staff**: `/api/v2/staff/consentForms`
+- **Admin**: `/api/v2/schoolAdmins/consentForms`
+- **Auth**: SchoolStaffSessionMiddleware (staff), SchoolStaffSessionMiddleware with `accessControlScope: 'Admin'` (admin)
+- **Auto-save header**: `pg-no-extend: ''`
+
+### Response Wrapper (all endpoints)
+
+```typescript
+{ resultCode: number; message: string; body: T; metadata?: Record<string, any> }
+```
+
+---
+
+### 5.1 POST `/staff/consentForms` — Publish
+
+**Rate Limited**: Yes.
+
+**Request**:
+```typescript
+{
+  consentFormDraftId?: number;
+  title: string;
+  content: Record<string, any>;
+  enquiryEmailAddress: string;
+  targets: Array<{ targetType: 'CLASS'|'LEVEL'|'SCHOOL'|'CCA'|'GROUP'; targetId: number; targetAcadYear?: string }>;
+  consentByDate: string;
+  responseType: 'YES_NO' | 'ACKNOWLEDGEMENT';
+  addReminderType: 'NONE' | 'ONE_TIME' | 'DAILY';
+  reminderDate?: string;
+  startDateTime?: string;
+  endDateTime?: string;
+  venue?: string;
+  staffInCharge: number[];
+  customQuestions?: Array<{ title: string; description: string; type: 'text'|'single_selection'|'multi_selection'; properties?: { choices: Array<{ id: string; label: string }> } }>;
+  webLinkList: Array<{ webLink: string; linkDescription: string }>;
+  inAppShortcutLink?: string[];
+  photos: Array<{ fileToken: string; isCover: boolean }>;
+  attachments: Array<{ fileToken: string }>;
+}
+```
+
+**Response**: `{ body: { consentForm: { id: number; ... } } }` OR `{ body: number }` (draft ID needing file rescan)
+
+---
+
+### 5.2 POST `/staff/consentForms/drafts` — Create Draft
+
+**Request** (`TConsentFormDraftRequestBody`):
+```typescript
+{
+  title?: string;
+  content?: Record<string, any> | string;
+  venue?: string;
+  addReminderType?: 'NONE'|'ONE_TIME'|'DAILY'|'';
+  enquiryEmailAddress?: string;
+  consentByDate?: string;
+  reminderDate?: string;
+  eventStartDate?: { date: string; time: string } | null;
+  eventEndDate?: { date: string; time: string } | null;
+  responseType?: 'YES_NO'|'ACKNOWLEDGEMENT'|'';
+  questions?: Array<{ id?: string; title: string; description: string; type: 'text'|'single_selection'|'multi_selection'; properties?: { choices: Array<{ id?: string; label: string }> } }>;
+  studentGroups?: Array<{ type: string; label: string; value: string|number }>;
+  staffGroups?: Array<{ type: string; label: string; value: string|number }>;
+  images?: Array<{ fileToken: string; isCover: boolean }>;
+  attachments?: Array<{ fileToken: string }>;
+  urls?: Array<{ webLink: string; linkDescription: string }>;
+  shortcuts?: string[];
+  scheduledDateTime?: null;
+  status?: 'DRAFT';
+}
+```
+
+**Response**: `{ body: { consentFormDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.3 PUT `/staff/consentForms/drafts/:consentFormDraftId` — Update Draft
+
+**Request**: Same as 5.2.
+
+**Response**: `{ body: { updatedAt: string } }`
+
+---
+
+### 5.4 GET `/staff/consentForms/drafts/:consentFormDraftId` — Get Draft
+
+**Response**:
+```typescript
+{
+  body: [{
+    consentFormDraftId: number;
+    status: 'DRAFT' | 'SCHEDULED' | 'POSTING';
+    postedConsentFormId: number | null;
+    studentGroups: Array<{ type: string; label: string; value: string }>;
+    staffGroups: Array<{ type: string; label: string; value: string }>;
+    title: string;
+    content: string | null;
+    richTextContent: Record<string, any> | null;
+    enquiryEmailAddress: string;
+    urls: Array<{ webLink: string; linkDescription: string }>;
+    shortcuts: string[];
+    attachments: Array<{ fileToken: string; name: string; size: number; status: 'success'|'failed'|'expired' }>;
+    images: { images: Array<{ fileToken: string; name: string; size: number; isCover: boolean; status: 'success'|'failed'|'expired' }>; imagesOrigin: string };
+    responseType: 'YES_NO' | 'ACKNOWLEDGEMENT' | '';
+    questions: Array<{ id: string; title: string; description: string; type: 'text'|'single_selection'|'multi_selection'; properties?: { choices: Array<{ id: string; label: string }> } }>;
+    eventStartDate: { date: string; time: string } | null;
+    eventEndDate: { date: string; time: string } | null;
+    venue: string;
+    consentByDate: string;
+    addReminderType: 'NONE' | 'ONE_TIME' | 'DAILY' | '';
+    reminderDate: string;
+    updatedAt: string;
+    pgSchoolId: number;
+    createdBy: number;
+    scheduledDateTime: Date | null;
+    cancelledBy: number | null;
+    cancelledAt: string | null;
+  }]
+}
+```
+
+**Post-status polling** (same endpoint, when checking if publish completed):
+```typescript
+{ body: [{ consentFormDraftId: number; status: 'POSTING'|'POSTED'; postedConsentFormId: number|null; attachments: [...]; images: [...] }] }
+```
+
+---
+
+### 5.5 DELETE `/staff/consentForms/drafts/:consentFormDraftId` — Delete Draft
+
+**Response**: Standard success.
+
+---
+
+### 5.6 POST `/staff/consentForms/drafts/duplicate` — Duplicate Draft
+
+**Request**: `{ consentFormDraftId: number }`
+
+**Response**: `{ body: { consentFormDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.7 POST `/staff/consentForms/duplicate` — Duplicate Posted Form
+
+**Request**: `{ consentFormId: number }`
+
+**Response**: `{ body: { consentFormDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.8 POST `/staff/consentForms/drafts/schedule` — Schedule New
+
+**Request**: Same as 5.2 with mandatory `scheduledDateTime: Date`.
+
+**Response**: `{ body: { consentFormDraftId: number; updatedAt: string } }`
+
+---
+
+### 5.9 PUT `/staff/consentForms/drafts/schedule/:consentFormDraftId` — Update Scheduled
+
+**Request**: Same as 5.8.
+
+**Response**: Same as 5.8.
+
+---
+
+### 5.10 PUT `/staff/consentForms/drafts/:consentFormDraftId/rescheduleSchedule` — Reschedule
+
+**Request**: `{ scheduledDateTime: Date }`
+
+**Response**: `{ body: { updatedAt: string } }`
+
+---
+
+### 5.11 POST `/staff/consentForms/drafts/:consentFormDraftId/cancelSchedule` — Cancel
+
+**Request**: None.
+
+**Response**: Standard success (`IPgApiResponse<boolean>`).
+
+---
+
+### 5.12 GET `/staff/consentForms` — List Created by You
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    id: string; postId: number; title: string; date: Date;
+    eventStartDate: { date: string; time: string } | null;
+    eventEndDate: { date: string; time: string } | null;
+    consentByDate: Date | null;
+    eventReminderDate: Date | null;
+    status: 'DRAFT'|'OPEN'|'CLOSED'|'SCHEDULED'|'POSTING';
+    toParentsOf: string[];
+    respondedMetrics: { respondedPerStudent: number; totalStudents: number };
+    scheduledSendFailureCode: string | null;
+  }>
+}
+```
+
+---
+
+### 5.13 GET `/staff/consentForms/shared` — List Shared with You
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    id: string; postId: number; title: string; date: Date;
+    status: 'OPEN' | 'CLOSED';
+    createdByName: string;
+    toParentsOf: string[];
+    respondedMetrics: { respondedPerStudent: number; totalStudents: number };
+  }>
+}
+```
+
+---
+
+### 5.14 GET `/staff/consentForms/:consentFormId` — Get Posted Form Details
+
+**Response**:
+```typescript
+{
+  body: [{
+    consentFormId: number;
+    title: string;
+    venue: string | null;
+    content: string;
+    richTextContent: Record<string, any> | null;
+    responseType: 'YES_NO' | 'ACKNOWLEDGEMENT';
+    eventStartDate: Date | null;
+    eventEndDate: Date | null;
+    consentByDate: Date;
+    addReminderType: string | null;
+    reminderDate: Date | null;
+    postedDate: Date;
+    enquiryEmailAddress: string;
+    fileName: string | null;
+    fileSize: number | null;
+    staffName: string;
+    createdBy: number;
+    createdAt: Date;
+    webLinkList: Array<{ webLink: string; linkDescription: string | null }>;
+    shortcutLinkList: Array<{ shortcutName: string }>;
+    targets: Array<{ consentFormId: number; targetSchool: number; targetType: string; targetAcadYear: string|null; targetId: number; targetName: string }>;
+    staffOwners: Array<{ staffName: string; staffID: number }>;
+    images: Array<{ imageId: number; size: number; name: string; url: string; thumbnailUrl: string; expiryDate?: string; isCover: boolean }>;
+    consentFormRecipients: Array<{
+      consentFormId: number;
+      studentId: number;
+      reply: 'YES' | 'NO' | null;
+      replyByParent: number | null;
+      replyDate: Date | null;
+      remarks: string | null;
+      staff: { staffEmailAddress: string; staffName: string } | null;
+      parent: { parentId: number; parentName: string; phone: string; relationship: string|null } | null;
+      student: { studentId: number; studentName: string; indexNumber: string; className: string; studentSex: string; uinFinNo: string };
+      customQuestionReply: Array<{ customQuestionId: string; answer: { text?: string; choice?: string; choices?: string[] } }> | null;
+      replyAppVersion: string | null;
+      onBoardedCategory: 'Onboarded' | 'Not Onboarded';
+      replyAudit: Array<
+        { type: 'custodian'; id: number; updatedAt: Date; name: string|null; phone: string|null; relationship: string|null }
+        | { type: 'staff'; id: number; name: string|null; updatedAt: Date; email: string|null }
+      > | null;
+    }>;
+    customQuestions: Array<{ id: string; title: string; description: string; type: 'text'|'single_selection'|'multi_selection'; properties?: { choices: Array<{ id: string; label: string }> } }> | null;
+    consentFormHistory: Array<{ id: number; auditField: object|null; auditType: 'CREATE_CONSENT_FORM'|'UPDATE_DUE_DATE'|'DELETE_CONSENT_FORM'; createdBy: number; createdAt: Date; staff: { staffName: string } }>;
+    attachments?: Array<{ name: string; size: number; sequence: number; downloadUrl: string }>;
+  }]
+}
+```
+
+---
+
+### 5.15 PUT `/staff/consentForms/:consentFormId/student/:studentId/reply` — Edit Response
+
+**Request**:
+```typescript
+{
+  consentType: 'YES' | 'NO';
+  remarks?: string | null;
+  customQuestionReply?: Array<{ customQuestionId: string; answer: { text?: string; choice?: string; choices?: string[] } }> | null;
+}
+```
+
+**Response**: Updated consent form details.
+
+---
+
+### 5.16 DELETE `/staff/consentForms/:consentFormId` — Delete Posted Form
+
+**Response**: Standard success.
+
+---
+
+### 5.17 POST `/staff/consentForms/:consentFormId/addStaffInCharge` — Add Staff
+
+**Request**: `{ staffIDs: number[] }`
+
+**Response**: Standard success.
+
+---
+
+### 5.18 PUT `/staff/consentForms/:consentFormId/removeAccess` — Remove Self
+
+**Request**: None.
+
+**Response**: Standard success.
+
+---
+
+### 5.19 PUT `/staff/consentForms/:consentFormId/updateEnquiryEmail` — Update Email
+
+**Request**:
+```typescript
+{ enquiryEmailAddress: string; prevEnquiryEmailAddress: string }
+```
+
+**Response**: Standard success.
+
+---
+
+### 5.20 PUT `/staff/consentForms/:consentFormId/updateDueDate` — Update Due Date
+
+**Request**:
+```typescript
+{ consentByDate: Date; eventReminderDate?: Date|null; addReminderType: 'NONE'|'ONE_TIME'|'DAILY' }
+```
+
+**Response**: Standard success. Creates audit record `auditType: 'UPDATE_DUE_DATE'`.
+
+---
+
+### 5.21 GET `/schoolAdmins/consentForms` — Admin List (Legacy)
+
+**Response**: Array of summary data.
+
+---
+
+### 5.22 GET `/schoolAdmins/r12/consentForms` — Admin List (Current)
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    id: string; postId: number; title: string; date: Date;
+    status: 'OPEN' | 'CLOSED';
+    createdByName: string; toParentsOf: string[];
+    respondedMetrics: { respondedPerStudent: number; totalStudents: number };
+  }>
+}
+```
+
+---
+
+### 5.23 GET `/schoolAdmins/consentForms/:consentFormId` — Admin Get Details
+
+**Response**: Same shape as 5.14.
+
+---
+
+### 5.24 DELETE `/schoolAdmins/consentForms/:consentFormId` — Admin Delete
+
+**Response**: Standard success.
+
+---
+
+## 6. Error Handling
+
+### 6.1 Server Error Messages
+
+| Key | Message |
+|-----|---------|
+| invalidDates | Consent Form end date must be after start date |
+| dateBeforeToday | Consent Form date must be today or later |
+| invalidTargetAcadYear | Consent Form targets are invalid, wrong academic year detected |
+| noTargetAccess | Consent Form targets are not accessible by this staff |
+| notExists | Consent Form is not found |
+| unauthorised | Unauthorised access of Consent Form |
+| invalidSchema | Field has failed schema check |
+| noAccess | No access to Consent Form |
+| noEditingBeforeDueDate | Editing Consent Form responses is not allowed before the due date |
+| noConsentByDate | Consent by date is not found |
+| noConsentFormStudent | Consent form student is not found |
+| noConsentFormRecipient | Consent form recipient is not found |
+| CUSTOM_QUESTIONS.lengthMismatch | Number of custom questions does not match |
+| CUSTOM_QUESTIONS.idMismatch | Custom question id does not match |
+| CUSTOM_QUESTIONS.choiceMismatch | Custom question choice does not match |
+| dateAt5MinuteInterval | Date must be at 5-minute interval |
+| atLeast5MinutesFromNow | Date must be at least 5 minutes from now |
+
+### 6.2 HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Validation error |
+| 401 | Unauthorized (session expired) |
+| 403 | Forbidden (insufficient permission) |
+| 404 | Not found |
+| 409 | Conflict (stale updatedAt / concurrent edit) |
+| 429 | Rate limited |
+| 500 | Internal error |

--- a/docs/requirements/ptm-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/ptm-1-pg-reverse-engineer-specs.md
@@ -1,168 +1,696 @@
-# Feature Specification: Parent-Teacher Meetings (PTM)
+# Meetings (PTM) - Complete Redevelopment Spec (Staff & Admin)
 
-**Feature Branch**: `005-ptm`
 **Created**: 2026-06-09
-**Status**: Reverse-Engineered (brief)
-**Input**: Reverse-engineered from existing codebase (pgw-web)
+**Purpose**: Comprehensive reference for frontend redevelopment — business logic, validation, functional behavior, and API contracts.
 
 ---
 
-## Overview
+## 1. Constants & Constraints
 
-Parent-Teacher Meetings (PTM) lets school staff create a slot-based meeting event for parents of selected students. A staff member configures basic info (targets, staff-in-charge, enquiry email, web links, attachments), meeting day/time ranges with a per-slot duration and slots-per-timing capacity, and a single booking window during which parents self-book a slot via the PG mobile app. Staff track booking progress on a Meetings dashboard (Ongoing / Upcoming / Past, each meeting showing Available / Booked / Pending counts) and drill into a per-meeting details page with a Schedule view, where they can block slots, add/change/remove a student in a slot on a parent's behalf, manage staff-in-charge, edit the enquiry email, export the schedule, and delete the event. All PTM endpoints are served under the staff v2 base (`{STAFF_BASE_URL_V2}/ptm`).
+### 1.1 Time & Duration
 
----
+| Constraint | Value |
+|-----------|-------|
+| Min slot duration | 10 minutes |
+| Max slot duration | 720 minutes (12 hours) |
+| Duration multiplier | 5 (must be multiples of 5) |
+| Start time interval | 15 minutes (picker options) |
+| Default scroll start | 07:00 |
 
-## User Scenarios & Testing
+### 1.2 Booking Limits
 
-### US-1: Create a Meeting Event (Staff)
+| Constraint | Value |
+|-----------|-------|
+| Min bookings per slot | 1 |
+| Max bookings per slot | 3 |
+| Max booking windows per meeting | 1 |
 
-**As a** school staff member,
-**I want to** create a meeting event with target students, meeting days/times, slot duration/capacity, and a booking window,
-**So that** parents can book a meeting slot with me.
+### 1.3 Meeting Configuration
 
-**Acceptance Criteria:**
+| Constraint | Value |
+|-----------|-------|
+| Max event dates | 15 |
+| Title max length | 120 characters |
+| Venue max length | 120 characters |
+| Description max length | 2,000 characters |
+| Max attachments | 3 files |
+| Max file size | 5 MB |
+| Web link description max | 40 characters |
+| Attachment extensions | `.pdf, .csv, .docx, .xlsx, .xls, .pptx, .jpg, .jpeg, .gif, .png, .mp3, .mp4, .m4v` |
 
-- Staff navigates to `/meetings/new`; a 4-step `Stepper` (Basic Info → Meeting Details → Booking Window → Booking Preview).
-- **Step 1**: target student groups, staff-in-charge (co-owners), title, description, venue, enquiry email, web links, file attachments (token-based via `fileToken`).
-- **Step 2**: `durationPerSlot` (minutes), `bookingsPerSlot` (slots per timing), one or more meeting day/time ranges (`meetingDateTimes`).
-- **Step 3**: one booking window (start/end date-time) — "5.0 initial will support one booking window".
-- **Step 4**: preview, then submit.
-- On submit, `PtmService.createPtmEvent` → `POST {STAFF_BASE_URL_V2}/ptm` with `staffsInCharge`, `targets`, `title`, `description`, `venue`, `enquiryEmailAddress`, `eventDates`, `durationPerSlot`, `bookingsPerSlot`, `bookingWindows`, `webLinkList`, `attachments`.
-- Server validates date ranges against duration (`validateDateRange`); meetings created today must be ≥ `DEFAULT_EARLIEST_MEETING_DATE_DAYS_AFTER_TODAY` days out.
-- Success returns `{ eventId }`, fires `MeetingCreated`, redirects to `/meetings`.
+### 1.4 Date Constraints
 
-### US-2: Meetings Dashboard (Staff)
-
-**As a** school staff member,
-**I want to** see all my meeting events grouped by status with booking progress,
-**So that** I can monitor responses at a glance.
-
-**Acceptance Criteria:**
-
-- `/meetings`; `usePtmList` → `GET {STAFF_BASE_URL_V2}/ptm` returns `{ events, serverDateTime }`.
-- Events categorised by server time into **Ongoing**, **Upcoming**, **Past**.
-- Each row shows meeting-day count, `{durationPerSlot} min per slot`, `{bookingsPerSlot} slot(s) per timing`, booking-window status, and stats **Available / Booked / Pending** + target count.
-- Rows sortable (`EarliestStart / LatestEnd / LatestCreated`); each links to `/meetings/details/{eventId}`. "Create New" → `/meetings/new`.
-
-### US-3: View Meeting Details & Per-Slot Booking Status (Staff)
-
-**As a** school staff member,
-**I want to** open a meeting and see each day's slots and who has booked,
-**So that** I can review and manage the schedule.
-
-**Acceptance Criteria:**
-
-- `/meetings/details/:id`; two tabs: **Schedule** and **Details**.
-- Loads details (`GET .../ptm/:id`), time slots (`GET .../ptm/timeslots/:id`), and bookings for the selected day (`GET .../ptm/bookings/:id?scheduleDate=...` with `bookedCount`/`availableCount`/`blockedCount`).
-- Schedule grouped by day; each slot shows status `available` / `booked` / `blocked` and, when booked, the student/comment. Per-booking detail via `GET .../ptm/booking/:timeslotBookingId`.
-- Schedule exportable (`ScheduleExportManager`, desktop).
-
-### US-4: Manage Slots — Block / Unblock and Help a Parent Book (Staff)
-
-**As a** school staff member,
-**I want to** block slots and add/change/remove a student in a slot on a parent's behalf,
-**So that** I can manage availability and assist parents who cannot self-book.
-
-**Acceptance Criteria:**
-
-- **Block (booked slot)**: "Block and remove student?" → `POST .../ptm/booking/block` (`{ bookingId, currEventStudentId? }`).
-- **Unblock**: `POST .../ptm/booking/unblock` (`{ bookingId }`).
-- **Help-book / Add student**: Add/Edit overlay with eligible students from `GET .../ptm/:eventId/targetStudents`. Add → `POST .../ptm/booking/add`; change → `POST .../ptm/booking/change`; remove → `POST .../ptm/booking/remove`.
-- Server guardrails surfaced as error reasons: `hasExistingResponse`, `slotAlreadyBooked`, `remarksMismatch`, `eventStudentMismatch`.
-
-### US-5: Manage Staff-in-Charge & Enquiry Email (Staff)
-
-**As a** school staff member,
-**I want to** add co-owners and update the enquiry email,
-**So that** the right staff can manage the meeting and parents have correct contact info.
-
-**Acceptance Criteria:**
-
-- Add staff-in-charge → `POST .../ptm/:eventId/addStaffInCharge`; new staff emailed.
-- Remove self → `PUT .../ptm/:eventId/removeAccess`; redirects to `/meetings`.
-- Edit enquiry email → `PUT .../ptm/:eventId/updateEnquiryEmail`.
-
-### US-6: Delete a Meeting Event (Staff)
-
-**As a** school staff member,
-**I want to** delete a meeting event,
-**So that** obsolete events are removed.
-
-**Acceptance Criteria:**
-
-- "Delete meeting event now?" confirmation → `DELETE .../ptm/:id`; redirects to `/meetings`.
-
-> **Not found / flagged:** No edit-event flow exists — routes are only `/meetings`, `/meetings/new`, `/meetings/details/:id`. Post-creation changes are limited to staff-in-charge, enquiry email, and per-slot booking management; core event fields (dates, duration, capacity, booking window) are not editable. Whole-slot block (`blockPtmTimeSlot`) is stubbed (`TODO`, not API-ready).
+| Constraint | Value |
+|-----------|-------|
+| Earliest booking window start | 1 day from today |
+| Earliest meeting date | 2 days from today |
+| Latest booking window end | 1 day before first meeting date |
+| Reminder sent | 1 day before booking opens/closes |
 
 ---
 
-## Requirements
+## 2. Business Logic Rules
 
-### Functional Requirements
+### 2.1 Enums
 
-- **FR-1 (Event creation):** Create a PTM event with targets, staff-in-charge, title, description, venue, enquiry email, web links, attachments. `POST {STAFF_BASE_URL_V2}/ptm` → `{ eventId }`.
-- **FR-2 (Slot model):** An event has one or more `eventDates` (day + start/end range); slots are generated from each range using `durationPerSlot`. Each timing supports `bookingsPerSlot` parallel bookings (capacity).
-- **FR-3 (Booking window):** Exactly one booking window governs parent self-booking; status `NOT_STARTED` / `OPEN` / `CLOSED` (`EBookingWindowStatus`).
-- **FR-4 (Date guardrail):** Dates validate against duration and respect a minimum lead time (`DEFAULT_EARLIEST_MEETING_DATE_DAYS_AFTER_TODAY`).
-- **FR-5 (Dashboard):** List events with server-time Ongoing/Upcoming/Past categorisation and per-event booking summary + target count; sortable.
-- **FR-6 (Schedule view):** Per-day slot grid with booking detail and `booked/available/blocked` counts; per-booking lookup by `timeslotBookingId`.
-- **FR-7 (Block/unblock):** `/ptm/booking/block`, `/ptm/booking/unblock`; blocked slots aren't bookable by parents.
-- **FR-8 (Help-book management):** Add/change/remove a student in a slot (`/ptm/booking/add|change|remove`) from eligible `targetStudents`, with conflict guards.
-- **FR-9 (Staff-in-charge):** Add staff-in-charge and remove self; notify added staff by email.
-- **FR-10 (Enquiry email):** Update enquiry email post-creation.
-- **FR-11 (Delete):** `DELETE /ptm/:id`.
-- **FR-12 (Export & server time):** Export schedule to Excel; expose server date-time (`/ptm/serverdatetime`) for categorisation/booking-window math.
-- **FR-13 (Parent side, out of web scope):** Parents view/book/change via mobile; reply enum `ESchoolEventReply` = YES/NO.
+**EBookingWindowStatus**:
+| Value | Meaning |
+|-------|---------|
+| `NOT_STARTED` | Booking hasn't opened yet |
+| `OPEN` | Booking window is active |
+| `CLOSED` | Booking window has closed |
 
-### Roles
+**ESlotBookingStatus**:
+| Value | Meaning |
+|-------|---------|
+| `available` | Slot has room for more bookings |
+| `unavailable` | Slot is blocked by staff or full |
 
-- **Owner / staff-in-charge:** full management (block, help-book, staff-in-charge, enquiry email, delete) on events they own/co-own.
-- **Parent (custodian):** self-books within the booking window via mobile; permission via `EParentPermission` (`''` / `r` / `rw`).
+**ESchoolEventReply** (Parent responses):
+| Value | Meaning |
+|-------|---------|
+| `YES` | Attending (requires slot selection) |
+| `NO` | Not attending |
+
+**EEventStudentResponderType**:
+| Value | Meaning |
+|-------|---------|
+| `custodian` | Parent/guardian responded |
+| `staff` | Staff responded on behalf |
+
+**ECustodianRights** (Parent access level):
+| Value | Meaning |
+|-------|---------|
+| `''` (empty) | No access to booking |
+| `'r'` | Read only (can view, cannot book) |
+| `'rw'` | Read/write (can view and book) |
+
+### 2.2 Meeting Lifecycle
+
+1. **Created** → Notifications sent to parents
+2. **Booking NOT_STARTED** → Waiting for booking window to open
+3. **Booking OPEN** → Parents can book slots
+4. **Booking CLOSED** → No more bookings allowed
+5. **Event Date** → Meeting occurs
+6. **Deleted** → Soft delete (`isDeleted: true`)
+
+### 2.3 Slot Calculation
+
+```
+Total Slots = (Total Minutes Across All Meeting Dates / Duration Per Slot)
+Total Booking Slots = Total Slots × Bookings Per Slot
+
+Example: 4 hours (240 min) with 15-min slots and 2 bookings/slot:
+= (240 / 15) × 2 = 32 total booking slots
+```
+
+### 2.4 Slot Management
+
+- Staff can **block** slots to prevent parent booking (marks as unavailable)
+- Staff can **unblock** previously blocked slots
+- Staff can **add booking** for a student into an available slot
+- Staff can **change booking** to a different slot
+- Staff can **remove booking** from a slot
+
+### 2.5 Booking Period Reminders
+
+- Reminder 1: Sent 1 day before booking opens
+- Reminder 2: Sent 1 day before booking closes (only if open/close dates differ)
+- If booking opens AND closes on same day, only 1 reminder sent
+
+### 2.6 Access Control
+
+| Action | Creator | Staff-in-Charge | School Admin |
+|--------|---------|-----------------|--------------|
+| View meeting details | Yes | Yes | Yes |
+| View bookings/schedule | Yes | Yes | Yes |
+| Block/unblock slots | Yes | Yes | No |
+| Add/change/remove bookings | Yes | Yes | No |
+| Add staff-in-charge | Yes | Yes | No |
+| Remove self as staff | N/A | Yes | N/A |
+| Edit enquiry email | Yes | Yes | No |
+| Delete meeting | Yes | No | Yes |
+
+### 2.7 Navigation / Draft Detection
+
+Meeting is considered "drafted" if any form step has data:
+- **Form 1**: staffInCharge, studentGroups, title, description, venue, enquiryEmailAddress
+- **Form 2**: durationPerSlot, bookingsPerSlot, or any meetingDateTimes entry
+- **Form 3**: any booking window date/time
+
+Warning on leave: "Are you sure you want to leave this page? All the data on this page will be lost if you leave the page now."
+
+### 2.8 Concurrent Edit Detection
+
+When multiple staff edit same booking simultaneously:
+- Error: "This meeting slot has just been edited"
+- Based on `remarksMismatch` or `eventStudentMismatch`
 
 ---
 
-## Key Entities
+## 3. Validation Rules
 
-| Entity                                           | Description                                                                              |
-| ------------------------------------------------ | ---------------------------------------------------------------------------------------- |
-| `IPTMEventSummary` / `IPTMEventDetails`          | A meeting event (targets, dates, `durationPerSlot`, `bookingsPerSlot`, booking summary). |
-| `ISchoolEventDate`                               | A start/end date-time range; used for both `eventDates` and `bookingWindows`.            |
-| `IPTMEventSlot` / `…WithBookings`                | A generated time slot with start/end and availability/bookings.                          |
-| `ISchoolEventTimeSlotBooking`                    | A booking of a slot (status `available`/`unavailable`; UI also surfaces `blocked`).      |
-| `ISchoolEventBookingSummary`                     | `{ available, booked, pending }` rollup per event.                                       |
-| `IEventStudentDetails` / `ITargetStudentDetails` | A targeted/eligible student for a booking.                                               |
-| `ICustodianDetails`                              | Parent linked to a student, with `EParentPermission`.                                    |
-| `IEventReply`                                    | A parent's reply (`ESchoolEventReply` YES/NO) + booked slot + remarks.                   |
+### 3.1 Form 1 — Basic Information
+
+| Field | Rule |
+|-------|------|
+| Student Groups | Mandatory (at least one) |
+| Title | Mandatory, max 120 chars |
+| Description | Mandatory, max 2000 chars |
+| Venue | Optional, max 120 chars |
+| Enquiry email | Mandatory, valid email format |
+| Web links | URL safety validated, description max 40 chars |
+| Attachments | Max 3, each max 5MB, accepted extensions |
+
+### 3.2 Form 2 — Meeting Details
+
+| Field | Rule |
+|-------|------|
+| Duration per slot | Required, 10-720 min, multiple of 5 |
+| Bookings per slot | Required, 1-3 |
+| Meeting date/times | 1-15 entries |
+| Each meeting date | >= 2 days from today |
+| From time | Must be before to time |
+| Time intervals | 15-minute intervals starting 07:00 |
+| Cross-day | Supports end times past midnight |
+
+### 3.3 Form 3 — Booking Window
+
+| Field | Rule |
+|-------|------|
+| Booking start date | >= 1 day from today |
+| Booking end date | >= start date, <= 1 day before first meeting date |
+| Date order | Start date <= end date |
+
+### 3.4 Web Link Validation
+
+- `isSafeLink`: No malicious URLs
+- `isMimeSafeLink`: Must be HTML or plain text MIME type
+- Empty links filtered out before submission
 
 ---
 
-## Success Criteria
+## 4. Functional Behavior
 
-1. **Creation:** Staff complete the 4-step flow; slots generate from day/time ranges using duration + capacity; the event appears in the correct dashboard section.
-2. **Tracking:** Dashboard and details counts (Available / Booked / Pending / Blocked) accurately reflect bookings against server time.
-3. **Management:** Block/unblock and add/change/remove-student actions persist and enforce conflict guardrails.
-4. **Lifecycle:** Staff-in-charge, enquiry email, and delete actions succeed with correct redirects/notifications.
+### 4.1 Creation Flow — 4-Step Wizard
+
+**Step 1: Basic Information**
+- Student groups selection
+- Staff-in-charge (optional, excludes creator)
+- Enquiry email (auto-fills from staff display email if configured)
+- Title, description, venue
+- Web links (up to 3)
+- File attachments (up to 3)
+
+**Step 2: Meeting Details**
+- Duration per slot (dropdown: 10-720 min in 5-min increments)
+- Bookings per slot (1, 2, or 3)
+- Meeting date/times (add up to 15 rows, each with date + from time + to time)
+- Shows calculated total slots summary
+
+**Step 3: Booking Window**
+- Booking start date/time
+- Booking end date/time
+- Shows reminder info: when reminders will be sent
+
+**Step 4: Preview & Confirm**
+- Summary of all entered data
+- Shows: Target groups, staff-in-charge, enquiry email, meeting dates, slot duration, bookings per slot, booking window, reminders
+- "Create" button → triggers email to staff + push notification to parents
+
+### 4.2 List Page
+
+**Columns**: Title, Meeting Dates, Booking Period, Available Slots, Status
+
+**Status indicators**: Based on booking window state (NOT_STARTED, OPEN, CLOSED)
+
+**Actions**: View details, Delete
+
+### 4.3 Details Page — Tabs
+
+**Details Tab**:
+1. Title, description, venue
+2. Meeting dates and times
+3. Slot duration and bookings per slot
+4. Booking period (with status: NOT_STARTED/OPEN/CLOSED)
+5. Staff-in-charge + "Add" button
+6. Enquiry email + "Edit" button
+7. Web links
+8. Attachments with download links
+9. Target groups
+10. Delete button
+
+**Schedule Tab**:
+- Day-by-day view of all meeting dates
+- Each day shows time slots with booking status
+- Per slot: start time, student name (if booked), parent name, status (available/booked/blocked)
+- Actions per slot: Block/Unblock, Add booking, Change booking, Remove booking
+- Shows booking summary: Available / Booked / Blocked counts
+
+**Read Status Tab**:
+- Shows which parents have read the meeting invitation
+- Export to Excel available
+
+### 4.4 Staff Booking Management
+
+**Block Slot**: Staff marks slot as unavailable (hidden from parents)
+
+**Unblock Slot**: Staff makes blocked slot available again
+
+**Add Booking** (staff books on behalf of parent):
+1. Select available slot
+2. Select target student from dropdown
+3. Add optional remarks
+4. Confirm → booking saved with `responderType: 'staff'`
+
+**Change Booking**: Move student to different slot
+
+**Remove Booking**: Remove student from slot (slot becomes available again)
+
+### 4.5 Edit Enquiry Email
+
+- Same pattern as announcements/consent forms
+- Request: `{ enquiryEmailAddress: string }`
+
+### 4.6 Add/Remove Staff-in-Charge
+
+- Same pattern as other features
+- Sends email to new staff member on add
+
+### 4.7 Delete Meeting
+
+- Confirmation modal
+- Soft delete (`isDeleted: true`)
+- Redirect to list
+
+### 4.8 Date/Time Display Formats
+
+| Format | Usage |
+|--------|-------|
+| `dddd D MMM YYYY` | Meeting day display (e.g. "Friday 15 Aug 2025") |
+| `h:mm A` | Time display (e.g. "2:30 PM") |
+| `ddd D MMM YYYY, h:mm A` | Meeting detail date/time |
+| `12:00AM (Next day)` | Midnight alias |
+| `DD/MM/YYYY` | Date input format |
+| `HH:mm` | Time input format (24-hour) |
+
+### 4.9 Analytics Events
+
+| Event | Trigger |
+|-------|---------|
+| NewMeetingButtonPressed | Create button clicked |
+| MeetingCreated | Meeting successfully created |
+| MeetingNextButtonPressed | Next button (forms 1-3) |
+| MeetingPreviewButtonPressed | Step 3 → Preview |
+| MeetingBackButtonPressed | Back button |
+| MeetingCreateButtonPressed | Final create button |
+| MeetingViewed | Detail page loaded |
+| MeetingDetailsTabPressed | Details tab |
+| MeetingScheduleTabPressed | Schedule tab |
+| MeetingReadStatusTabPressed | Read status tab |
+| DeleteMeetingButtonPressed | Delete button |
+| MeetingDeleted | Deletion completed |
+| MeetingTitleTooltipPressed | Title tooltip |
+| ReminderTooltipPressed | Reminder tooltip |
+| WebsiteLinkTooltipPressed | Web link tooltip |
+| WebsiteDescriptionTooltipPressed | Description tooltip |
+| EditEnquiryEmailButtonPressed | Edit email button |
+| StaffInChargeTooltipPressed | Staff tooltip |
 
 ---
 
-## Assumptions
+## 5. API Contracts
 
-1. PTM is built on the shared school-event/booking model; it's the only school-event type wired to this slot/booking-window flow here.
-2. Backend is the Node BFF (Sequelize via `@pgw/db-migration`); all routes under `{STAFF_BASE_URL_V2}/ptm`.
-3. Parent-side booking happens on the PG mobile app; this spec covers the staff web portal only.
-4. Exactly one booking window per event in this version; multi-window is a future extension.
-5. Attachments use the token-based (`fileToken`) flow shared with Consent Forms.
-6. No event-edit or scheduled-post flow exists for PTM; whole-time-slot block is stubbed and not yet API-backed.
+### Base
+
+- **Base URL**: `/api/v2`
+- **Staff**: `/api/v2/staff/ptm`
+- **Auth**: SchoolStaffSessionMiddleware
+- **Rate Limit**: 250 requests per 60 minutes
+
+### Response Wrapper (all endpoints)
+
+```typescript
+{ resultCode: number; message: string; body: T; metadata?: Record<string, any> }
+```
 
 ---
 
-## Jira Mapping
+### 5.1 POST `/staff/ptm` — Create Meeting
 
-| Ticket      | Scope                                | Spec coverage                 |
-| ----------- | ------------------------------------ | ----------------------------- |
-| **PGTW-21** | Create meeting event                 | US-1, FR-1..FR-4              |
-| **PGTW-22** | Dashboard + responses/booking status | US-2, US-3, FR-5, FR-6, FR-12 |
-| **PGTW-23** | Management: block slots / help book  | US-4, US-5, US-6, FR-7..FR-11 |
+**Request** (`ICreatePTMEventRecordsRequest`):
+```typescript
+{
+  staffsInCharge: number[];
+  targets: Array<{ targetType: 'CLASS'|'LEVEL'|'SCHOOL'|'CCA'|'GROUP'; targetId: number; targetAcadYear?: string }>;
+  title: string;                          // max 120 chars
+  description: string;                    // max 2000 chars
+  venue?: string;                         // max 120 chars
+  enquiryEmailAddress: string;
+  eventDates: Array<{ startDateTime: Date; endDateTime: Date }>;  // 1-15 dates, sorted
+  durationPerSlot: number;                // 10-720, multiple of 5
+  bookingsPerSlot: number;                // 1-3
+  bookingWindows: Array<{ startDateTime: Date; endDateTime: Date }>;  // exactly 1
+  webLinkList: Array<{ webLink: string; linkDescription: string | null }>;
+  attachments?: Array<{ fileToken: string }>;  // max 3
+}
+```
 
-**Notes:** Edit-event and scheduled-posting (present in Consent Forms) are absent in PTM. `removeSelfFromStaffInCharge` / `updateEnquiryEmail` could split into a separate lifecycle ticket if PGTW-23 is scoped purely to slot management.
+**Response**: `{ body: { eventId: number } }`
+
+---
+
+### 5.2 GET `/staff/ptm` — List Meetings
+
+**Response**:
+```typescript
+{
+  body: {
+    events: Array<{
+      eventId: number;
+      title: string;
+      description: string;
+      venue?: string;
+      enquiryEmailAddress: string;
+      eventDates: Array<{ startDateTime: Date; endDateTime: Date }>;
+      bookingWindows: Array<{ startDateTime: Date; endDateTime: Date }>;
+      webLinkList?: Array<{ webLink: string; linkDescription: string | null }>;
+      attachments: Array<{ name: string; size: number; downloadUrl: string }>;
+      staffsInCharge: Array<{ staffId: number; name: string }>;
+      targets: string[];
+      createdBy: { staffId: number; name: string };
+      isCreatorValidEventStaff: boolean;
+      createdAt: Date;
+      updatedAt: Date;
+      availableCount: number;
+    }>;
+    serverDateTime: Date;
+  }
+}
+```
+
+---
+
+### 5.3 GET `/staff/ptm/:eventId` — Get Meeting Details
+
+**Path Params**: `eventId: number`
+
+**Response**:
+```typescript
+{
+  body: {
+    eventId: number;
+    title: string;
+    description: string;
+    venue?: string;
+    enquiryEmailAddress: string;
+    eventDates: Array<{ startDateTime: Date; endDateTime: Date }>;
+    bookingWindows: Array<{ startDateTime: Date; endDateTime: Date }>;
+    webLinkList?: Array<{ webLink: string; linkDescription: string | null }>;
+    attachments: Array<{ name: string; size: number; downloadUrl: string }>;
+    staffsInCharge: Array<{ staffId: number; name: string }>;
+    targets: string[];
+    createdBy: { staffId: number; name: string };
+    createdAt: Date;
+    updatedAt: Date;
+    bookingSummary: { available: number; booked: number; pending: number };
+    durationPerSlot: number;
+    bookingsPerSlot: number;
+  }
+}
+```
+
+---
+
+### 5.4 GET `/staff/ptm/timeslots/:eventId` — Get Time Slots
+
+**Path Params**: `eventId: number`
+
+**Response**:
+```typescript
+{
+  body: {
+    eventDays: Array<{
+      date: Date;
+      slots: Array<{ slotId: number; startDateTime: Date }>;
+    }>;
+    durationPerSlot: number;
+    bookingsPerSlot: number;
+    totalCount: number;
+  }
+}
+```
+
+---
+
+### 5.5 GET `/staff/ptm/bookings/:eventId` — Get Bookings
+
+**Path Params**: `eventId: number`
+**Query Params**: `scheduleDate?: string` (ISO date to filter by day)
+
+**Response**:
+```typescript
+{
+  body: {
+    timeSlotBookings: Record<number, Array<{
+      bookingId: number;
+      slotId: number;
+      studentId: number | null;
+      studentName: string | null;
+      className: string | null;
+      parentName: string | null;
+      remarks: string | null;
+      status: 'available' | 'unavailable';
+      responderType: 'custodian' | 'staff' | null;
+    }>>;
+    bookedCount: number;
+    availableCount: number;
+    blockedCount: number;
+  }
+}
+```
+
+---
+
+### 5.6 GET `/staff/ptm/schedule/:eventId` — Get Full Schedule
+
+**Path Params**: `eventId: number`
+**Query Params**: `includeResponseData=true`
+
+**Response**:
+```typescript
+{
+  body: {
+    title: string;
+    targets: string[];
+    dates: Array<{
+      date: Date;
+      slots: Array<{
+        slotId: number;
+        startDateTime: Date;
+        bookings: Array<{
+          bookingId: number;
+          studentId: number | null;
+          studentName: string | null;
+          className: string | null;
+          parentName: string | null;
+          remarks: string | null;
+          status: 'available' | 'unavailable';
+          responderType: 'custodian' | 'staff' | null;
+        }>;
+      }>;
+    }>;
+  }
+}
+```
+
+---
+
+### 5.7 GET `/staff/ptm/booking/:bookingId` — Get Single Booking
+
+**Path Params**: `bookingId: number`
+
+**Response**: Single booking details with student/parent info.
+
+---
+
+### 5.8 DELETE `/staff/ptm/:eventId` — Delete Meeting
+
+**Path Params**: `eventId: number`
+
+**Response**: `{ body: boolean }`
+
+---
+
+### 5.9 POST `/staff/ptm/:eventId/addStaffInCharge` — Add Staff
+
+**Path Params**: `eventId: number`
+
+**Request**: `{ staffIDs: number[] }`
+
+**Response**: Standard success.
+
+---
+
+### 5.10 GET `/staff/ptm/:eventId/targetStudents` — Get Target Students
+
+**Path Params**: `eventId: number`
+
+**Response**:
+```typescript
+{
+  body: {
+    eventStudents: Array<{
+      eventStudentId: number;
+      studentId: number;
+      studentName: string;
+      className: string;
+      indexNumber: string;
+      hasBooking: boolean;
+    }>;
+  }
+}
+```
+
+---
+
+### 5.11 PUT `/staff/ptm/:eventId/removeAccess` — Remove Self
+
+**Path Params**: `eventId: number`
+
+**Response**: Standard success.
+
+---
+
+### 5.12 PUT `/staff/ptm/:eventId/updateEnquiryEmail` — Update Email
+
+**Path Params**: `eventId: number`
+
+**Request**: `{ enquiryEmailAddress: string }`
+
+**Response**: Standard success.
+
+---
+
+### 5.13 POST `/staff/ptm/booking/block` — Block Slot
+
+**Request**:
+```typescript
+{ bookingId: number; currEventStudentId?: number }
+```
+
+**Response**: `{ body: { status: string } }`
+
+---
+
+### 5.14 POST `/staff/ptm/booking/unblock` — Unblock Slot
+
+**Request**:
+```typescript
+{ bookingId: number }
+```
+
+**Response**: `{ body: { status: string } }`
+
+---
+
+### 5.15 POST `/staff/ptm/booking/add` — Add Booking (Staff)
+
+**Request**:
+```typescript
+{
+  bookingId: number;
+  newStudentId: number;
+  currRemarks?: string;
+  newRemarks?: string;
+}
+```
+
+**Response**: `{ body: { status: string } }`
+
+---
+
+### 5.16 POST `/staff/ptm/booking/change` — Change Booking
+
+**Request**:
+```typescript
+{
+  bookingId: number;
+  currStudentId: number;
+  newStudentId: number;
+  currRemarks?: string;
+  newRemarks?: string;
+}
+```
+
+**Response**: `{ body: { status: string } }`
+
+---
+
+### 5.17 POST `/staff/ptm/booking/remove` — Remove Booking
+
+**Request**:
+```typescript
+{ bookingId: number; currStudentId: number }
+```
+
+**Response**: `{ body: { status: string } }`
+
+---
+
+### 5.18 GET `/staff/ptm/serverdatetime` — Get Server Time
+
+**Response**: `{ body: { serverDateTime: Date } }`
+
+---
+
+### 5.19 POST `/staff/ptm/booking/validate` — Validate Web Links
+
+**Request**: `{ webLinkList: Array<{ webLink: string; linkDescription: string | null }> }`
+
+**Response**: Validation result (boolean or error details).
+
+---
+
+## 6. Error Handling
+
+### 6.1 Event Error Codes
+
+| Code | Meaning |
+|------|---------|
+| BookingWindowClosed | Parent attempted to book outside window |
+| EventStudentMismatch | Student validation failed |
+| HasExistingResponse | Parent already has YES response |
+| InvalidBookingWindow | Booking dates invalid |
+| InvalidCustodian | Parent/guardian not valid |
+| InvalidEvent | Event ID not found |
+| InvalidEventDate | Date validation failed |
+| InvalidEventStaff | Staff not valid |
+| InvalidSchoolName | School mismatch |
+| InvalidTimeslot | Slot ID not found |
+| slotAlreadyBooked | Slot filled or blocked |
+| eventNotFound | Meeting not found |
+| remarksMismatch | Concurrent edit conflict |
+| timeslotNotAvailable | Slot unavailable/blocked |
+| unauthorisedAccess | No permission |
+| duplicateStaffInCharge | Staff already in charge |
+| invalidStaffInCharge | Staff cannot be added |
+| invalidStudent | Student not targetable |
+
+### 6.2 Web Link Validation Errors
+
+| Code | Message |
+|------|---------|
+| INVALID_MIME_TYPES_LINK_ERROR | "Request contains a link that is not a html or a plain text" |
+| MALICIOUS_AND_INVALID_MIME_TYPES_LINK_ERROR | "Request contains a link that is malicious and it is not a html or a plain text" |
+
+### 6.3 HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Validation error |
+| 401 | Unauthorized |
+| 403 | Forbidden |
+| 404 | Not found |
+| 500 | Internal error |

--- a/docs/requirements/reports-1-pg-reverse-engineer-specs.md
+++ b/docs/requirements/reports-1-pg-reverse-engineer-specs.md
@@ -1,138 +1,404 @@
-# Feature Specification: Reports
+# Admin Reports - Complete Redevelopment Spec (Staff & Admin)
 
-**Feature Branch**: `006-reports`
 **Created**: 2026-06-09
-**Status**: Reverse-Engineered (brief)
-**Input**: Reverse-engineered from existing codebase (`src/app/pages/StaffReports/`, `src/app/pages/AdminReports/`)
+**Purpose**: Comprehensive reference for frontend redevelopment — business logic, validation, functional behavior, and API contracts.
 
 ---
 
-## Overview
+## 1. Report Types
 
-Reports is a self-service export feature in Parents Gateway Web that lets school staff generate Excel (`.xlsx`) reports about their students. The real codebase exposes exactly **two report types**, surfaced as sub-nav tabs on a single Reports page:
+The system supports **2 report types**:
 
-1. **Onboarding** — custodian (parent) PG onboarding status.
-2. **Travel Declaration** — declaration status over a chosen date range.
-
-There are two parallel pages with near-identical UX, differing only in scope and API path:
-
-- **Staff Reports** (`/staff/reports`) — Form Teacher (FT) / Co-Form Teacher: scoped to the staff member's assigned **form class**.
-- **Admin Reports** (`/admin/reports`, gated by `AdminRoute`) — Staff with Admin rights: scoped to the **whole school**.
-
-For **IHL** schools the Travel Declaration tab is hidden (`!isIhl` gates the `SubNav`), so IHL sees only the Onboarding report with IHL-specific copy. Both reports are **desktop-only** — on mobile a "This report can only be exported on desktop" notice replaces the export controls.
-
-> **Important:** there is **no in-app drill-down or paginated data table** — the "view" of a report _is_ the downloaded Excel file. Exports are generated **client-side** from JSON rows the API returns.
+| Report | Description | Admin | Form Teacher | IHL Compatible |
+|--------|-------------|-------|--------------|----------------|
+| Onboarding Report | Custodian onboarding status per student | Yes (whole school) | Yes (their classes) | Yes |
+| Travel Declaration Report | Travel declarations by custodians | Yes (whole school) | Yes (their classes) | **No** (disabled) |
 
 ---
 
-## User Scenarios & Testing
+## 2. Constants & Constraints
 
-### US-1: Generate Onboarding report for my form class (Staff)
+### 2.1 Date Range Limits (Travel Declaration)
 
-**As a** Form / Co-Form Teacher,
-**I want to** export my form class's custodian onboarding status,
-**So that** I can see which parents have/haven't onboarded onto PG.
+| Constraint | Value |
+|-----------|-------|
+| Max past | 3 months from today (start of month) |
+| Max future | 12 months from today (end of month) |
+| Max range (frontend) | 3 months |
+| Max range (backend) | 4 months |
 
-**Acceptance Criteria:**
+### 2.2 Other
 
-- Staff navigates to `/staff/reports`; the **Onboarding** tab is selected by default.
-- On mount, the page calls `GroupsService.getAssignedGroups()` and renders the staff member's `formClass`.
-- If no form class is assigned, the page shows guidance ("you need a form class… approach Staff with Admin rights") instead of an export button (IHL gets school-info-system worded copy).
-- "Export to Excel" → `downloadStudentOnboardingReport(formClass)` → `GET /api/web/2/staff/school/students/retrieveReport?action=onboardReport`.
-- The workbook has two sheets: **Students** and **Onboarding Status Breakdown**; filename `{schoolCode}-{formClass}-onboarding-report-{timestamp}.xlsx`.
-
-### US-2: Generate Travel Declaration report for my form class (Staff)
-
-**As a** Form / Co-Form Teacher,
-**I want to** export who did/did not declare travel over a date range,
-**So that** I can follow up with non-declaring families.
-
-**Acceptance Criteria:**
-
-- Staff selects the **Travel Declaration** tab (hidden for IHL).
-- Filters: a **declaration status** radio (`Declared (Include travelling and not travelling)` / `Did Not Declare (No declarations made)`) and a **date range** picker.
-- Export is disabled until the date range passes validation (`dateTimeValidationHasError`).
-- "Export to Excel" → `downloadFormClassTravelDeclarationReport(...)` → `POST /api/web/2/staff/school/travelDeclaration` with `{ reportType, startDate, endDate }`; fires `ExportToExcelButtonPressed`.
-- For the "Did Not Declare" case a second **Onboarding Status Breakdown** sheet is appended; otherwise a single **Students** sheet. Empty results yield a placeholder row.
-
-### US-3: Generate school-wide reports (Admin)
-
-**As a** Staff member with Admin rights,
-**I want to** generate Onboarding and Travel Declaration reports for the whole school,
-**So that** I can oversee onboarding and travel compliance across all classes.
-
-**Acceptance Criteria:**
-
-- Admin navigates to `/admin/reports` (route protected by `AdminRoute`).
-- Same two tabs and filters as staff, but scoped to `schoolName` (no form-class lookup; no "without form class" guidance).
-- Onboarding export → `downloadStudentOnboardingReport()` → `GET /api/web/2/schoolAdmins/students?action=onboardReport`; filename `{schoolCode}-onboarding-report-{timestamp}.xlsx`.
-- Travel Declaration export → `POST /api/web/2/schoolAdmins/travelDeclaration`.
-
-### US-4: Switching tabs resets filters
-
-**As a** staff/admin user,
-**I want** filters to reset when I change report tabs,
-**So that** stale date/status selections aren't carried over.
-
-**Acceptance Criteria:**
-
-- Changing tab via `SubNav` resets state to `INITIAL_STATES` (clears status, dates, re-flags `dateTimeValidationHasError`).
+| Constraint | Value |
+|-----------|-------|
+| Export format | Excel (.xlsx) |
+| Mobile support | **No** — reports disabled on mobile |
 
 ---
 
-## Requirements
+## 3. Business Logic Rules
 
-### Functional Requirements
+### 3.1 Access Control
 
-- **FR-1**: Provide exactly two report types — **Onboarding** and **Travel Declaration** — as sub-nav tabs on a single Reports page.
-- **FR-2**: Staff reports scoped to the user's assigned form class (`getAssignedGroups()`); Admin reports scoped to the whole school.
-- **FR-3**: For staff with no assigned form class, suppress export and show guidance copy (IHL variant differs).
-- **FR-4**: Hide the Travel Declaration tab for IHL schools; render IHL-specific descriptions for Onboarding.
-- **FR-5**: Travel Declaration requires two filters: declaration-status radio (Declared / Did Not Declare) and a validated date range; disable export until valid.
-- **FR-6**: All exports produce client-side `.xlsx` (`xlsx` / `xlsx-style` + `file-saver`); the API returns JSON rows that the FE serializes (no server-side file download).
-- **FR-7**: Onboarding exports always include a second **Onboarding Status Breakdown** sheet; Travel Declaration includes it only for "Did Not Declare".
-- **FR-8**: Block all exports on mobile user agents; show a desktop-only notice.
-- **FR-9**: Filenames embed `schoolCode`, scope (form class for staff), report identity, and a timestamp.
-- **FR-10**: Route protection — `/admin/reports` requires admin (`AdminRoute`); `/staff/reports` is a standard staff route.
+| Role | Onboarding Report | Travel Declaration |
+|------|-------------------|-------------------|
+| School Admin | Whole school | Whole school (non-IHL only) |
+| Form/Co-Form Teacher | Their assigned classes only | Their assigned classes only (non-IHL) |
+| IHL Admin | Whole school (IHL variant) | **Disabled** |
+| Other Staff | No access | No access |
 
-### Key Entities
+**Admin** requires 2FA authorization (AdminMultiFactorAuthorizationMiddleware).
 
-| Entity                         | Description                                              |
-| ------------------------------ | -------------------------------------------------------- |
-| Onboarding report row          | Per-student custodian onboarding status (Students sheet) |
-| Travel Declaration report row  | Per-student declaration status over date range           |
-| `ETravelDeclarationReportType` | Enum: `Declared` / `DidNotDeclare` (drives radio + API)  |
-| Onboarding Status Breakdown    | Static explainer sheet appended to certain exports       |
-| `formClass`                    | Staff's assigned form class string (report scope)        |
+**Form Teacher** scope determined by `GroupsService.getAssignedGroups()` — if no class assigned, shows error: "No Form Class assigned".
+
+### 3.2 Onboarding Status Logic
+
+For each custodian (Father, Mother, Caregiver, Legal Guardian):
+
+```
+if (!uinFinNo || !parentPermission):
+    onboardedStatus = 'No Access'
+    canRespondStatus = 'No Access'
+else if (isOnboarded):
+    onboardedStatus = 'Yes'
+else:
+    onboardedStatus = 'No'
+
+if (parentPermission === 'rw'):
+    canRespondStatus = 'Yes'
+else if (parentPermission === 'r'):
+    canRespondStatus = 'No'
+```
+
+### 3.3 Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `Yes` (Onboarded) | Previously logged into PG with Singpass |
+| `No` (Onboarded) | Has not logged into PG yet |
+| `No Access` | No NRIC/FIN in system or custody issue |
+| `Nil` | No such custodian assigned to student |
+| `Yes` (Can Respond) | Has read-write permission (`rw`) |
+| `No` (Can Respond) | Has read-only permission (`r`) |
+
+### 3.4 Relationship Codes
+
+| Code | Display |
+|------|---------|
+| F | Father |
+| M | Mother |
+| G | Caregiver |
+| G4 | Legal Guardian |
+| G2, G3 | Not supported (ignored) |
+
+### 3.5 Parent Permission Codes
+
+| Code | Meaning |
+|------|---------|
+| `rw` | Read-write (can respond to forms) |
+| `r` | Read-only (cannot respond) |
+| null/undefined | No access |
+
+### 3.6 Special Cases
+
+- **Multiple guardians/caregivers**: Creates multiple rows per student (one per guardian)
+- **Deceased parents**: Skipped (not shown)
+- **Deleted parents**: Skipped (not shown)
+- **PreP1 students**: Level/class/serialNo replaced with "PRE-PRIMARY 1"
+- **IHL schools**: "Index No" column replaced with "StudentID" (NRIC/FIN)
+
+### 3.7 Travel Declaration Report Types
+
+| Type | Display Label | Shows |
+|------|--------------|-------|
+| Declared | "Declared (Include travelling and not travelling)" | Students WITH declarations in date range |
+| Did Not Declare | "Did Not Declare (No declarations made)" | Students WITHOUT any declarations in date range |
 
 ---
 
-## Success Criteria
+## 4. Functional Behavior
 
-1. FT/Co-FT can export both reports scoped to their form class; admins can export both school-wide.
-2. Onboarding and Travel Declaration `.xlsx` files open with the correct sheets and naming.
-3. Travel Declaration export is gated on a valid date range and a selected status.
-4. IHL schools see only the Onboarding tab with IHL copy.
-5. Mobile users are blocked with a clear desktop-only message.
-6. Staff without a form class see guidance instead of broken exports.
+### 4.1 Admin Reports Page (`/admin/reports`)
+
+**Tabs**: Onboarding, Travel Declaration
+
+**Tab switching resets state** to initial values.
+
+### 4.2 Staff Reports Page (`/staff/reports`)
+
+**Tabs**: Onboarding, Travel Declaration
+
+**Additional info**: Shows assigned class name(s) (comma-separated if multiple).
+
+**Error state**: If no form class assigned, shows message directing staff to School Cockpit.
+
+### 4.3 Onboarding Report Tab
+
+**No filters** — downloads all data immediately.
+
+**Export button**: "Export to Excel" — always enabled.
+
+**Mobile**: Shows message "This report can only be exported on desktop".
+
+### 4.4 Travel Declaration Report Tab
+
+**Filters**:
+1. **Report Type** (radio buttons): "Declared" or "Did Not Declare"
+2. **Date Range** (date pickers): Start Date and End Date
+
+**Validation**:
+- Both dates required
+- Start date >= today - 3 months (start of month)
+- End date <= today + 12 months (end of month)
+- Date range <= 3 months
+- Start date must be before end date
+
+**Export button**: Disabled until date range is valid.
+
+**Note displayed**: "Eg. If you are interested in the June 2020 School Holidays, you may enter the Start Date (30 May) and End Date (28 June) of the holidays."
+
+### 4.5 Export — Onboarding Report
+
+**File name**:
+- Admin: `{schoolCode}-onboarding-report-{datetime}.xlsx`
+- Staff: `{schoolCode}-{className}-onboarding-report-{datetime}.xlsx`
+
+**Excel structure**:
+- **Sheet 1: "Students"** — main report data
+- **Sheet 2: "Onboarding Status Breakdown"** — explainer table
+
+**Columns (Standard Schools)**:
+| Column | Description |
+|--------|-------------|
+| Level | Student level |
+| Class | Class name |
+| Index No | Class serial number |
+| Student | Student name |
+| Father | Father name |
+| Father Onboarded? | "Logged into PG before" |
+| Father Can Respond? | "If have Singpass to Login" |
+| Mother | Mother name |
+| Mother Onboarded? | Same |
+| Mother Can Respond? | Same |
+| Caregiver | Caregiver name |
+| Caregiver Onboarded? | Same |
+| Caregiver Can Respond? | Same |
+| Legal Guardian | Legal guardian name |
+| Legal Guardian Onboarded? | Same |
+| Legal Guardian Can Respond? | Same |
+
+**Columns (IHL Schools)**:
+- Replaces "Index No" with "StudentID" (NRIC/FIN)
+- Otherwise same structure
+
+**Breakdown Sheet** (Sheet 2):
+| Custodian | Onboarded? | Can Respond? | Meaning |
+|-----------|-----------|-------------|---------|
+| [Name] | No | No | No Singpass or custody issue |
+| [Name] | No | Yes | Eligible for Singpass |
+| [Name] | Yes | No | Onboarded but custody issue |
+| [Name] | Yes | Yes | Fully onboarded and responsive |
+| [Name] | No Access | No Access | NRIC/FIN missing or custody issue |
+| Nil | Nil | Nil | No such custodian |
+
+### 4.6 Export — Travel Declaration Report (Declared)
+
+**File name**: `{schoolCode}-{formClass}-Travel_Declared-{startDate}-{endDate}-on_{currentDateTime}.xlsx`
+
+**Columns**:
+| Column | Description |
+|--------|-------------|
+| Level | Student level |
+| Class | Class name |
+| Index No | Class serial number |
+| Student | Student name |
+| Custodian | Trip declared by (name) |
+| Relationship | Father/Mother/Caregiver/Legal Guardian |
+| Not Travelling During | Yes/No |
+| Country (-City) | Destination |
+| From | Trip start date |
+| To | Trip end date |
+| Date Declared | Declaration date |
+| Time Declared | Declaration time |
+
+### 4.7 Export — Travel Declaration Report (Did Not Declare)
+
+**File name**: `{schoolCode}-{formClass}-Travel_Did_Not_Declare-{startDate}-{endDate}-on_{currentDateTime}.xlsx`
+
+**Columns**: Same as Onboarding Report (shows custodian status for students who haven't declared).
+
+### 4.8 Empty Report Handling
+
+If no records found: placeholder row with text "No records found for {startDate} to {endDate}".
+
+### 4.9 File Name Sanitization
+
+Non-alphanumeric characters replaced with underscore (`_`). Spaces replaced with underscores.
+
+### 4.10 Excel Formatting
+
+- Column wrapping enabled
+- Header row with borders
+- Standard column widths: 13 chars
+- Breakdown sheet widths: 17/14/14/95 chars
+- Row height: 50 points for breakdown header
+
+### 4.11 Analytics Events
+
+| Event | Trigger |
+|-------|---------|
+| ReportsOnboardingTabPressed | Onboarding tab clicked |
+| ReportsTravelDeclarationTabPressed | Travel declaration tab clicked |
+| ExportToExcelButtonPressed | Export button clicked |
 
 ---
 
-## Assumptions
+## 5. API Contracts
 
-1. The BFF report endpoints (`.../retrieveReport?action=onboardReport`, `.../travelDeclaration`) return JSON row arrays plus `metadata.schoolCode`; the FE assembles the workbook.
-2. `isIhl`, `staffSchoolId`, `schoolName` come from Redux `indexPage`.
-3. "Admin" here means a staff member with admin rights (the `AdminRoute` guard), not a separate persona.
-4. The Onboarding Status Breakdown sheet content is static reference data.
-5. Date-range validation limits (3-month window) are enforced by the shared `DateRangePicker`.
+### Base
+
+- **Admin**: `/api/v2/schoolAdmins/...` (requires Admin access scope + 2FA)
+- **Staff**: `/api/v2/staff/school/...` (requires SchoolStaffSessionMiddleware)
+
+### Response Wrapper
+
+```typescript
+{ resultCode: number; message: string; body: T; metadata?: Record<string, any> }
+```
 
 ---
 
-## Jira Mapping
+### 5.1 GET `/schoolAdmins/students?action=onboardReport` — Admin Onboarding Report
 
-| Story                                   | Coverage                                                                                                                                                                                                                           |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **PGTW-16 — Travel Declaration report** | US-2 (staff/form-class), US-3 (admin/school-wide), FR-5, FR-7. Endpoints: `POST /api/web/2/staff/school/travelDeclaration` (staff), `POST /api/web/2/schoolAdmins/travelDeclaration` (admin).                                      |
-| **PGTW-17 — PG onboarding report**      | US-1 (staff/form-class), US-3 (admin/school-wide), FR-2, FR-7. Endpoints: `GET /api/web/2/staff/school/students/retrieveReport?action=onboardReport` (staff), `GET /api/web/2/schoolAdmins/students?action=onboardReport` (admin). |
+**Query Params**: `action=onboardReport` (required)
 
-**Notes:** access = FT / Co-FT (form-class scope) and Staff-with-Admin (school scope); IHL hides Travel Declaration; both reports are desktop-only; there is **no in-app drill-down table** — the report is the exported Excel file.
+**Auth**: SchoolStaffSessionMiddleware with `accessControlScope: 'Admin'`
+
+**Response**:
+```typescript
+{
+  body: Array<{
+    'Level': string;
+    'Class': string;
+    'Index No': string;                                    // or 'StudentID' for IHL
+    'Student': string;
+    'Father': string;
+    'Father Onboarded?\n(Logged into PG before)': string;  // 'Yes'|'No'|'No Access'|'Nil'
+    'Father Can Respond?\n(If have Singpass to Login)': string;
+    'Mother': string;
+    'Mother Onboarded?\n(Logged into PG before)': string;
+    'Mother Can Respond?\n(If have Singpass to Login)': string;
+    'Caregiver': string;
+    'Caregiver Onboarded?\n(Logged into PG before)': string;
+    'Caregiver Can Respond?\n(If have Singpass to Login)': string;
+    'Legal Guardian': string;
+    'Legal Guardian Onboarded?\n(Logged into PG before)': string;
+    'Legal Guardian Can Respond?\n(If have Singpass to Login)': string;
+  }>;
+  metadata: { schoolCode: string };
+}
+```
+
+---
+
+### 5.2 GET `/staff/school/students/retrieveReport?action=onboardReport` — Staff Onboarding Report
+
+**Query Params**: `action=onboardReport` (required)
+
+**Auth**: SchoolStaffSessionMiddleware
+
+**Response**: Same shape as 5.1 but filtered by teacher's assigned form classes.
+
+**Error**: If no form class assigned, returns error.
+
+---
+
+### 5.3 POST `/schoolAdmins/travelDeclaration` — Admin Travel Declaration Report
+
+**Auth**: SchoolStaffSessionMiddleware with `accessControlScope: 'Admin'`, `IhlEnabled: false`
+
+**Request**:
+```typescript
+{
+  reportType: 'Declared (Include travelling and not travelling)' | 'Did Not Declare (No declarations made)';
+  startDate: string;    // ISO date
+  endDate: string;      // ISO date
+}
+```
+
+**Response (Declared)**:
+```typescript
+{
+  body: Array<{
+    'Level': string;
+    'Class': string;
+    'Index No': string;
+    'Student': string;
+    'Custodian': string;
+    'Relationship': string;
+    'Not Travelling During': string;   // 'Yes'|'No'
+    'Country (-City)': string;
+    'From': string;                    // Date
+    'To': string;                      // Date
+    'Date Declared': string;
+    'Time Declared': string;
+  }>
+}
+```
+
+**Response (Did Not Declare)**:
+```typescript
+{
+  body: Array<{
+    // Same shape as Onboarding Report (custodian status for non-declarers)
+    'Level': string;
+    'Class': string;
+    'Index No': string;
+    'Student': string;
+    'Father': string;
+    'Father Onboarded?\n(Logged into PG before)': string;
+    'Father Can Respond?\n(If have Singpass to Login)': string;
+    // ... (Mother, Caregiver, Legal Guardian same pattern)
+  }>
+}
+```
+
+---
+
+### 5.4 POST `/staff/school/travelDeclaration` — Staff Travel Declaration Report
+
+**Auth**: SchoolStaffSessionMiddleware with `IhlEnabled: false`
+
+**Request**: Same as 5.3.
+
+**Response**: Same as 5.3 but filtered by teacher's assigned form classes.
+
+---
+
+## 6. Error Handling
+
+### 6.1 Validation Errors
+
+| Error | Message |
+|-------|---------|
+| Start after end | "end date must be after start date" |
+| Range too large | "Invalid start date and end date must be within {n} months" |
+| Start too far back | Date range start validation error |
+| End too far forward | Date range end validation error |
+| Invalid report type | "Invalid report type" |
+| No form class | "No Form Class assigned" |
+
+### 6.2 Frontend Error Handling
+
+- API errors: Redirect to error page with resultCode (-500)
+- Excel generation errors: Alert modal "Sorry, something went wrong when saving the {report type} report"
+
+### 6.3 HTTP Status Codes
+
+| Code | Meaning |
+|------|---------|
+| 200 | Success |
+| 400 | Validation error (dates, report type) |
+| 401 | Unauthorized |
+| 403 | Forbidden (non-admin, IHL for travel) |
+| 500 | Internal error |


### PR DESCRIPTION
Updates the per-feature specs in `docs/requirements/` to the **engineering team's Complete Redevelopment Specs** (authoritative — business logic, validation, functional behaviour, API contracts), replacing the earlier reverse-engineered drafts.

## Changes
- Replaced content (filenames kept, so all existing links stay valid):
  - `announcements-1-…` ← announcements redevelopment spec
  - `forms-1-…` ← consent forms redevelopment spec
  - `custom-groups-1-…` ← custom groups redevelopment spec
  - `ptm-1-…` ← meetings (PTM) redevelopment spec
  - `reports-1-…` ← reports redevelopment spec
  - `heytalia-1-…` — unchanged (no redevelopment spec; out of Phase-1)
- README: added a "Specs updated" credit note; fixed the index "Requirements doc" links to point at the actual spec files; repointed the "Issue" links to the moved repo (`teacher-workspace-pg-frontend`) with current numbers.

Filenames unchanged on purpose → the spec links already in the epics, tracker, and shared messages all resolve to the updated content with no further edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)